### PR TITLE
test(sparse): exhaustive validation — cross-solver consistency and edge cases

### DIFF
--- a/tests/unit/sparse/test_cross_solver_validation.cpp
+++ b/tests/unit/sparse/test_cross_solver_validation.cpp
@@ -1,0 +1,402 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <cmath>
+#include <cstddef>
+#include <mtl/mat/compressed2D.hpp>
+#include <mtl/mat/inserter.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/sparse/factorization/sparse_cholesky.hpp>
+#include <mtl/sparse/factorization/sparse_lu.hpp>
+#include <mtl/sparse/factorization/sparse_qr.hpp>
+#include <mtl/sparse/ordering/amd.hpp>
+#include <mtl/sparse/ordering/rcm.hpp>
+
+#ifdef MTL5_HAS_UMFPACK
+#include <mtl/interface/umfpack.hpp>
+#endif
+
+using namespace mtl;
+using namespace mtl::sparse;
+
+static double relative_residual(
+    const mat::compressed2D<double>& A,
+    const vec::dense_vector<double>& x,
+    const vec::dense_vector<double>& b)
+{
+    std::size_t m = A.num_rows();
+    double res = 0.0, bnorm = 0.0;
+    const auto& starts = A.ref_major();
+    const auto& indices = A.ref_minor();
+    const auto& data = A.ref_data();
+    for (std::size_t i = 0; i < m; ++i) {
+        double Ax_i = 0.0;
+        for (std::size_t k = starts[i]; k < starts[i + 1]; ++k)
+            Ax_i += data[k] * x(indices[k]);
+        double ri = Ax_i - b(i);
+        res += ri * ri;
+        bnorm += b(i) * b(i);
+    }
+    if (bnorm == 0.0) return std::sqrt(res);
+    return std::sqrt(res / bnorm);
+}
+
+static double solution_difference(
+    const vec::dense_vector<double>& x1,
+    const vec::dense_vector<double>& x2)
+{
+    double diff = 0.0, norm = 0.0;
+    for (std::size_t i = 0; i < x1.size(); ++i) {
+        double d = x1(i) - x2(i);
+        diff += d * d;
+        norm += x1(i) * x1(i);
+    }
+    if (norm == 0.0) return std::sqrt(diff);
+    return std::sqrt(diff / norm);
+}
+
+// Build SPD tridiagonal: A(i,i)=4, A(i,i+1)=A(i+1,i)=-1
+static mat::compressed2D<double> make_spd_tridiag(std::size_t n) {
+    mat::compressed2D<double> A(n, n);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        for (std::size_t i = 0; i < n; ++i) {
+            ins[i][i] << 4.0;
+            if (i + 1 < n) {
+                ins[i][i + 1] << -1.0;
+                ins[i + 1][i] << -1.0;
+            }
+        }
+    }
+    return A;
+}
+
+// Build SPD arrow matrix
+static mat::compressed2D<double> make_spd_arrow(std::size_t n) {
+    mat::compressed2D<double> A(n, n);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        ins[0][0] << static_cast<double>(3 * n);
+        for (std::size_t i = 1; i < n; ++i) {
+            ins[0][i] << 1.0;
+            ins[i][0] << 1.0;
+            ins[i][i] << 5.0;
+        }
+    }
+    return A;
+}
+
+// Build unsymmetric tridiagonal with perturbation
+static mat::compressed2D<double> make_unsym_tridiag(std::size_t n) {
+    mat::compressed2D<double> A(n, n);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        for (std::size_t i = 0; i < n; ++i) {
+            ins[i][i] << 4.0;
+            if (i + 1 < n) {
+                ins[i][i + 1] << -1.0;
+                ins[i + 1][i] << -0.5;  // unsymmetric
+            }
+        }
+        if (n > 2) {
+            ins[0][n - 1] << 0.3;
+            ins[n - 1][0] << -0.2;
+        }
+    }
+    return A;
+}
+
+static vec::dense_vector<double> make_rhs(std::size_t n) {
+    vec::dense_vector<double> b(n);
+    for (std::size_t i = 0; i < n; ++i)
+        b(i) = static_cast<double>((i % 7) - 3);  // deterministic pattern
+    return b;
+}
+
+// ---- Cross-solver consistency tests ----
+
+TEST_CASE("Cholesky vs LU on SPD system", "[sparse][cross][consistency]") {
+    for (std::size_t n : {3, 5, 10, 20, 50}) {
+        auto A = make_spd_tridiag(n);
+        auto b = make_rhs(n);
+
+        vec::dense_vector<double> x_chol(n, 0.0);
+        factorization::sparse_cholesky_solve(A, x_chol, b);
+
+        vec::dense_vector<double> x_lu(n, 0.0);
+        factorization::sparse_lu_solve(A, x_lu, b);
+
+        REQUIRE(solution_difference(x_chol, x_lu) < 1e-10);
+        REQUIRE(relative_residual(A, x_chol, b) < 1e-12);
+        REQUIRE(relative_residual(A, x_lu, b) < 1e-12);
+    }
+}
+
+TEST_CASE("Cholesky vs QR on SPD system", "[sparse][cross][consistency]") {
+    for (std::size_t n : {3, 5, 10, 20}) {
+        auto A = make_spd_tridiag(n);
+        auto b = make_rhs(n);
+
+        vec::dense_vector<double> x_chol(n, 0.0);
+        factorization::sparse_cholesky_solve(A, x_chol, b);
+
+        vec::dense_vector<double> x_qr(n, 0.0);
+        factorization::sparse_qr_solve(A, x_qr, b);
+
+        REQUIRE(solution_difference(x_chol, x_qr) < 1e-10);
+    }
+}
+
+TEST_CASE("LU vs QR on unsymmetric system", "[sparse][cross][consistency]") {
+    for (std::size_t n : {3, 5, 10, 20}) {
+        auto A = make_unsym_tridiag(n);
+        auto b = make_rhs(n);
+
+        vec::dense_vector<double> x_lu(n, 0.0);
+        factorization::sparse_lu_solve(A, x_lu, b);
+
+        vec::dense_vector<double> x_qr(n, 0.0);
+        factorization::sparse_qr_solve(A, x_qr, b);
+
+        REQUIRE(solution_difference(x_lu, x_qr) < 1e-10);
+        REQUIRE(relative_residual(A, x_lu, b) < 1e-12);
+    }
+}
+
+TEST_CASE("All three solvers agree on arrow SPD matrix", "[sparse][cross][consistency]") {
+    for (std::size_t n : {4, 8, 15, 30}) {
+        auto A = make_spd_arrow(n);
+        auto b = make_rhs(n);
+
+        vec::dense_vector<double> x_chol(n, 0.0), x_lu(n, 0.0), x_qr(n, 0.0);
+        factorization::sparse_cholesky_solve(A, x_chol, b, ordering::amd{});
+        factorization::sparse_lu_solve(A, x_lu, b);
+        factorization::sparse_qr_solve(A, x_qr, b);
+
+        REQUIRE(solution_difference(x_chol, x_lu) < 1e-10);
+        REQUIRE(solution_difference(x_chol, x_qr) < 1e-10);
+    }
+}
+
+TEST_CASE("Ordering does not change solution", "[sparse][cross][ordering]") {
+    auto A = make_spd_tridiag(15);
+    auto b = make_rhs(15);
+
+    vec::dense_vector<double> x_nat(15, 0.0), x_rcm(15, 0.0), x_amd(15, 0.0);
+    factorization::sparse_cholesky_solve(A, x_nat, b);
+    factorization::sparse_cholesky_solve(A, x_rcm, b, ordering::rcm{});
+    factorization::sparse_cholesky_solve(A, x_amd, b, ordering::amd{});
+
+    REQUIRE(solution_difference(x_nat, x_rcm) < 1e-12);
+    REQUIRE(solution_difference(x_nat, x_amd) < 1e-12);
+}
+
+#ifdef MTL5_HAS_UMFPACK
+TEST_CASE("UMFPACK vs native LU", "[sparse][cross][umfpack]") {
+    for (std::size_t n : {3, 5, 10, 20}) {
+        auto A = make_unsym_tridiag(n);
+        auto b = make_rhs(n);
+
+        vec::dense_vector<double> x_umf(n, 0.0);
+        interface::umfpack_solve(A, x_umf, b);
+
+        vec::dense_vector<double> x_lu(n, 0.0);
+        factorization::sparse_lu_solve(A, x_lu, b);
+
+        REQUIRE(solution_difference(x_umf, x_lu) < 1e-10);
+    }
+}
+
+TEST_CASE("UMFPACK vs native Cholesky on SPD", "[sparse][cross][umfpack]") {
+    for (std::size_t n : {5, 10, 20}) {
+        auto A = make_spd_tridiag(n);
+        auto b = make_rhs(n);
+
+        vec::dense_vector<double> x_umf(n, 0.0);
+        interface::umfpack_solve(A, x_umf, b);
+
+        vec::dense_vector<double> x_chol(n, 0.0);
+        factorization::sparse_cholesky_solve(A, x_chol, b);
+
+        REQUIRE(solution_difference(x_umf, x_chol) < 1e-10);
+    }
+}
+#endif
+
+// ---- Medium and large scale tests ----
+
+TEST_CASE("Cholesky on 50x50 tridiagonal", "[sparse][scale]") {
+    auto A = make_spd_tridiag(50);
+    auto b = make_rhs(50);
+    vec::dense_vector<double> x(50, 0.0);
+    factorization::sparse_cholesky_solve(A, x, b, ordering::amd{});
+    REQUIRE(relative_residual(A, x, b) < 1e-12);
+}
+
+TEST_CASE("Cholesky on 100x100 tridiagonal", "[sparse][scale]") {
+    auto A = make_spd_tridiag(100);
+    auto b = make_rhs(100);
+    vec::dense_vector<double> x(100, 0.0);
+    factorization::sparse_cholesky_solve(A, x, b, ordering::amd{});
+    REQUIRE(relative_residual(A, x, b) < 1e-12);
+}
+
+TEST_CASE("LU on 50x50 unsymmetric", "[sparse][scale]") {
+    auto A = make_unsym_tridiag(50);
+    auto b = make_rhs(50);
+    vec::dense_vector<double> x(50, 0.0);
+    factorization::sparse_lu_solve(A, x, b);
+    REQUIRE(relative_residual(A, x, b) < 1e-12);
+}
+
+TEST_CASE("QR on 50x50 system", "[sparse][scale]") {
+    auto A = make_spd_tridiag(50);
+    auto b = make_rhs(50);
+    vec::dense_vector<double> x(50, 0.0);
+    factorization::sparse_qr_solve(A, x, b);
+    REQUIRE(relative_residual(A, x, b) < 1e-11);
+}
+
+TEST_CASE("Cholesky on 30x30 arrow matrix", "[sparse][scale]") {
+    auto A = make_spd_arrow(30);
+    auto b = make_rhs(30);
+    vec::dense_vector<double> x(30, 0.0);
+    factorization::sparse_cholesky_solve(A, x, b, ordering::amd{});
+    REQUIRE(relative_residual(A, x, b) < 1e-12);
+}
+
+// ---- Edge cases ----
+
+TEST_CASE("Cholesky on block diagonal SPD", "[sparse][edge]") {
+    // Two disconnected 3x3 SPD blocks
+    std::size_t n = 6;
+    mat::compressed2D<double> A(n, n);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        // Block 1: rows/cols 0-2
+        ins[0][0] << 4.0; ins[0][1] << -1.0;
+        ins[1][0] << -1.0; ins[1][1] << 4.0; ins[1][2] << -1.0;
+        ins[2][1] << -1.0; ins[2][2] << 4.0;
+        // Block 2: rows/cols 3-5
+        ins[3][3] << 5.0; ins[3][4] << -2.0;
+        ins[4][3] << -2.0; ins[4][4] << 5.0; ins[4][5] << -2.0;
+        ins[5][4] << -2.0; ins[5][5] << 5.0;
+    }
+
+    vec::dense_vector<double> b = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+    vec::dense_vector<double> x(n, 0.0);
+    factorization::sparse_cholesky_solve(A, x, b);
+    REQUIRE(relative_residual(A, x, b) < 1e-12);
+}
+
+TEST_CASE("LU on diagonal matrix", "[sparse][edge]") {
+    std::size_t n = 5;
+    mat::compressed2D<double> A(n, n);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        for (std::size_t i = 0; i < n; ++i)
+            ins[i][i] << static_cast<double>(i + 1);
+    }
+    vec::dense_vector<double> b = {1.0, 4.0, 9.0, 16.0, 25.0};
+    vec::dense_vector<double> x(n, 0.0);
+    factorization::sparse_lu_solve(A, x, b);
+    // x should be [1, 2, 3, 4, 5]
+    for (std::size_t i = 0; i < n; ++i)
+        REQUIRE_THAT(x(i), Catch::Matchers::WithinAbs(static_cast<double>(i + 1), 1e-12));
+}
+
+TEST_CASE("LU on upper triangular matrix", "[sparse][edge]") {
+    mat::compressed2D<double> A(3, 3);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        ins[0][0] << 2.0; ins[0][1] << 3.0; ins[0][2] << 1.0;
+        ins[1][1] << 4.0; ins[1][2] << 2.0;
+        ins[2][2] << 5.0;
+    }
+    vec::dense_vector<double> b = {11.0, 14.0, 10.0};
+    vec::dense_vector<double> x(3, 0.0);
+    factorization::sparse_lu_solve(A, x, b);
+    REQUIRE(relative_residual(A, x, b) < 1e-12);
+}
+
+TEST_CASE("LU on permutation matrix", "[sparse][edge]") {
+    // P = [[0,1,0],[0,0,1],[1,0,0]]
+    mat::compressed2D<double> A(3, 3);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        ins[0][1] << 1.0;
+        ins[1][2] << 1.0;
+        ins[2][0] << 1.0;
+    }
+    vec::dense_vector<double> b = {10.0, 20.0, 30.0};
+    vec::dense_vector<double> x(3, 0.0);
+    factorization::sparse_lu_solve(A, x, b);
+    // P*x = b => x = P^T * b = [30, 10, 20]
+    REQUIRE_THAT(x(0), Catch::Matchers::WithinAbs(30.0, 1e-12));
+    REQUIRE_THAT(x(1), Catch::Matchers::WithinAbs(10.0, 1e-12));
+    REQUIRE_THAT(x(2), Catch::Matchers::WithinAbs(20.0, 1e-12));
+}
+
+TEST_CASE("QR least-squares on tall skinny system", "[sparse][edge]") {
+    // 10x3 overdetermined system
+    std::size_t m = 10, n = 3;
+    mat::compressed2D<double> A(m, n);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        for (std::size_t i = 0; i < m; ++i) {
+            ins[i][0] << 1.0;                               // constant
+            ins[i][1] << static_cast<double>(i);             // linear
+            ins[i][2] << static_cast<double>(i * i);         // quadratic
+        }
+    }
+    // b = 1 + 2*i + 3*i^2 (exact fit)
+    vec::dense_vector<double> b(m);
+    for (std::size_t i = 0; i < m; ++i)
+        b(i) = 1.0 + 2.0 * i + 3.0 * static_cast<double>(i * i);
+
+    vec::dense_vector<double> x(n, 0.0);
+    factorization::sparse_qr_solve(A, x, b);
+
+    REQUIRE_THAT(x(0), Catch::Matchers::WithinAbs(1.0, 1e-8));
+    REQUIRE_THAT(x(1), Catch::Matchers::WithinAbs(2.0, 1e-8));
+    REQUIRE_THAT(x(2), Catch::Matchers::WithinAbs(3.0, 1e-8));
+}
+
+TEST_CASE("Identity matrix solve (all solvers)", "[sparse][edge]") {
+    std::size_t n = 5;
+    mat::compressed2D<double> A(n, n);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        for (std::size_t i = 0; i < n; ++i)
+            ins[i][i] << 1.0;
+    }
+    vec::dense_vector<double> b = {1.0, 2.0, 3.0, 4.0, 5.0};
+
+    vec::dense_vector<double> x_chol(n, 0.0), x_lu(n, 0.0), x_qr(n, 0.0);
+    factorization::sparse_cholesky_solve(A, x_chol, b);
+    factorization::sparse_lu_solve(A, x_lu, b);
+    factorization::sparse_qr_solve(A, x_qr, b);
+
+    for (std::size_t i = 0; i < n; ++i) {
+        REQUIRE_THAT(x_chol(i), Catch::Matchers::WithinAbs(b(i), 1e-12));
+        REQUIRE_THAT(x_lu(i), Catch::Matchers::WithinAbs(b(i), 1e-12));
+        REQUIRE_THAT(x_qr(i), Catch::Matchers::WithinAbs(b(i), 1e-12));
+    }
+}
+
+TEST_CASE("Cholesky symbolic reuse across multiple solves", "[sparse][edge]") {
+    auto A = make_spd_tridiag(10);
+    auto sym = factorization::sparse_cholesky_symbolic(A, ordering::amd{});
+    auto num = factorization::sparse_cholesky_numeric(A, sym);
+
+    // Solve 5 different RHS with the same factorization
+    for (int trial = 0; trial < 5; ++trial) {
+        vec::dense_vector<double> b(10);
+        for (std::size_t i = 0; i < 10; ++i)
+            b(i) = static_cast<double>((i + trial) % 7);
+
+        vec::dense_vector<double> x(10, 0.0);
+        num.solve(x, b);
+        REQUIRE(relative_residual(A, x, b) < 1e-12);
+    }
+}

--- a/tests/unit/sparse/test_infrastructure_edge_cases.cpp
+++ b/tests/unit/sparse/test_infrastructure_edge_cases.cpp
@@ -1,0 +1,261 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <cstddef>
+#include <mtl/mat/compressed2D.hpp>
+#include <mtl/mat/inserter.hpp>
+#include <mtl/sparse/util/csc.hpp>
+#include <mtl/sparse/util/permutation.hpp>
+#include <mtl/sparse/util/scatter.hpp>
+#include <mtl/sparse/analysis/elimination_tree.hpp>
+#include <mtl/sparse/analysis/postorder.hpp>
+#include <mtl/sparse/factorization/triangular_solve.hpp>
+
+using namespace mtl;
+using namespace mtl::sparse;
+
+// ---- CSC edge cases ----
+
+TEST_CASE("CSC conversion of empty matrix", "[sparse][csc][edge]") {
+    mat::compressed2D<double> A(0, 0);
+    auto csc = util::crs_to_csc(A);
+    REQUIRE(csc.nrows == 0);
+    REQUIRE(csc.ncols == 0);
+    REQUIRE(csc.nnz() == 0);
+}
+
+TEST_CASE("CSC conversion of 1x1 matrix", "[sparse][csc][edge]") {
+    mat::compressed2D<double> A(1, 1);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        ins[0][0] << 7.0;
+    }
+    auto csc = util::crs_to_csc(A);
+    REQUIRE(csc.nrows == 1);
+    REQUIRE(csc.ncols == 1);
+    REQUIRE(csc.nnz() == 1);
+    REQUIRE(csc(0, 0) == 7.0);
+}
+
+TEST_CASE("CSC conversion of empty sparse matrix (allocated but no entries)", "[sparse][csc][edge]") {
+    mat::compressed2D<double> A(5, 5);
+    // No entries inserted
+    auto csc = util::crs_to_csc(A);
+    REQUIRE(csc.nrows == 5);
+    REQUIRE(csc.ncols == 5);
+    REQUIRE(csc.nnz() == 0);
+}
+
+TEST_CASE("CSC round-trip on rectangular 5x3", "[sparse][csc][edge]") {
+    mat::compressed2D<double> A(5, 3);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        ins[0][0] << 1.0;
+        ins[1][1] << 2.0;
+        ins[2][2] << 3.0;
+        ins[3][0] << 4.0; ins[3][2] << 5.0;
+        ins[4][1] << 6.0;
+    }
+    auto csc = util::crs_to_csc(A);
+    auto B = util::csc_to_crs(csc);
+    REQUIRE(B.num_rows() == 5);
+    REQUIRE(B.num_cols() == 3);
+    for (std::size_t i = 0; i < 5; ++i)
+        for (std::size_t j = 0; j < 3; ++j)
+            REQUIRE(B(i, j) == A(i, j));
+}
+
+TEST_CASE("CSC round-trip on rectangular 3x5", "[sparse][csc][edge]") {
+    mat::compressed2D<double> A(3, 5);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        ins[0][0] << 1.0; ins[0][4] << 2.0;
+        ins[1][2] << 3.0;
+        ins[2][1] << 4.0; ins[2][3] << 5.0;
+    }
+    auto csc = util::crs_to_csc(A);
+    auto B = util::csc_to_crs(csc);
+    for (std::size_t i = 0; i < 3; ++i)
+        for (std::size_t j = 0; j < 5; ++j)
+            REQUIRE(B(i, j) == A(i, j));
+}
+
+// ---- Elimination tree edge cases ----
+
+TEST_CASE("Elimination tree of 1x1 matrix", "[sparse][etree][edge]") {
+    mat::compressed2D<double> A(1, 1);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        ins[0][0] << 1.0;
+    }
+    auto parent = analysis::elimination_tree(A);
+    REQUIRE(parent.size() == 1);
+    REQUIRE(parent[0] == analysis::no_parent);
+}
+
+TEST_CASE("Elimination tree of block diagonal", "[sparse][etree][edge]") {
+    // Two disconnected 2x2 blocks
+    mat::compressed2D<double> A(4, 4);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        ins[0][0] << 2.0; ins[0][1] << 1.0;
+        ins[1][0] << 1.0; ins[1][1] << 2.0;
+        ins[2][2] << 3.0; ins[2][3] << 1.0;
+        ins[3][2] << 1.0; ins[3][3] << 3.0;
+    }
+    auto csc = util::crs_to_csc(A);
+    auto parent = analysis::elimination_tree(csc);
+
+    // Two separate subtrees: 0->1 and 2->3
+    REQUIRE(parent[0] == 1);
+    REQUIRE(parent[1] == analysis::no_parent);
+    REQUIRE(parent[2] == 3);
+    REQUIRE(parent[3] == analysis::no_parent);
+}
+
+TEST_CASE("Column counts for arrow matrix", "[sparse][etree][edge]") {
+    // Arrow: node 0 connects to all
+    std::size_t n = 5;
+    mat::compressed2D<double> A(n, n);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        ins[0][0] << 10.0;
+        for (std::size_t i = 1; i < n; ++i) {
+            ins[0][i] << 1.0;
+            ins[i][0] << 1.0;
+            ins[i][i] << 5.0;
+        }
+    }
+    auto csc = util::crs_to_csc(A);
+    auto parent = analysis::elimination_tree(csc);
+    auto counts = analysis::column_counts(csc, parent);
+
+    // Total nnz should be >= n (at least the diagonal)
+    std::size_t total = analysis::total_nnz(counts);
+    REQUIRE(total >= n);
+}
+
+// ---- Postorder edge cases ----
+
+TEST_CASE("Postorder of single node", "[sparse][postorder][edge]") {
+    std::vector<std::size_t> parent = {analysis::no_parent};
+    auto post = analysis::tree_postorder(parent);
+    REQUIRE(post.size() == 1);
+    REQUIRE(post[0] == 0);
+}
+
+TEST_CASE("Postorder of long chain (50 nodes)", "[sparse][postorder][edge]") {
+    std::size_t n = 50;
+    std::vector<std::size_t> parent(n);
+    for (std::size_t i = 0; i + 1 < n; ++i) parent[i] = i + 1;
+    parent[n - 1] = analysis::no_parent;
+
+    auto post = analysis::tree_postorder(parent);
+    REQUIRE(post.size() == n);
+
+    // Postorder of a chain: 0, 1, 2, ..., n-1
+    for (std::size_t i = 0; i < n; ++i)
+        REQUIRE(post[i] == i);
+}
+
+// ---- Permutation edge cases ----
+
+TEST_CASE("Permutation on rectangular 4x3 column permute", "[sparse][perm][edge]") {
+    mat::compressed2D<double> A(4, 3);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        ins[0][0] << 1.0; ins[0][2] << 2.0;
+        ins[1][1] << 3.0;
+        ins[2][0] << 4.0;
+        ins[3][1] << 5.0; ins[3][2] << 6.0;
+    }
+    // Swap columns 0 and 2: perm = [2, 1, 0]
+    std::vector<std::size_t> perm = {2, 1, 0};
+    auto B = util::column_permute(A, perm);
+
+    // B(:, pinv[old]) = A(:, old)
+    // pinv = [2, 1, 0], so B(:,2)=A(:,0), B(:,1)=A(:,1), B(:,0)=A(:,2)
+    REQUIRE(B(0, 2) == 1.0);  // A(0,0)
+    REQUIRE(B(0, 0) == 2.0);  // A(0,2)
+    REQUIRE(B(1, 1) == 3.0);  // A(1,1)
+    REQUIRE(B(2, 2) == 4.0);  // A(2,0)
+    REQUIRE(B(3, 1) == 5.0);  // A(3,1)
+    REQUIRE(B(3, 0) == 6.0);  // A(3,2)
+}
+
+TEST_CASE("Permutation on rectangular 3x5 row permute", "[sparse][perm][edge]") {
+    mat::compressed2D<double> A(3, 5);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        ins[0][0] << 1.0;
+        ins[1][2] << 2.0;
+        ins[2][4] << 3.0;
+    }
+    // Reverse rows: perm = [2, 1, 0]
+    std::vector<std::size_t> perm = {2, 1, 0};
+    auto B = util::row_permute(A, perm);
+
+    // B(pinv[old], :) = A(old, :)
+    // pinv = [2, 1, 0], so B(2,:)=A(0,:), B(1,:)=A(1,:), B(0,:)=A(2,:)
+    REQUIRE(B(2, 0) == 1.0);
+    REQUIRE(B(1, 2) == 2.0);
+    REQUIRE(B(0, 4) == 3.0);
+}
+
+// ---- Scatter edge cases ----
+
+TEST_CASE("Scatter with many clear cycles", "[sparse][scatter][edge]") {
+    util::sparse_accumulator<double> acc(10);
+    for (int cycle = 0; cycle < 20; ++cycle) {
+        acc.clear();
+        acc.scatter(cycle % 10, static_cast<double>(cycle));
+        REQUIRE(acc.nnz() == 1);
+        REQUIRE(acc(cycle % 10) == static_cast<double>(cycle));
+    }
+}
+
+TEST_CASE("Scatter with large accumulator", "[sparse][scatter][edge]") {
+    std::size_t n = 1000;
+    util::sparse_accumulator<double> acc(n);
+    // Scatter every 10th entry
+    for (std::size_t i = 0; i < n; i += 10)
+        acc.scatter(i, static_cast<double>(i));
+    REQUIRE(acc.nnz() == 100);
+    REQUIRE(acc(0) == 0.0);
+    REQUIRE(acc(990) == 990.0);
+    REQUIRE(acc(5) == 0.0);  // not set
+}
+
+// ---- Triangular solve edge cases ----
+
+TEST_CASE("Lower triangular solve with identity matrix", "[sparse][trisolve][edge]") {
+    mat::compressed2D<double> I(3, 3);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(I);
+        ins[0][0] << 1.0;
+        ins[1][1] << 1.0;
+        ins[2][2] << 1.0;
+    }
+    auto L = util::crs_to_csc(I);
+    std::vector<double> x = {7.0, 8.0, 9.0};
+    factorization::dense_lower_solve(L, x);
+    REQUIRE(x[0] == 7.0);
+    REQUIRE(x[1] == 8.0);
+    REQUIRE(x[2] == 9.0);
+}
+
+TEST_CASE("Upper triangular solve with diagonal matrix", "[sparse][trisolve][edge]") {
+    mat::compressed2D<double> D(3, 3);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(D);
+        ins[0][0] << 2.0;
+        ins[1][1] << 3.0;
+        ins[2][2] << 4.0;
+    }
+    auto U = util::crs_to_csc(D);
+    std::vector<double> x = {6.0, 12.0, 20.0};
+    factorization::dense_upper_solve(U, x);
+    REQUIRE_THAT(x[0], Catch::Matchers::WithinAbs(3.0, 1e-12));
+    REQUIRE_THAT(x[1], Catch::Matchers::WithinAbs(4.0, 1e-12));
+    REQUIRE_THAT(x[2], Catch::Matchers::WithinAbs(5.0, 1e-12));
+}


### PR DESCRIPTION
## Summary

35 new test cases with 243 assertions addressing the critical coverage gaps identified in the sparse direct solver infrastructure.

### Cross-solver consistency (most critical gap)

Previously, no test verified that Cholesky, LU, and QR produce the same solution for the same system. Now:

| Test | Systems sizes | Tolerance |
|------|--------------|-----------|
| Cholesky vs LU (SPD) | 3, 5, 10, 20, 50 | 1e-10 relative diff |
| Cholesky vs QR (SPD) | 3, 5, 10, 20 | 1e-10 |
| LU vs QR (unsymmetric) | 3, 5, 10, 20 | 1e-10 |
| All three (arrow matrix) | 4, 8, 15, 30 | 1e-10 |
| Natural vs RCM vs AMD | 15x15 | 1e-12 (ordering invariance) |
| UMFPACK vs native LU | 3, 5, 10, 20 | 1e-10 (conditional) |
| UMFPACK vs native Cholesky | 5, 10, 20 | 1e-10 (conditional) |

### Scale testing (previously max 10x10)

- Cholesky on 50x50 and 100x100 tridiagonal
- LU on 50x50 unsymmetric
- QR on 50x50
- Cholesky on 30x30 arrow (fill-in stress)

### Edge cases

- Block diagonal SPD (disconnected components)
- Diagonal, upper triangular, permutation matrix inputs to LU
- Identity matrix solve across all three solvers
- 10x3 polynomial least-squares via QR
- Empty/1x1/rectangular CSC conversions
- Block diagonal elimination tree (forest)
- Long chain postorder (50 nodes)
- Rectangular row and column permutations
- Large scatter accumulator (1000 entries)
- Identity and diagonal triangular solves

## Test plan

- [x] 35 new test cases, 243 assertions, all pass
- [x] Full suite: 90/90 tests pass (including UMFPACK cross-validation)
- [ ] CI: verify cross-platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)