### PR TITLE
chore(ci): add release workflow and bump to v5.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [ '**' ]
+    tags: [ 'v[0-9]*' ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,118 @@
+name: Release
+
+# Triggered when a version tag is pushed: git tag v5.2.0 && git push --tags
+on:
+  push:
+    tags:
+      - 'v[0-9]*'
+
+permissions:
+  contents: write
+
+jobs:
+  # ── Run the full CI matrix first ──────────────────────────────────────
+  ci:
+    uses: ./.github/workflows/ci.yml
+
+  # ── Create GitHub release after CI passes ─────────────────────────────
+  release:
+    needs: ci
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history for changelog generation
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Release: $TAG (version $VERSION)"
+
+      - name: Verify CMake version matches tag
+        run: |
+          CMAKE_VERSION=$(grep 'MTL5_FALLBACK_VERSION' CMakeLists.txt | head -1 | grep -oP '\d+\.\d+\.\d+')
+          TAG_VERSION="${{ steps.version.outputs.version }}"
+          echo "CMake fallback version: $CMAKE_VERSION"
+          echo "Tag version: $TAG_VERSION"
+          if [ "$CMAKE_VERSION" != "$TAG_VERSION" ]; then
+            echo "::warning::CMake fallback version ($CMAKE_VERSION) does not match tag ($TAG_VERSION). The build will use the git tag version."
+          fi
+
+      - name: Generate release notes
+        id: notes
+        run: |
+          # Get the previous tag for changelog range
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          if [ -n "$PREV_TAG" ]; then
+            echo "Changes since $PREV_TAG:"
+            RANGE="${PREV_TAG}..HEAD"
+          else
+            echo "Initial release"
+            RANGE="HEAD"
+          fi
+
+          # Generate changelog from conventional commits
+          {
+            echo "## What's Changed"
+            echo ""
+
+            # Features
+            FEATS=$(git log "$RANGE" --pretty=format:"%s" 2>/dev/null | grep "^feat" | sed 's/^feat[^:]*: /- /' || true)
+            if [ -n "$FEATS" ]; then
+              echo "### Features"
+              echo "$FEATS"
+              echo ""
+            fi
+
+            # Fixes
+            FIXES=$(git log "$RANGE" --pretty=format:"%s" 2>/dev/null | grep "^fix" | sed 's/^fix[^:]*: /- /' || true)
+            if [ -n "$FIXES" ]; then
+              echo "### Bug Fixes"
+              echo "$FIXES"
+              echo ""
+            fi
+
+            # Tests
+            TESTS=$(git log "$RANGE" --pretty=format:"%s" 2>/dev/null | grep "^test" | sed 's/^test[^:]*: /- /' || true)
+            if [ -n "$TESTS" ]; then
+              echo "### Tests"
+              echo "$TESTS"
+              echo ""
+            fi
+
+            # Docs
+            DOCS=$(git log "$RANGE" --pretty=format:"%s" 2>/dev/null | grep "^docs\|^doc" | sed 's/^docs\?[^:]*: /- /' || true)
+            if [ -n "$DOCS" ]; then
+              echo "### Documentation"
+              echo "$DOCS"
+              echo ""
+            fi
+
+            # Other
+            OTHER=$(git log "$RANGE" --pretty=format:"%s" 2>/dev/null | grep -v "^feat\|^fix\|^test\|^docs\|^doc\|^Merge" | sed 's/^[^:]*: /- /' || true)
+            if [ -n "$OTHER" ]; then
+              echo "### Other Changes"
+              echo "$OTHER"
+              echo ""
+            fi
+
+            echo "---"
+            echo ""
+            echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG:-v0.0.0}...${{ steps.version.outputs.tag }}"
+          } > release_notes.md
+
+          cat release_notes.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: "MTL5 ${{ steps.version.outputs.tag }}"
+          body_path: release_notes.md
+          draft: false
+          prerelease: false
+          generate_release_notes: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to MTL5 are documented in this file.
 Format follows [Conventional Commits](https://www.conventionalcommits.org/).
 
-## [Unreleased]
+## [5.2.0] — 2026-03-16
 
 ### Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,3 +205,27 @@ BREAKING CHANGE: All code using `Scalar<T>` must update to `ArithmeticScalar<T>`
 4. CodeRabbit reviews automatically; address feedback
 5. CI must pass on all platforms (Linux GCC/Clang, macOS Apple Clang, Windows MSVC/Clang-CL)
 6. Merge via squash-merge or regular merge (maintainer preference)
+
+### Releases
+
+Releases follow [Semantic Versioning](https://semver.org/) and are triggered by pushing a git tag:
+
+```bash
+git tag v5.2.0
+git push --tags
+```
+
+This triggers the release workflow (`.github/workflows/release.yml`) which:
+1. Runs the full CI matrix (8 platforms) on the tagged commit
+2. Verifies the CMake fallback version matches the tag
+3. Generates release notes from conventional commit messages
+4. Creates a GitHub Release with the changelog
+
+The CMake build system extracts the version from the git tag automatically (`git describe --tags`). When building outside a git repo or without a tag, it falls back to `MTL5_FALLBACK_VERSION` in `CMakeLists.txt`.
+
+**Version bumping checklist:**
+1. Update `MTL5_FALLBACK_VERSION` in `CMakeLists.txt` to the new version
+2. Update `CHANGELOG.md` with the release date and changes
+3. Commit, push, create and merge the PR
+4. Tag the merge commit: `git tag v<major>.<minor>.<patch>`
+5. Push the tag: `git push --tags`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,35 @@
 cmake_minimum_required(VERSION 3.22)
 
+# ── Version from git tag ────────────────────────────────────────────────
+# If building from a git tag like v5.2.0, extract the version automatically.
+# Falls back to the hardcoded version below when git is unavailable or
+# the working directory is not a tagged commit.
+set(MTL5_FALLBACK_VERSION "5.2.0")
+
+find_package(Git QUIET)
+if(GIT_FOUND)
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} describe --tags --match "v[0-9]*" --abbrev=0
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        OUTPUT_VARIABLE MTL5_GIT_TAG
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        RESULT_VARIABLE GIT_DESCRIBE_RESULT
+    )
+    if(GIT_DESCRIBE_RESULT EQUAL 0 AND MTL5_GIT_TAG MATCHES "^v([0-9]+\\.[0-9]+\\.[0-9]+)")
+        set(MTL5_DETECTED_VERSION "${CMAKE_MATCH_1}")
+        message(STATUS "MTL5 version from git tag: ${MTL5_DETECTED_VERSION}")
+    else()
+        set(MTL5_DETECTED_VERSION "${MTL5_FALLBACK_VERSION}")
+        message(STATUS "MTL5 version (fallback): ${MTL5_DETECTED_VERSION}")
+    endif()
+else()
+    set(MTL5_DETECTED_VERSION "${MTL5_FALLBACK_VERSION}")
+    message(STATUS "MTL5 version (no git): ${MTL5_DETECTED_VERSION}")
+endif()
+
 project(MTL5
-    VERSION 5.1.0
+    VERSION ${MTL5_DETECTED_VERSION}
     LANGUAGES CXX
     DESCRIPTION "Matrix Template Library 5 — C++20 header-only linear algebra"
 )


### PR DESCRIPTION
## Summary

Formalize the MTL5 release process with automated version detection from git tags and a GitHub Actions release workflow.

### Release workflow

```
git tag v5.2.0 && git push --tags
```

This triggers `.github/workflows/release.yml` which:
1. Runs the full CI matrix (8 platforms) on the tagged commit
2. Verifies the CMake fallback version matches the tag
3. Generates categorized release notes from conventional commits (feat/fix/test/docs)
4. Creates a GitHub Release with the changelog

### Version detection

CMake now extracts the version from the nearest git tag automatically:

```cmake
# git describe --tags --match "v[0-9]*" --abbrev=0
# Parses v5.2.0 → PROJECT_VERSION = 5.2.0
```

Falls back to `MTL5_FALLBACK_VERSION` (now `5.2.0`) when:
- Building outside a git repository
- No matching tag exists
- Git is not installed

### Changes

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | New: release workflow |
| `.github/workflows/ci.yml` | Trigger on `v*` tags |
| `CMakeLists.txt` | Git tag version detection, fallback bump to 5.2.0 |
| `CHANGELOG.md` | Mark changes as [5.2.0] release |
| `CLAUDE.md` | Document release workflow and version bump checklist |

## After merge

Tag the merge commit to trigger the first release:

```bash
git checkout main && git pull
git tag v5.2.0
git push --tags
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)