### PR TITLE
fix(ci): add workflow_call trigger to ci.yml for release reuse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     tags: [ 'v[0-9]*' ]
   pull_request:
     branches: [ main ]
+  workflow_call:
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

One-line fix: add `workflow_call:` to `ci.yml`'s `on:` block so the release workflow can call it as a reusable workflow.

Without this, GitHub rejects `release.yml` at parse time with:
> workflow is not reusable as it is missing a `on.workflow_call` trigger

## Test plan

- [ ] CI runs on this PR (validates the workflow file parses correctly)
- [ ] After merge + tag, release workflow should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced workflow automation configuration to enable reusability across multiple workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->