### PR TITLE
fix(ci): remove duplicate CI from release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
     tags: [ 'v[0-9]*' ]
   pull_request:
     branches: [ main ]
-  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Release
 
 # Triggered when a version tag is pushed: git tag v5.2.0 && git push --tags
+# CI runs separately via ci.yml (which also triggers on v* tags).
+# This workflow only creates the GitHub Release — no duplicate builds.
 on:
   push:
     tags:
@@ -10,13 +12,7 @@ permissions:
   contents: write
 
 jobs:
-  # ── Run the full CI matrix first ──────────────────────────────────────
-  ci:
-    uses: ./.github/workflows/ci.yml
-
-  # ── Create GitHub release after CI passes ─────────────────────────────
   release:
-    needs: ci
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -43,7 +39,6 @@ jobs:
           fi
 
       - name: Generate release notes
-        id: notes
         run: |
           # Get the previous tag for changelog range
           PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary

Tag push triggers `ci.yml` independently. The release workflow was also calling `ci.yml` as a reusable workflow, doubling the build. Now `release.yml` only creates the GitHub Release — CI runs once.

- Remove `uses: ./.github/workflows/ci.yml` and `needs: ci` from release.yml
- Remove `workflow_call:` trigger from ci.yml (no longer needed)

**On tag push, two workflows run in parallel:**
- `ci.yml` — 8-platform build + test matrix
- `release.yml` — extract version, generate changelog, create GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)