### PR TITLE
feat(array): add ndarray<T,N> core with slicing, broadcasting, reductions

### DIFF
--- a/include/mtl/array/broadcast.hpp
+++ b/include/mtl/array/broadcast.hpp
@@ -1,0 +1,101 @@
+#pragma once
+// MTL5 -- Broadcasting element-wise operations for ndarray
+//
+// Implements NumPy broadcasting rules via lazy expression templates.
+// Binary operations (+, -, *, /) between ndarrays of compatible shapes
+// produce broadcast_expr objects that are evaluated on assignment.
+
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <stdexcept>
+#include <type_traits>
+
+#include <mtl/array/ndarray.hpp>
+#include <mtl/array/shape.hpp>
+
+namespace mtl::array {
+
+// ── Broadcast expression ───────────────────────────────────────────
+
+/// Lazy expression for element-wise binary operations with broadcasting.
+template <typename LHS, typename RHS, typename Op, std::size_t N>
+class broadcast_expr {
+    const LHS& lhs_;
+    const RHS& rhs_;
+    Op op_;
+    shape<N> result_shape_;
+    std::array<std::size_t, N> lhs_strides_;
+    std::array<std::size_t, N> rhs_strides_;
+
+public:
+    using value_type = decltype(std::declval<Op>()(
+        std::declval<typename LHS::value_type>(),
+        std::declval<typename RHS::value_type>()));
+    using size_type  = std::size_t;
+    static constexpr size_type rank = N;
+
+    broadcast_expr(const LHS& lhs, const RHS& rhs, Op op)
+        : lhs_(lhs), rhs_(rhs), op_(op) {
+        bool ok = broadcast_shape(lhs.get_shape(), rhs.get_shape(), result_shape_);
+        if (!ok) throw std::invalid_argument("ndarray: incompatible shapes for broadcasting");
+        lhs_strides_ = broadcast_strides(lhs.get_shape(), lhs.get_strides(), result_shape_);
+        rhs_strides_ = broadcast_strides(rhs.get_shape(), rhs.get_strides(), result_shape_);
+    }
+
+    const ::mtl::array::shape<N>& get_shape() const { return result_shape_; }
+
+    size_type size() const { return result_shape_.total_size(); }
+
+    /// Evaluate at a multi-index.
+    value_type operator[](const std::array<size_type, N>& idx) const {
+        size_type lhs_off = compute_offset(idx, lhs_strides_);
+        size_type rhs_off = compute_offset(idx, rhs_strides_);
+        return op_(lhs_.data()[lhs_off], rhs_.data()[rhs_off]);
+    }
+
+    /// Materialize the expression into a new ndarray.
+    ndarray<value_type, N> eval() const {
+        ndarray<value_type, N> result(result_shape_);
+        result.iterate_indices([&](const std::array<size_type, N>& idx) {
+            result[idx] = (*this)[idx];
+        });
+        return result;
+    }
+
+    /// Allow implicit conversion to ndarray (materialization).
+    operator ndarray<value_type, N>() const { return eval(); }
+};
+
+// ── Functors ───────────────────────────────────────────────────────
+
+namespace ops {
+    struct plus  { template <typename T, typename U> auto operator()(T a, U b) const { return a + b; } };
+    struct minus { template <typename T, typename U> auto operator()(T a, U b) const { return a - b; } };
+    struct times { template <typename T, typename U> auto operator()(T a, U b) const { return a * b; } };
+    struct divides { template <typename T, typename U> auto operator()(T a, U b) const { return a / b; } };
+} // namespace ops
+
+// ── Operators ──────────────────────────────────────────────────────
+
+template <typename V1, std::size_t N, typename O1, typename V2, typename O2>
+auto operator+(const ndarray<V1, N, O1>& a, const ndarray<V2, N, O2>& b) {
+    return broadcast_expr<ndarray<V1, N, O1>, ndarray<V2, N, O2>, ops::plus, N>(a, b, ops::plus{});
+}
+
+template <typename V1, std::size_t N, typename O1, typename V2, typename O2>
+auto operator-(const ndarray<V1, N, O1>& a, const ndarray<V2, N, O2>& b) {
+    return broadcast_expr<ndarray<V1, N, O1>, ndarray<V2, N, O2>, ops::minus, N>(a, b, ops::minus{});
+}
+
+template <typename V1, std::size_t N, typename O1, typename V2, typename O2>
+auto operator*(const ndarray<V1, N, O1>& a, const ndarray<V2, N, O2>& b) {
+    return broadcast_expr<ndarray<V1, N, O1>, ndarray<V2, N, O2>, ops::times, N>(a, b, ops::times{});
+}
+
+template <typename V1, std::size_t N, typename O1, typename V2, typename O2>
+auto operator/(const ndarray<V1, N, O1>& a, const ndarray<V2, N, O2>& b) {
+    return broadcast_expr<ndarray<V1, N, O1>, ndarray<V2, N, O2>, ops::divides, N>(a, b, ops::divides{});
+}
+
+} // namespace mtl::array

--- a/include/mtl/array/ndarray.hpp
+++ b/include/mtl/array/ndarray.hpp
@@ -1,0 +1,336 @@
+#pragma once
+// MTL5 -- N-dimensional array (ndarray) core type
+//
+// ndarray<T, N, Order> provides a NumPy-compatible multi-dimensional array:
+//   - Static rank N, runtime shape and strides
+//   - Owning (heap-allocated) and non-owning (view) modes
+//   - C-order (row-major, default) or F-order (column-major)
+//   - Element access via operator()(i, j, k, ...)
+//   - Slicing returns views (no copies)
+//
+// Follows MTL5 patterns: composition with contiguous_memory_block,
+// [[no_unique_address]], C++20 concepts, bounds checking in debug builds.
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <initializer_list>
+#include <numeric>
+#include <stdexcept>
+#include <type_traits>
+
+#include <mtl/config.hpp>
+#include <mtl/tag/sparsity.hpp>
+#include <mtl/traits/category.hpp>
+#include <mtl/traits/ashape.hpp>
+#include <mtl/traits/is_expression.hpp>
+#include <mtl/detail/contiguous_memory_block.hpp>
+#include <mtl/array/shape.hpp>
+
+namespace mtl::array {
+
+/// N-dimensional array with static rank and runtime shape.
+///
+/// @tparam Value  element type (must be default-constructible)
+/// @tparam N      number of dimensions (compile-time rank)
+/// @tparam Order  memory layout: c_order (default) or f_order
+template <typename Value, std::size_t N, typename Order = c_order>
+class ndarray {
+public:
+    // -- Type aliases --------------------------------------------------------
+    using value_type      = Value;
+    using reference       = Value&;
+    using const_reference = const Value&;
+    using pointer         = Value*;
+    using const_pointer   = const Value*;
+    using size_type       = std::size_t;
+    using shape_type      = ::mtl::array::shape<N>;
+    using strides_type    = std::array<size_type, N>;
+
+    static constexpr size_type rank = N;
+
+private:
+    using memory_type = detail::contiguous_memory_block<Value, tag::on_heap, 0>;
+
+    shape_type   shape_;
+    strides_type strides_{};
+    memory_type  mem_;
+
+    constexpr void init_strides() {
+        strides_ = compute_strides<Order>(shape_);
+    }
+
+public:
+    // -- Constructors --------------------------------------------------------
+
+    /// Default: empty array with zero extents.
+    ndarray() = default;
+
+    /// Construct from shape, zero-initialized.
+    explicit ndarray(shape_type sh)
+        : mem_(sh.total_size()), shape_(sh) {
+        init_strides();
+    }
+
+    /// Construct from initializer list of extents.
+    ndarray(std::initializer_list<size_type> extents)
+        : shape_(extents), mem_(shape_.total_size()) {
+        init_strides();
+    }
+
+    /// Construct from shape + fill value.
+    ndarray(shape_type sh, const Value& val)
+        : mem_(sh.total_size()), shape_(sh) {
+        init_strides();
+        std::fill_n(mem_.data(), mem_.size(), val);
+    }
+
+    /// Non-owning view: wraps external memory with given shape and strides.
+    ndarray(Value* ptr, shape_type sh, strides_type strides)
+        : mem_(ptr, sh.total_size(), /*is_view=*/true),
+          shape_(sh), strides_(strides) {}
+
+    /// Non-owning view: wraps external memory with contiguous layout.
+    ndarray(Value* ptr, shape_type sh)
+        : mem_(ptr, sh.total_size(), /*is_view=*/true),
+          shape_(sh) {
+        init_strides();
+    }
+
+    // Copy and move: default (contiguous_memory_block handles ownership)
+    ndarray(const ndarray&) = default;
+    ndarray(ndarray&&) noexcept = default;
+    ndarray& operator=(const ndarray&) = default;
+    ndarray& operator=(ndarray&&) noexcept = default;
+
+    // -- Shape and size ------------------------------------------------------
+
+    constexpr const shape_type&   get_shape()   const { return shape_; }
+    constexpr const strides_type& get_strides() const { return strides_; }
+
+    constexpr size_type extent(size_type dim) const { return shape_[dim]; }
+
+    constexpr size_type size() const { return shape_.total_size(); }
+    constexpr bool      empty() const { return size() == 0; }
+
+    /// Check if this array owns its memory.
+    bool is_view() const {
+        return mem_.category() == detail::memory_category::view ||
+               mem_.category() == detail::memory_category::external;
+    }
+
+    /// Check if memory is contiguous (enables BLAS dispatch, reshape, etc.)
+    bool is_contiguous() const {
+        return ::mtl::array::is_contiguous(shape_, strides_);
+    }
+
+    // -- Element access ------------------------------------------------------
+
+    /// Multi-index access: a(i, j, k, ...)
+    template <typename... Indices>
+        requires (sizeof...(Indices) == N)
+    reference operator()(Indices... indices) {
+        if constexpr (bounds_checking) {
+            check_bounds({static_cast<size_type>(indices)...});
+        }
+        const size_type off = offset_from<N>(strides_, indices...);
+        return mem_[off];
+    }
+
+    template <typename... Indices>
+        requires (sizeof...(Indices) == N)
+    const_reference operator()(Indices... indices) const {
+        if constexpr (bounds_checking) {
+            check_bounds({static_cast<size_type>(indices)...});
+        }
+        const size_type off = offset_from<N>(strides_, indices...);
+        return mem_[off];
+    }
+
+    /// Array-index access: a[{i, j, k}]
+    reference operator[](const std::array<size_type, N>& idx) {
+        if constexpr (bounds_checking) check_bounds(idx);
+        return mem_[compute_offset(idx, strides_)];
+    }
+
+    const_reference operator[](const std::array<size_type, N>& idx) const {
+        if constexpr (bounds_checking) check_bounds(idx);
+        return mem_[compute_offset(idx, strides_)];
+    }
+
+    /// Flat (linear) index access — only valid for contiguous arrays.
+    reference flat(size_type i) {
+        assert(i < size());
+        return mem_[i];
+    }
+
+    const_reference flat(size_type i) const {
+        assert(i < size());
+        return mem_[i];
+    }
+
+    // -- Data access ---------------------------------------------------------
+
+    pointer       data()       { return mem_.data(); }
+    const_pointer data() const { return mem_.data(); }
+
+    pointer       begin()       { return mem_.begin(); }
+    const_pointer begin() const { return mem_.begin(); }
+    pointer       end()         { return mem_.end(); }
+    const_pointer end()   const { return mem_.end(); }
+
+    // -- Fill ----------------------------------------------------------------
+
+    void fill(const Value& val) {
+        if (is_contiguous()) {
+            std::fill_n(mem_.data(), size(), val);
+        } else {
+            iterate_indices([&](const std::array<size_type, N>& idx) {
+                (*this)[idx] = val;
+            });
+        }
+    }
+
+    // -- View creation -------------------------------------------------------
+
+    /// Create a view (non-owning) of this array with the same shape and strides.
+    ndarray view() {
+        return ndarray(mem_.data(), shape_, strides_);
+    }
+
+    /// Reshape: returns a view if contiguous, otherwise throws.
+    template <std::size_t M>
+    ndarray<Value, M, Order> reshape(::mtl::array::shape<M> new_shape) const {
+        assert(new_shape.total_size() == size() && "Reshape must preserve total size");
+        if (!is_contiguous()) {
+            throw std::runtime_error("Cannot reshape non-contiguous array without copy");
+        }
+        return ndarray<Value, M, Order>(
+            const_cast<Value*>(mem_.data()), new_shape);
+    }
+
+    /// Transpose: returns a view with reversed shape and strides.
+    ndarray<Value, N, Order> transpose() const {
+        shape_type   new_shape;
+        strides_type new_strides;
+        for (size_type i = 0; i < N; ++i) {
+            new_shape[i]   = shape_[N - 1 - i];
+            new_strides[i] = strides_[N - 1 - i];
+        }
+        return ndarray<Value, N, Order>(
+            const_cast<Value*>(mem_.data()), new_shape, new_strides);
+    }
+
+    // -- Scalar compound assignment ------------------------------------------
+
+    ndarray& operator+=(const Value& s) {
+        for_each_element([&](Value& v) { v += s; });
+        return *this;
+    }
+
+    ndarray& operator-=(const Value& s) {
+        for_each_element([&](Value& v) { v -= s; });
+        return *this;
+    }
+
+    ndarray& operator*=(const Value& s) {
+        for_each_element([&](Value& v) { v *= s; });
+        return *this;
+    }
+
+    ndarray& operator/=(const Value& s) {
+        for_each_element([&](Value& v) { v /= s; });
+        return *this;
+    }
+
+    // -- Utility -------------------------------------------------------------
+
+    /// Iterate over all valid multi-indices, calling f(idx) for each.
+    template <typename F>
+    void iterate_indices(F&& f) const {
+        std::array<size_type, N> idx{};
+        iterate_impl(f, idx, 0);
+    }
+
+    /// Apply f to every element (respects strides for non-contiguous arrays).
+    template <typename F>
+    void for_each_element(F&& f) {
+        if (is_contiguous()) {
+            for (size_type i = 0; i < size(); ++i) {
+                f(mem_[i]);
+            }
+        } else {
+            iterate_indices([&](const std::array<size_type, N>& idx) {
+                f((*this)[idx]);
+            });
+        }
+    }
+
+    template <typename F>
+    void for_each_element(F&& f) const {
+        if (is_contiguous()) {
+            for (size_type i = 0; i < size(); ++i) {
+                f(mem_[i]);
+            }
+        } else {
+            iterate_indices([&](const std::array<size_type, N>& idx) {
+                f((*this)[idx]);
+            });
+        }
+    }
+
+private:
+    void check_bounds(const std::array<size_type, N>& idx) const {
+        for (size_type i = 0; i < N; ++i) {
+            if (idx[i] >= shape_[i]) {
+                throw std::out_of_range("ndarray: index out of bounds");
+            }
+        }
+    }
+
+    template <typename F>
+    void iterate_impl(F& f, std::array<size_type, N>& idx, size_type dim) const {
+        if (dim == N) {
+            f(idx);
+            return;
+        }
+        for (size_type i = 0; i < shape_[dim]; ++i) {
+            idx[dim] = i;
+            iterate_impl(f, idx, dim + 1);
+        }
+    }
+};
+
+// -- Deduction guides --------------------------------------------------------
+
+template <typename Value, std::size_t N>
+ndarray(Value*, shape<N>) -> ndarray<Value, N, c_order>;
+
+template <typename Value, std::size_t N>
+ndarray(Value*, shape<N>, std::array<std::size_t, N>) -> ndarray<Value, N, c_order>;
+
+} // namespace mtl::array
+
+// -- Trait specializations ---------------------------------------------------
+
+namespace mtl::traits {
+
+template <typename V, std::size_t N, typename O>
+struct category<::mtl::array::ndarray<V, N, O>> {
+    using type = tag::dense;
+};
+
+template <typename V, std::size_t N, typename O>
+struct is_expression<::mtl::array::ndarray<V, N, O>> : std::false_type {};
+
+} // namespace mtl::traits
+
+namespace mtl::ashape {
+
+template <typename V, std::size_t N, typename O>
+struct ashape<::mtl::array::ndarray<V, N, O>> {
+    using type = nonscal;
+};
+
+} // namespace mtl::ashape

--- a/include/mtl/array/operations.hpp
+++ b/include/mtl/array/operations.hpp
@@ -1,0 +1,101 @@
+#pragma once
+// MTL5 -- Reduction operations for ndarray
+//
+// Provides sum, prod, min, max, mean as free functions.
+// Full reductions return a scalar; axis reductions return an ndarray
+// of reduced rank.
+
+#include <algorithm>
+#include <cstddef>
+#include <limits>
+#include <type_traits>
+
+#include <mtl/array/ndarray.hpp>
+#include <mtl/math/identity.hpp>
+
+namespace mtl::array {
+
+// ── Full reductions (scalar result) ────────────────────────────────
+
+/// Sum all elements.
+template <typename V, std::size_t N, typename O>
+V sum(const ndarray<V, N, O>& a) {
+    V result = V{0};
+    a.for_each_element([&](const V& v) { result += v; });
+    return result;
+}
+
+/// Product of all elements.
+template <typename V, std::size_t N, typename O>
+V prod(const ndarray<V, N, O>& a) {
+    V result = V{1};
+    a.for_each_element([&](const V& v) { result *= v; });
+    return result;
+}
+
+/// Minimum element.
+template <typename V, std::size_t N, typename O>
+    requires std::totally_ordered<V>
+V min(const ndarray<V, N, O>& a) {
+    V result = std::numeric_limits<V>::max();
+    a.for_each_element([&](const V& v) { if (v < result) result = v; });
+    return result;
+}
+
+/// Maximum element.
+template <typename V, std::size_t N, typename O>
+    requires std::totally_ordered<V>
+V max(const ndarray<V, N, O>& a) {
+    V result = std::numeric_limits<V>::lowest();
+    a.for_each_element([&](const V& v) { if (v > result) result = v; });
+    return result;
+}
+
+/// Mean of all elements.
+template <typename V, std::size_t N, typename O>
+V mean(const ndarray<V, N, O>& a) {
+    return sum(a) / static_cast<V>(a.size());
+}
+
+// ── Axis reductions (ndarray result) ───────────────────────────────
+
+/// Sum along a specified axis, producing an ndarray of rank N-1.
+template <typename V, std::size_t N, typename O>
+    requires (N > 1)
+ndarray<V, N - 1, O> sum_axis(const ndarray<V, N, O>& a, std::size_t axis) {
+    assert(axis < N);
+
+    // Build output shape: remove the axis dimension
+    shape<N - 1> out_shape;
+    std::size_t j = 0;
+    for (std::size_t i = 0; i < N; ++i) {
+        if (i != axis) out_shape[j++] = a.extent(i);
+    }
+
+    ndarray<V, N - 1, O> result(out_shape, V{0});
+
+    // Iterate over all indices of the input
+    a.iterate_indices([&](const std::array<std::size_t, N>& idx) {
+        // Build the output index by skipping the axis
+        std::array<std::size_t, N - 1> out_idx;
+        std::size_t k = 0;
+        for (std::size_t i = 0; i < N; ++i) {
+            if (i != axis) out_idx[k++] = idx[i];
+        }
+        result[out_idx] += a[idx];
+    });
+
+    return result;
+}
+
+/// Mean along a specified axis.
+template <typename V, std::size_t N, typename O>
+    requires (N > 1)
+ndarray<V, N - 1, O> mean_axis(const ndarray<V, N, O>& a, std::size_t axis) {
+    auto result = sum_axis(a, axis);
+    V divisor = static_cast<V>(a.extent(axis));
+    result.for_each_element([&](V& v) { v /= divisor; });
+    return result;
+}
+
+} // namespace mtl::array

--- a/include/mtl/array/shape.hpp
+++ b/include/mtl/array/shape.hpp
@@ -1,0 +1,164 @@
+#pragma once
+// MTL5 -- N-dimensional shape and stride utilities for ndarray
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <initializer_list>
+#include <numeric>
+#include <stdexcept>
+
+#include <mtl/tag/orientation.hpp>
+
+namespace mtl::array {
+
+/// Layout order for multi-dimensional arrays
+using c_order = tag::row_major;     // last index varies fastest (NumPy default)
+using f_order = tag::col_major;     // first index varies fastest (Fortran/MATLAB)
+
+// ── Shape ──────────────────────────────────────────────────────────
+
+/// Static-rank shape: an array of N extents.
+template <std::size_t N>
+class shape {
+    std::array<std::size_t, N> extents_{};
+
+public:
+    static constexpr std::size_t rank = N;
+
+    constexpr shape() = default;
+
+    constexpr shape(std::array<std::size_t, N> ext) : extents_(ext) {}
+
+    constexpr shape(std::initializer_list<std::size_t> il) {
+        assert(il.size() == N);
+        std::copy_n(il.begin(), N, extents_.begin());
+    }
+
+    constexpr std::size_t  operator[](std::size_t i) const { return extents_[i]; }
+    constexpr std::size_t& operator[](std::size_t i)       { return extents_[i]; }
+
+    constexpr const std::array<std::size_t, N>& extents() const { return extents_; }
+
+    constexpr std::size_t total_size() const {
+        std::size_t s = 1;
+        for (std::size_t i = 0; i < N; ++i) s *= extents_[i];
+        return s;
+    }
+
+    constexpr bool operator==(const shape&) const = default;
+};
+
+// ── Strides ────────────────────────────────────────────────────────
+
+/// Compute C-order (row-major) strides: last dimension has stride 1.
+template <std::size_t N>
+constexpr std::array<std::size_t, N> c_order_strides(const shape<N>& sh) {
+    std::array<std::size_t, N> strides{};
+    if constexpr (N > 0) {
+        strides[N - 1] = 1;
+        for (std::size_t i = N - 1; i > 0; --i) {
+            strides[i - 1] = strides[i] * sh[i];
+        }
+    }
+    return strides;
+}
+
+/// Compute F-order (column-major) strides: first dimension has stride 1.
+template <std::size_t N>
+constexpr std::array<std::size_t, N> f_order_strides(const shape<N>& sh) {
+    std::array<std::size_t, N> strides{};
+    if constexpr (N > 0) {
+        strides[0] = 1;
+        for (std::size_t i = 1; i < N; ++i) {
+            strides[i] = strides[i - 1] * sh[i - 1];
+        }
+    }
+    return strides;
+}
+
+/// Compute strides for a given layout order.
+template <typename Order, std::size_t N>
+constexpr std::array<std::size_t, N> compute_strides(const shape<N>& sh) {
+    if constexpr (std::is_same_v<Order, f_order>)
+        return f_order_strides(sh);
+    else
+        return c_order_strides(sh);
+}
+
+// ── Offset computation ─────────────────────────────────────────────
+
+/// Compute flat offset from multi-index and strides.
+template <std::size_t N>
+constexpr std::size_t compute_offset(const std::array<std::size_t, N>& indices,
+                                     const std::array<std::size_t, N>& strides) {
+    std::size_t offset = 0;
+    for (std::size_t i = 0; i < N; ++i) {
+        offset += indices[i] * strides[i];
+    }
+    return offset;
+}
+
+/// Variadic offset computation — converts (i, j, k, ...) to flat index.
+template <std::size_t N, typename... Indices>
+constexpr std::size_t offset_from(const std::array<std::size_t, N>& strides,
+                                  Indices... indices) {
+    static_assert(sizeof...(Indices) == N, "Number of indices must match rank");
+    const std::array<std::size_t, N> idx{static_cast<std::size_t>(indices)...};
+    return compute_offset(idx, strides);
+}
+
+// ── Broadcasting ───────────────────────────────────────────────────
+
+/// Compute the broadcast shape of two shapes.
+/// Follows NumPy rules: trailing dimensions aligned, size-1 axes stretch.
+/// Returns false if shapes are incompatible.
+template <std::size_t N>
+constexpr bool broadcast_shape(const shape<N>& a, const shape<N>& b, shape<N>& result) {
+    for (std::size_t i = 0; i < N; ++i) {
+        if (a[i] == b[i]) {
+            result[i] = a[i];
+        } else if (a[i] == 1) {
+            result[i] = b[i];
+        } else if (b[i] == 1) {
+            result[i] = a[i];
+        } else {
+            return false;  // incompatible
+        }
+    }
+    return true;
+}
+
+/// Compute broadcast strides: dimension with extent 1 gets stride 0 (repeat).
+template <std::size_t N>
+constexpr std::array<std::size_t, N> broadcast_strides(const shape<N>& original,
+                                                       const std::array<std::size_t, N>& strides,
+                                                       const shape<N>& target) {
+    std::array<std::size_t, N> result{};
+    for (std::size_t i = 0; i < N; ++i) {
+        result[i] = (original[i] == target[i]) ? strides[i] : 0;
+    }
+    return result;
+}
+
+// ── Contiguity check ───────────────────────────────────────────────
+
+/// Check if strides correspond to a contiguous C-order layout.
+template <std::size_t N>
+constexpr bool is_contiguous_c(const shape<N>& sh, const std::array<std::size_t, N>& strides) {
+    return strides == c_order_strides(sh);
+}
+
+/// Check if strides correspond to a contiguous F-order layout.
+template <std::size_t N>
+constexpr bool is_contiguous_f(const shape<N>& sh, const std::array<std::size_t, N>& strides) {
+    return strides == f_order_strides(sh);
+}
+
+/// Check if the array is contiguous in any order.
+template <std::size_t N>
+constexpr bool is_contiguous(const shape<N>& sh, const std::array<std::size_t, N>& strides) {
+    return is_contiguous_c(sh, strides) || is_contiguous_f(sh, strides);
+}
+
+} // namespace mtl::array

--- a/include/mtl/array/slice.hpp
+++ b/include/mtl/array/slice.hpp
@@ -1,0 +1,145 @@
+#pragma once
+// MTL5 -- Slicing helpers for ndarray
+//
+// Provides slice descriptors that can be used with ndarray::slice():
+//   all       — select entire dimension
+//   range     — select a contiguous range with optional step
+//   integer   — select a single index (reduces rank by 1)
+
+#include <array>
+#include <cstddef>
+#include <tuple>
+#include <type_traits>
+
+#include <mtl/array/ndarray.hpp>
+
+namespace mtl::array {
+
+// ── Slice descriptors ──────────────────────────────────────────────
+
+/// Select all elements along a dimension.
+struct all_t {};
+inline constexpr all_t all{};
+
+/// Select a contiguous range [start, stop) with optional step.
+struct range {
+    std::size_t start;
+    std::size_t stop;
+    std::size_t step;
+
+    constexpr range(std::size_t s, std::size_t e, std::size_t st = 1)
+        : start(s), stop(e), step(st) {}
+
+    constexpr std::size_t extent() const {
+        return (stop > start) ? (stop - start + step - 1) / step : 0;
+    }
+};
+
+// ── Slice implementation ───────────────────────────────────────────
+
+namespace detail_slice {
+
+// Count how many integer (non-slice) arguments there are → rank reduction
+template <typename T>
+struct is_index_arg : std::false_type {};
+
+template <>
+struct is_index_arg<all_t> : std::false_type {};
+
+template <>
+struct is_index_arg<range> : std::false_type {};
+
+// Anything convertible to size_t that isn't all_t or range is an integer index
+template <typename T>
+concept SliceIndex = std::convertible_to<T, std::size_t>
+    && !std::is_same_v<std::remove_cvref_t<T>, all_t>
+    && !std::is_same_v<std::remove_cvref_t<T>, range>;
+
+// Count non-integer slice args (these become dimensions in the result)
+template <typename... Args>
+constexpr std::size_t count_kept_dims() {
+    return (... + (!SliceIndex<Args> ? std::size_t{1} : std::size_t{0}));
+}
+
+} // namespace detail_slice
+
+/// Slice an ndarray, returning a view with potentially reduced rank.
+///
+/// Each argument is one of:
+///   - all       → keep the full dimension
+///   - range     → select a sub-range (adjusts shape + offset)
+///   - integer   → fix an index (reduces rank by 1)
+///
+/// Returns an ndarray view with rank = N - (number of integer args).
+template <typename Value, std::size_t N, typename Order, typename... Args>
+    requires (sizeof...(Args) == N)
+auto slice(ndarray<Value, N, Order>& arr, Args... args) {
+    constexpr std::size_t M = detail_slice::count_kept_dims<Args...>();
+
+    // Compute the new shape, strides, and base offset
+    shape<M>                   new_shape;
+    std::array<std::size_t, M> new_strides;
+    std::size_t base_offset = 0;
+
+    auto process = [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+        std::size_t out_dim = 0;
+        auto process_one = [&](auto arg, std::size_t dim) {
+            using Arg = decltype(arg);
+            if constexpr (std::is_same_v<std::remove_cvref_t<Arg>, all_t>) {
+                new_shape[out_dim]   = arr.extent(dim);
+                new_strides[out_dim] = arr.get_strides()[dim];
+                ++out_dim;
+            } else if constexpr (std::is_same_v<std::remove_cvref_t<Arg>, range>) {
+                new_shape[out_dim]   = arg.extent();
+                new_strides[out_dim] = arr.get_strides()[dim] * arg.step;
+                base_offset += arg.start * arr.get_strides()[dim];
+                ++out_dim;
+            } else {
+                // Integer index: fix this dimension
+                base_offset += static_cast<std::size_t>(arg) * arr.get_strides()[dim];
+            }
+        };
+        (process_one(args, Is), ...);
+    };
+    process(std::make_index_sequence<N>{});
+
+    return ndarray<Value, M, Order>(
+        arr.data() + base_offset, new_shape, new_strides);
+}
+
+/// Const overload: returns a view over const data.
+template <typename Value, std::size_t N, typename Order, typename... Args>
+    requires (sizeof...(Args) == N)
+auto slice(const ndarray<Value, N, Order>& arr, Args... args) {
+    constexpr std::size_t M = detail_slice::count_kept_dims<Args...>();
+
+    shape<M>                   new_shape;
+    std::array<std::size_t, M> new_strides;
+    std::size_t base_offset = 0;
+
+    auto process = [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+        std::size_t out_dim = 0;
+        auto process_one = [&](auto arg, std::size_t dim) {
+            using Arg = decltype(arg);
+            if constexpr (std::is_same_v<std::remove_cvref_t<Arg>, all_t>) {
+                new_shape[out_dim]   = arr.extent(dim);
+                new_strides[out_dim] = arr.get_strides()[dim];
+                ++out_dim;
+            } else if constexpr (std::is_same_v<std::remove_cvref_t<Arg>, range>) {
+                new_shape[out_dim]   = arg.extent();
+                new_strides[out_dim] = arr.get_strides()[dim] * arg.step;
+                base_offset += arg.start * arr.get_strides()[dim];
+                ++out_dim;
+            } else {
+                base_offset += static_cast<std::size_t>(arg) * arr.get_strides()[dim];
+            }
+        };
+        (process_one(args, Is), ...);
+    };
+    process(std::make_index_sequence<N>{});
+
+    return ndarray<const Value, M, Order>(
+        arr.data() + base_offset, new_shape, new_strides);
+}
+
+} // namespace mtl::array

--- a/include/mtl/concepts/ndarray.hpp
+++ b/include/mtl/concepts/ndarray.hpp
@@ -1,0 +1,25 @@
+#pragma once
+// MTL5 -- NdArray concept for N-dimensional array types
+#include <concepts>
+#include <cstddef>
+
+#include <mtl/concepts/collection.hpp>
+
+namespace mtl {
+
+/// An N-dimensional array with rank, shape, and multi-dimensional element access.
+template <typename T>
+concept NdArray = Collection<T> && requires(const T& a) {
+    { T::rank }       -> std::convertible_to<std::size_t>;
+    { a.get_shape() };
+    { a.get_strides() };
+    { a.data() };
+};
+
+/// A mutable NdArray that allows element modification.
+template <typename T>
+concept MutableNdArray = NdArray<T> && MutableCollection<T> && requires(T& a) {
+    { a.data() };
+};
+
+} // namespace mtl

--- a/include/mtl/mtl.hpp
+++ b/include/mtl/mtl.hpp
@@ -17,6 +17,7 @@
 #include <mtl/concepts/vector.hpp>
 #include <mtl/concepts/linear_operator.hpp>
 #include <mtl/concepts/preconditioner.hpp>
+#include <mtl/concepts/ndarray.hpp>
 
 // Tags
 #include <mtl/tag/orientation.hpp>
@@ -61,6 +62,13 @@
 #include <mtl/mat/shifted_inserter.hpp>
 #include <mtl/vec/unit_vector.hpp>
 #include <mtl/vec/strided_vector_ref.hpp>
+
+// N-dimensional array
+#include <mtl/array/shape.hpp>
+#include <mtl/array/ndarray.hpp>
+#include <mtl/array/slice.hpp>
+#include <mtl/array/broadcast.hpp>
+#include <mtl/array/operations.hpp>
 
 // Scalar functors
 #include <mtl/functor/scalar/plus.hpp>

--- a/include/mtl/mtl_fwd.hpp
+++ b/include/mtl/mtl_fwd.hpp
@@ -60,6 +60,12 @@ namespace math {
     template <typename T> constexpr T one();
 } // namespace math
 
+// -- N-dimensional array -----------------------------------------------------
+namespace array {
+    template <std::size_t N> class shape;
+    template <typename Value, std::size_t N, typename Order> class ndarray;
+} // namespace array
+
 // -- Generators ----------------------------------------------------------
 namespace generators {
     template <typename Value> class hilbert;

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -39,3 +39,6 @@ compile_all("true" "iface" "Tests/interface" "MTL5::mtl5;Catch2::Catch2WithMain"
 
 file(GLOB SPARSE_SRC "sparse/*.cpp")
 compile_all("true" "sparse" "Tests/sparse" "MTL5::mtl5;Catch2::Catch2WithMain" ${SPARSE_SRC})
+
+file(GLOB ARRAY_SRC "array/*.cpp")
+compile_all("true" "array" "Tests/array" "MTL5::mtl5;Catch2::Catch2WithMain" ${ARRAY_SRC})

--- a/tests/unit/array/test_ndarray.cpp
+++ b/tests/unit/array/test_ndarray.cpp
@@ -1,0 +1,404 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <mtl/array/ndarray.hpp>
+#include <mtl/array/shape.hpp>
+#include <mtl/array/slice.hpp>
+#include <mtl/array/broadcast.hpp>
+#include <mtl/array/operations.hpp>
+#include <mtl/concepts/ndarray.hpp>
+#include <mtl/tag/sparsity.hpp>
+#include <mtl/traits/category.hpp>
+
+using namespace mtl;
+using namespace mtl::array;
+
+// ── Shape tests ────────────────────────────────────────────────────
+
+TEST_CASE("shape construction and access", "[array][shape]") {
+    shape<3> sh{4, 5, 6};
+    REQUIRE(sh[0] == 4);
+    REQUIRE(sh[1] == 5);
+    REQUIRE(sh[2] == 6);
+    REQUIRE(sh.total_size() == 120);
+}
+
+TEST_CASE("shape equality", "[array][shape]") {
+    shape<2> a{3, 4};
+    shape<2> b{3, 4};
+    shape<2> c{4, 3};
+    REQUIRE(a == b);
+    REQUIRE(a != c);
+}
+
+// ── Stride tests ───────────────────────────────────────────────────
+
+TEST_CASE("c-order strides", "[array][strides]") {
+    shape<3> sh{2, 3, 4};
+    auto strides = c_order_strides(sh);
+    // Last dim stride=1, middle=4, first=12
+    REQUIRE(strides[0] == 12);
+    REQUIRE(strides[1] == 4);
+    REQUIRE(strides[2] == 1);
+}
+
+TEST_CASE("f-order strides", "[array][strides]") {
+    shape<3> sh{2, 3, 4};
+    auto strides = f_order_strides(sh);
+    // First dim stride=1, middle=2, last=6
+    REQUIRE(strides[0] == 1);
+    REQUIRE(strides[1] == 2);
+    REQUIRE(strides[2] == 6);
+}
+
+// ── Construction tests ─────────────────────────────────────────────
+
+TEST_CASE("ndarray default construction", "[array][ctor]") {
+    ndarray<double, 2> a;
+    REQUIRE(a.size() == 0);
+    REQUIRE(a.empty());
+}
+
+TEST_CASE("ndarray shape construction", "[array][ctor]") {
+    ndarray<double, 3> a(shape<3>{4, 5, 6});
+    REQUIRE(a.size() == 120);
+    REQUIRE(a.extent(0) == 4);
+    REQUIRE(a.extent(1) == 5);
+    REQUIRE(a.extent(2) == 6);
+    REQUIRE(!a.empty());
+}
+
+TEST_CASE("ndarray initializer-list construction", "[array][ctor]") {
+    ndarray<int, 2> a({3, 4});
+    REQUIRE(a.size() == 12);
+    REQUIRE(a.extent(0) == 3);
+    REQUIRE(a.extent(1) == 4);
+}
+
+TEST_CASE("ndarray fill construction", "[array][ctor]") {
+    ndarray<int, 2> a(shape<2>{2, 3}, 42);
+    REQUIRE(a(0, 0) == 42);
+    REQUIRE(a(1, 2) == 42);
+}
+
+// ── Concept satisfaction ───────────────────────────────────────────
+
+TEST_CASE("ndarray satisfies NdArray concept", "[array][concept]") {
+    STATIC_REQUIRE(Collection<ndarray<double, 2>>);
+    STATIC_REQUIRE(MutableCollection<ndarray<double, 2>>);
+    STATIC_REQUIRE(NdArray<ndarray<double, 2>>);
+    STATIC_REQUIRE(MutableNdArray<ndarray<double, 2>>);
+}
+
+TEST_CASE("ndarray has dense category trait", "[array][trait]") {
+    using cat = traits::category_t<ndarray<double, 3>>;
+    STATIC_REQUIRE(std::is_same_v<cat, tag::dense>);
+}
+
+// ── Element access ─────────────────────────────────────────────────
+
+TEST_CASE("ndarray element access via operator()", "[array][access]") {
+    ndarray<int, 2> a({3, 4});
+    a(0, 0) = 1;
+    a(1, 2) = 42;
+    a(2, 3) = 99;
+    REQUIRE(a(0, 0) == 1);
+    REQUIRE(a(1, 2) == 42);
+    REQUIRE(a(2, 3) == 99);
+}
+
+TEST_CASE("ndarray element access via array index", "[array][access]") {
+    ndarray<int, 3> a({2, 3, 4});
+    a[{1, 2, 3}] = 7;
+    REQUIRE(a[{1, 2, 3}] == 7);
+    REQUIRE(a(1, 2, 3) == 7);
+}
+
+TEST_CASE("ndarray C-order memory layout", "[array][layout]") {
+    // In C-order, last index varies fastest
+    ndarray<int, 2> a({2, 3});
+    int counter = 0;
+    for (std::size_t i = 0; i < 2; ++i)
+        for (std::size_t j = 0; j < 3; ++j)
+            a(i, j) = counter++;
+
+    // Flat memory should be 0,1,2,3,4,5
+    for (int k = 0; k < 6; ++k) {
+        REQUIRE(a.flat(k) == k);
+    }
+}
+
+TEST_CASE("ndarray F-order memory layout", "[array][layout]") {
+    // In F-order, first index varies fastest
+    ndarray<int, 2, f_order> a(shape<2>{2, 3});
+    int counter = 0;
+    for (std::size_t j = 0; j < 3; ++j)
+        for (std::size_t i = 0; i < 2; ++i)
+            a(i, j) = counter++;
+
+    // Flat memory should be 0,1,2,3,4,5 (column-major: i varies first)
+    for (int k = 0; k < 6; ++k) {
+        REQUIRE(a.flat(k) == k);
+    }
+}
+
+// ── View tests ─────────────────────────────────────────────────────
+
+TEST_CASE("ndarray view shares memory", "[array][view]") {
+    ndarray<int, 2> a({3, 4}, 0);
+    auto v = a.view();
+    REQUIRE(v.is_view());
+    REQUIRE(!a.is_view());
+    REQUIRE(v.data() == a.data());
+
+    // Mutation through view visible in original
+    v(1, 2) = 99;
+    REQUIRE(a(1, 2) == 99);
+}
+
+TEST_CASE("ndarray external pointer constructor", "[array][view]") {
+    int data[] = {1, 2, 3, 4, 5, 6};
+    ndarray<int, 2> a(data, shape<2>{2, 3});
+    REQUIRE(a.is_view());
+    REQUIRE(a(0, 0) == 1);
+    REQUIRE(a(1, 2) == 6);
+
+    // Modification goes through to original array
+    a(0, 1) = 42;
+    REQUIRE(data[1] == 42);
+}
+
+// ── Reshape and transpose ──────────────────────────────────────────
+
+TEST_CASE("ndarray reshape", "[array][reshape]") {
+    ndarray<int, 2> a({3, 4});
+    for (int i = 0; i < 12; ++i) a.flat(i) = i;
+
+    auto b = a.reshape(shape<1>{12});
+    REQUIRE(b.size() == 12);
+    REQUIRE(b(0) == 0);
+    REQUIRE(b(11) == 11);
+    REQUIRE(b.is_view());
+}
+
+TEST_CASE("ndarray transpose", "[array][transpose]") {
+    ndarray<int, 2> a({2, 3});
+    a(0, 0) = 1; a(0, 1) = 2; a(0, 2) = 3;
+    a(1, 0) = 4; a(1, 1) = 5; a(1, 2) = 6;
+
+    auto t = a.transpose();
+    REQUIRE(t.extent(0) == 3);
+    REQUIRE(t.extent(1) == 2);
+    REQUIRE(t(0, 0) == 1);
+    REQUIRE(t(1, 0) == 2);
+    REQUIRE(t(2, 0) == 3);
+    REQUIRE(t(0, 1) == 4);
+    REQUIRE(t(2, 1) == 6);
+}
+
+// ── Slicing tests ──────────────────────────────────────────────────
+
+TEST_CASE("slice with all keeps full dimension", "[array][slice]") {
+    ndarray<int, 2> a({3, 4}, 0);
+    for (std::size_t i = 0; i < 3; ++i)
+        for (std::size_t j = 0; j < 4; ++j)
+            a(i, j) = static_cast<int>(i * 4 + j);
+
+    auto row = slice(a, 1, all);  // row 1 → 1D view
+    REQUIRE(row.size() == 4);
+    REQUIRE(row(0) == 4);
+    REQUIRE(row(1) == 5);
+    REQUIRE(row(2) == 6);
+    REQUIRE(row(3) == 7);
+}
+
+TEST_CASE("slice with integer reduces rank", "[array][slice]") {
+    ndarray<int, 3> a({2, 3, 4}, 0);
+    a(1, 2, 3) = 42;
+
+    auto s = slice(a, 1, all, all);  // fix first dim → 2D
+    REQUIRE(s.extent(0) == 3);
+    REQUIRE(s.extent(1) == 4);
+    REQUIRE(s(2, 3) == 42);
+}
+
+TEST_CASE("slice with range", "[array][slice]") {
+    ndarray<int, 2> a({4, 6}, 0);
+    for (std::size_t i = 0; i < 4; ++i)
+        for (std::size_t j = 0; j < 6; ++j)
+            a(i, j) = static_cast<int>(i * 6 + j);
+
+    auto s = slice(a, range(1, 3), all);  // rows 1..2
+    REQUIRE(s.extent(0) == 2);
+    REQUIRE(s.extent(1) == 6);
+    REQUIRE(s(0, 0) == 6);   // original row 1
+    REQUIRE(s(1, 0) == 12);  // original row 2
+}
+
+TEST_CASE("slice mutation visible in original", "[array][slice]") {
+    ndarray<int, 2> a({3, 4}, 0);
+    auto row = slice(a, 1, all);
+    row(2) = 99;
+    REQUIRE(a(1, 2) == 99);
+}
+
+// ── Broadcasting tests ─────────────────────────────────────────────
+
+TEST_CASE("broadcast shape computation", "[array][broadcast]") {
+    shape<3> a{4, 1, 6};
+    shape<3> b{1, 5, 6};
+    shape<3> result;
+    REQUIRE(broadcast_shape(a, b, result));
+    REQUIRE(result[0] == 4);
+    REQUIRE(result[1] == 5);
+    REQUIRE(result[2] == 6);
+}
+
+TEST_CASE("broadcast shape incompatible", "[array][broadcast]") {
+    shape<2> a{3, 4};
+    shape<2> b{2, 4};
+    shape<2> result;
+    REQUIRE(!broadcast_shape(a, b, result));
+}
+
+TEST_CASE("element-wise addition same shape", "[array][broadcast]") {
+    ndarray<int, 2> a({2, 3}, 1);
+    ndarray<int, 2> b({2, 3}, 2);
+    ndarray<int, 2> c = a + b;
+    REQUIRE(c(0, 0) == 3);
+    REQUIRE(c(1, 2) == 3);
+}
+
+TEST_CASE("element-wise multiplication with broadcasting", "[array][broadcast]") {
+    // a is (3, 1), b is (1, 4) → result is (3, 4)
+    ndarray<int, 2> a(shape<2>{3, 1});
+    ndarray<int, 2> b(shape<2>{1, 4});
+
+    for (std::size_t i = 0; i < 3; ++i) a(i, 0) = static_cast<int>(i + 1);
+    for (std::size_t j = 0; j < 4; ++j) b(0, j) = static_cast<int>(j + 1);
+
+    ndarray<int, 2> c = a * b;
+    REQUIRE(c.extent(0) == 3);
+    REQUIRE(c.extent(1) == 4);
+    // c(i,j) = (i+1) * (j+1)
+    REQUIRE(c(0, 0) == 1);
+    REQUIRE(c(0, 3) == 4);
+    REQUIRE(c(2, 3) == 12);
+}
+
+// ── Reduction tests ────────────────────────────────────────────────
+
+TEST_CASE("sum all elements", "[array][reduction]") {
+    ndarray<int, 2> a({2, 3}, 5);
+    REQUIRE(sum(a) == 30);
+}
+
+TEST_CASE("prod all elements", "[array][reduction]") {
+    ndarray<int, 1> a(shape<1>{4});
+    a(0) = 1; a(1) = 2; a(2) = 3; a(3) = 4;
+    REQUIRE(prod(a) == 24);
+}
+
+TEST_CASE("min and max", "[array][reduction]") {
+    ndarray<int, 1> a(shape<1>{5});
+    a(0) = 3; a(1) = 1; a(2) = 4; a(3) = 1; a(4) = 5;
+    REQUIRE(min(a) == 1);
+    REQUIRE(max(a) == 5);
+}
+
+TEST_CASE("mean", "[array][reduction]") {
+    ndarray<double, 1> a(shape<1>{4});
+    a(0) = 1.0; a(1) = 2.0; a(2) = 3.0; a(3) = 4.0;
+    REQUIRE(mean(a) == Catch::Approx(2.5));
+}
+
+TEST_CASE("sum along axis", "[array][reduction]") {
+    ndarray<int, 2> a({2, 3});
+    a(0, 0) = 1; a(0, 1) = 2; a(0, 2) = 3;
+    a(1, 0) = 4; a(1, 1) = 5; a(1, 2) = 6;
+
+    // Sum along axis 0 → shape (3,)
+    auto s0 = sum_axis(a, 0);
+    REQUIRE(s0.extent(0) == 3);
+    REQUIRE(s0(0) == 5);   // 1+4
+    REQUIRE(s0(1) == 7);   // 2+5
+    REQUIRE(s0(2) == 9);   // 3+6
+
+    // Sum along axis 1 → shape (2,)
+    auto s1 = sum_axis(a, 1);
+    REQUIRE(s1.extent(0) == 2);
+    REQUIRE(s1(0) == 6);   // 1+2+3
+    REQUIRE(s1(1) == 15);  // 4+5+6
+}
+
+TEST_CASE("mean along axis", "[array][reduction]") {
+    ndarray<double, 2> a({2, 3});
+    a(0, 0) = 1; a(0, 1) = 2; a(0, 2) = 3;
+    a(1, 0) = 4; a(1, 1) = 5; a(1, 2) = 6;
+
+    auto m = mean_axis(a, 0);
+    REQUIRE(m(0) == Catch::Approx(2.5));
+    REQUIRE(m(1) == Catch::Approx(3.5));
+    REQUIRE(m(2) == Catch::Approx(4.5));
+}
+
+// ── Fill and compound assignment ───────────────────────────────────
+
+TEST_CASE("ndarray fill", "[array][fill]") {
+    ndarray<int, 2> a({3, 4});
+    a.fill(7);
+    REQUIRE(a(0, 0) == 7);
+    REQUIRE(a(2, 3) == 7);
+}
+
+TEST_CASE("ndarray compound assignment", "[array][ops]") {
+    ndarray<int, 1> a(shape<1>{3});
+    a(0) = 1; a(1) = 2; a(2) = 3;
+
+    a += 10;
+    REQUIRE(a(0) == 11);
+    REQUIRE(a(2) == 13);
+
+    a *= 2;
+    REQUIRE(a(0) == 22);
+    REQUIRE(a(2) == 26);
+}
+
+// ── 3D array test ──────────────────────────────────────────────────
+
+TEST_CASE("3D ndarray construction and access", "[array][3d]") {
+    ndarray<double, 3> vol({4, 5, 6});
+    REQUIRE(vol.size() == 120);
+    REQUIRE(vol.is_contiguous());
+
+    vol(2, 3, 4) = 3.14;
+    REQUIRE(vol(2, 3, 4) == Catch::Approx(3.14));
+}
+
+// ── Contiguity ─────────────────────────────────────────────────────
+
+TEST_CASE("contiguity check", "[array][contiguous]") {
+    ndarray<int, 2> a({3, 4});
+    REQUIRE(a.is_contiguous());
+
+    // A transpose of a C-order 3x4 is F-order contiguous (4x3 with strides {1, 4})
+    auto t = a.transpose();
+    REQUIRE(t.is_contiguous());  // contiguous in F-order
+
+    // A sliced view with step > 1 is not contiguous
+    ndarray<int, 3> vol({4, 5, 6});
+    auto s = slice(vol, range(0, 4, 2), all, all);  // stride 2 on first dim
+    REQUIRE(!s.is_contiguous());
+}
+
+// ── Copy semantics ─────────────────────────────────────────────────
+
+TEST_CASE("ndarray copy is deep", "[array][copy]") {
+    ndarray<int, 1> a(shape<1>{3});
+    a(0) = 1; a(1) = 2; a(2) = 3;
+
+    ndarray<int, 1> b = a;
+    b(0) = 99;
+    REQUIRE(a(0) == 1);  // original unchanged
+    REQUIRE(b(0) == 99);
+}


### PR DESCRIPTION
## Summary
- Implements `ndarray<T, N, Order>` — the foundational N-dimensional array type for MTL5
- Static rank `N`, runtime shape/strides, owning and non-owning (view) modes
- NumPy-compatible broadcasting, slicing, and reductions

## Changes
- `include/mtl/array/shape.hpp` — `shape<N>`, stride computation (C-order, F-order), broadcasting utilities
- `include/mtl/array/ndarray.hpp` — core class with variadic `operator()`, flat access, fill, reshape, transpose
- `include/mtl/array/slice.hpp` — `all`, `range`, integer indexing returning rank-reduced views
- `include/mtl/array/broadcast.hpp` — lazy expression templates for element-wise `+`, `-`, `*`, `/` with broadcasting
- `include/mtl/array/operations.hpp` — `sum`, `prod`, `min`, `max`, `mean` (full and per-axis)
- `include/mtl/concepts/ndarray.hpp` — `NdArray` and `MutableNdArray` concepts
- `tests/unit/array/test_ndarray.cpp` — 37 test cases, 119 assertions

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| array_test_ndarray | OK | 37/37 PASS | OK | 37/37 PASS |
| full suite (92 tests) | OK | 92/92 PASS | — | — |

## Test plan
- [x] gcc build and test (37/37 pass)
- [x] clang build and test (37/37 pass)
- [x] Full regression suite (92/92 pass)
- [x] Fast CI passes
- [x] Promote to ready when satisfied: `gh pr ready`

Relates to #19

Generated with [Claude Code](https://claude.com/claude-code)