### PR TITLE
feat(operation): add LDL^T (square-root-free Cholesky) decomposition

### DIFF
--- a/include/mtl/mtl.hpp
+++ b/include/mtl/mtl.hpp
@@ -162,6 +162,7 @@
 #include <mtl/operation/qr.hpp>
 #include <mtl/operation/lq.hpp>
 #include <mtl/operation/cholesky.hpp>
+#include <mtl/operation/ldlt.hpp>
 #include <mtl/operation/inv.hpp>
 #include <mtl/operation/hessenberg.hpp>
 #include <mtl/operation/eigenvalue_symmetric.hpp>

--- a/include/mtl/operation/ldlt.hpp
+++ b/include/mtl/operation/ldlt.hpp
@@ -12,6 +12,8 @@
 // Reference: Golub & Van Loan, "Matrix Computations", Section 4.1.2
 
 #include <cassert>
+#include <cstddef>
+#include <stdexcept>
 #include <mtl/concepts/matrix.hpp>
 #include <mtl/concepts/vector.hpp>
 #include <mtl/math/identity.hpp>
@@ -25,8 +27,7 @@ namespace mtl {
 template <Matrix M>
 int ldlt_factor(M& A) {
     using value_type = typename M::value_type;
-    using size_type  = typename M::size_type;
-    const size_type n = A.num_rows();
+    const std::size_t n = A.num_rows();
     assert(A.num_cols() == n);
 
     // Algorithm: column-outer LDL^T (Golub & Van Loan, Algorithm 4.1.2)
@@ -36,10 +37,10 @@ int ldlt_factor(M& A) {
     //   D(j) = A(j,j) - sum_{k<j} L(j,k) * v(k)
     //   L(i,j) = (A(i,j) - sum_{k<j} L(i,k) * v(k)) / D(j)  for i > j
 
-    for (size_type j = 0; j < n; ++j) {
+    for (std::size_t j = 0; j < n; ++j) {
         // Compute D(j) = A(j,j) - sum_{k<j} L(j,k)^2 * D(k)
         auto dj = A(j, j);
-        for (size_type k = 0; k < j; ++k) {
+        for (std::size_t k = 0; k < j; ++k) {
             auto ljk = A(j, k);
             dj -= ljk * ljk * A(k, k);  // A(k,k) holds D(k)
         }
@@ -48,9 +49,9 @@ int ldlt_factor(M& A) {
         A(j, j) = dj;  // Store D(j) on diagonal
 
         // Compute L(i,j) for i > j
-        for (size_type i = j + 1; i < n; ++i) {
+        for (std::size_t i = j + 1; i < n; ++i) {
             auto sum = math::zero<value_type>();
-            for (size_type k = 0; k < j; ++k)
+            for (std::size_t k = 0; k < j; ++k)
                 sum += A(i, k) * A(j, k) * A(k, k);  // L(i,k) * L(j,k) * D(k)
             A(i, j) = (A(i, j) - sum) / dj;
         }
@@ -64,27 +65,29 @@ int ldlt_factor(M& A) {
 template <Matrix M, Vector VecX, Vector VecB>
 void ldlt_solve(const M& A, VecX& x, const VecB& b) {
     using value_type = typename VecX::value_type;
-    using size_type  = typename M::size_type;
-    const size_type n = A.num_rows();
+    const std::size_t n = A.num_rows();
     assert(A.num_cols() == n && x.size() == n && b.size() == n);
 
     // Forward substitution: L*y = b (L has unit diagonal)
-    for (size_type i = 0; i < n; ++i) {
+    for (std::size_t i = 0; i < n; ++i) {
         auto sum = math::zero<value_type>();
-        for (size_type j = 0; j < i; ++j)
+        for (std::size_t j = 0; j < i; ++j)
             sum += A(i, j) * x(j);
         x(i) = b(i) - sum;
     }
 
     // Diagonal solve: D*z = y
-    for (size_type i = 0; i < n; ++i)
+    for (std::size_t i = 0; i < n; ++i) {
+        if (A(i, i) == math::zero<value_type>())
+            throw std::domain_error("ldlt_solve: zero diagonal pivot in D");
         x(i) /= A(i, i);
+    }
 
     // Back substitution: L^T*x = z (L has unit diagonal)
-    for (size_type ii = 0; ii < n; ++ii) {
-        size_type i = n - 1 - ii;
+    for (std::size_t ii = 0; ii < n; ++ii) {
+        std::size_t i = n - 1 - ii;
         auto sum = math::zero<value_type>();
-        for (size_type j = i + 1; j < n; ++j)
+        for (std::size_t j = i + 1; j < n; ++j)
             sum += A(j, i) * x(j);  // L^T(i,j) = L(j,i)
         x(i) = x(i) - sum;
     }

--- a/include/mtl/operation/ldlt.hpp
+++ b/include/mtl/operation/ldlt.hpp
@@ -1,0 +1,93 @@
+#pragma once
+// MTL5 -- LDL^T factorization for symmetric matrices (square-root-free Cholesky)
+// A = L*D*L^T where L is unit lower triangular, D is diagonal.
+// In-place: lower triangle of A is overwritten with L (unit diagonal implicit),
+// diagonal of A is overwritten with D.
+//
+// Key advantages over LL^T Cholesky:
+//   - No square roots — avoids precision loss for ill-conditioned matrices
+//   - Works for symmetric indefinite matrices (D can have negative entries)
+//   - Same O(n^3/3) cost as Cholesky
+//
+// Reference: Golub & Van Loan, "Matrix Computations", Section 4.1.2
+
+#include <cassert>
+#include <mtl/concepts/matrix.hpp>
+#include <mtl/concepts/vector.hpp>
+#include <mtl/math/identity.hpp>
+
+namespace mtl {
+
+/// LDL^T factorization: A = L * D * L^T.
+/// The strictly lower triangle of A is overwritten with L (unit diagonal implicit).
+/// The diagonal of A is overwritten with D.
+/// Returns 0 on success, k+1 if D(k,k) == 0 (zero pivot).
+template <Matrix M>
+int ldlt_factor(M& A) {
+    using value_type = typename M::value_type;
+    using size_type  = typename M::size_type;
+    const size_type n = A.num_rows();
+    assert(A.num_cols() == n);
+
+    // Algorithm: column-outer LDL^T (Golub & Van Loan, Algorithm 4.1.2)
+    //
+    // For j = 0..n-1:
+    //   v(k) = L(j,k) * D(k)  for k = 0..j-1
+    //   D(j) = A(j,j) - sum_{k<j} L(j,k) * v(k)
+    //   L(i,j) = (A(i,j) - sum_{k<j} L(i,k) * v(k)) / D(j)  for i > j
+
+    for (size_type j = 0; j < n; ++j) {
+        // Compute D(j) = A(j,j) - sum_{k<j} L(j,k)^2 * D(k)
+        auto dj = A(j, j);
+        for (size_type k = 0; k < j; ++k) {
+            auto ljk = A(j, k);
+            dj -= ljk * ljk * A(k, k);  // A(k,k) holds D(k)
+        }
+        if (dj == math::zero<value_type>())
+            return static_cast<int>(j + 1);
+        A(j, j) = dj;  // Store D(j) on diagonal
+
+        // Compute L(i,j) for i > j
+        for (size_type i = j + 1; i < n; ++i) {
+            auto sum = math::zero<value_type>();
+            for (size_type k = 0; k < j; ++k)
+                sum += A(i, k) * A(j, k) * A(k, k);  // L(i,k) * L(j,k) * D(k)
+            A(i, j) = (A(i, j) - sum) / dj;
+        }
+    }
+    return 0;
+}
+
+/// Solve A*x = b using precomputed LDL^T factors stored in A.
+/// Lower triangle of A contains L (unit diagonal implicit), diagonal contains D.
+/// Three phases: L*y = b (forward), D*z = y (diagonal), L^T*x = z (backward).
+template <Matrix M, Vector VecX, Vector VecB>
+void ldlt_solve(const M& A, VecX& x, const VecB& b) {
+    using value_type = typename VecX::value_type;
+    using size_type  = typename M::size_type;
+    const size_type n = A.num_rows();
+    assert(A.num_cols() == n && x.size() == n && b.size() == n);
+
+    // Forward substitution: L*y = b (L has unit diagonal)
+    for (size_type i = 0; i < n; ++i) {
+        auto sum = math::zero<value_type>();
+        for (size_type j = 0; j < i; ++j)
+            sum += A(i, j) * x(j);
+        x(i) = b(i) - sum;
+    }
+
+    // Diagonal solve: D*z = y
+    for (size_type i = 0; i < n; ++i)
+        x(i) /= A(i, i);
+
+    // Back substitution: L^T*x = z (L has unit diagonal)
+    for (size_type ii = 0; ii < n; ++ii) {
+        size_type i = n - 1 - ii;
+        auto sum = math::zero<value_type>();
+        for (size_type j = i + 1; j < n; ++j)
+            sum += A(j, i) * x(j);  // L^T(i,j) = L(j,i)
+        x(i) = x(i) - sum;
+    }
+}
+
+} // namespace mtl

--- a/include/mtl/sparse/factorization/sparse_ldlt.hpp
+++ b/include/mtl/sparse/factorization/sparse_ldlt.hpp
@@ -1,0 +1,359 @@
+#pragma once
+// MTL5 -- Sparse LDL^T factorization (square-root-free Cholesky)
+// for symmetric matrices (positive definite or indefinite).
+//
+// A = L * D * L^T where L is unit lower triangular, D is diagonal.
+//
+// The symbolic phase is identical to Cholesky (same elimination tree,
+// same fill-in pattern), so we reuse cholesky_symbolic directly.
+//
+// The numeric phase is the up-looking LDL^T algorithm: same structure
+// as up-looking Cholesky but stores D separately and avoids sqrt.
+//
+// Key advantages over LL^T:
+//   - No square roots — avoids precision loss for ill-conditioned matrices
+//   - Works for symmetric indefinite matrices (D can have negative entries)
+//   - Only fails on zero pivots (D(j) == 0)
+//
+// Reference: Davis, "Direct Methods for Sparse Linear Systems", SIAM, 2006.
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <mtl/mat/compressed2D.hpp>
+#include <mtl/mat/inserter.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/sparse/util/csc.hpp>
+#include <mtl/sparse/util/permutation.hpp>
+#include <mtl/sparse/analysis/elimination_tree.hpp>
+#include <mtl/sparse/analysis/postorder.hpp>
+#include <mtl/sparse/factorization/triangular_solve.hpp>
+#include <mtl/sparse/factorization/sparse_cholesky.hpp>  // for cholesky_symbolic
+
+namespace mtl::sparse::factorization {
+
+/// Symbolic analysis result — identical to Cholesky since sparsity of L
+/// is the same for LDL^T and LL^T.
+using ldlt_symbolic = cholesky_symbolic;
+
+/// Result of numeric LDL^T factorization.
+/// Contains the unit lower triangular factor L in CSC format,
+/// the diagonal D, and the symbolic analysis (for permutation during solve).
+template <typename Value>
+struct ldlt_numeric {
+    util::csc_matrix<Value> L;            // unit lower triangular (CSC)
+    std::vector<Value>      D;            // diagonal entries
+    ldlt_symbolic           symbolic;     // symbolic analysis used
+
+    std::size_t num_rows() const { return symbolic.n; }
+    std::size_t num_cols() const { return symbolic.n; }
+
+    /// Solve A*x = b using the LDL^T factorization.
+    /// A = P^T L D L^T P, so x = P^T L^{-T} D^{-1} L^{-1} P b
+    template <typename VecX, typename VecB>
+    void solve(VecX& x, const VecB& b) const {
+        std::size_t n = symbolic.n;
+        if (static_cast<std::size_t>(x.size()) != n ||
+            static_cast<std::size_t>(b.size()) != n) {
+            throw std::invalid_argument(
+                "ldlt_numeric::solve: vector size mismatch (expected "
+                + std::to_string(n) + ")");
+        }
+
+        // Step 1: Apply permutation: w = P * b
+        std::vector<Value> w(n);
+        for (std::size_t i = 0; i < n; ++i)
+            w[i] = static_cast<Value>(b(symbolic.perm[i]));
+
+        // Step 2: Forward solve: L * y = w  (L is unit lower triangular)
+        dense_unit_lower_solve(L, w);
+
+        // Step 3: Diagonal solve: D * z = y
+        for (std::size_t i = 0; i < n; ++i)
+            w[i] /= D[i];
+
+        // Step 4: Back solve: L^T * u = z  (L^T is unit upper triangular)
+        dense_unit_lower_transpose_solve(L, w);
+
+        // Step 5: Apply inverse permutation: x = P^T * u
+        for (std::size_t i = 0; i < n; ++i)
+            x(symbolic.perm[i]) = static_cast<typename VecX::value_type>(w[i]);
+    }
+};
+
+/// Perform symbolic LDL^T analysis on a symmetric sparse matrix.
+/// Delegates to sparse_cholesky_symbolic since the sparsity structure is identical.
+template <typename Value, typename Parameters, typename Ordering>
+ldlt_symbolic sparse_ldlt_symbolic(
+    const mat::compressed2D<Value, Parameters>& A,
+    const Ordering& ordering)
+{
+    return sparse_cholesky_symbolic(A, ordering);
+}
+
+/// Overload without ordering: uses identity permutation (natural ordering).
+template <typename Value, typename Parameters>
+ldlt_symbolic sparse_ldlt_symbolic(
+    const mat::compressed2D<Value, Parameters>& A)
+{
+    return sparse_cholesky_symbolic(A);
+}
+
+/// Perform numeric LDL^T factorization using pre-computed symbolic analysis.
+///
+/// Up-looking (left-looking) LDL^T: for each column j, compute L(:,j)
+/// and D(j) by subtracting contributions from previously factored columns.
+/// Identical to Cholesky but replaces L(j,j) = sqrt(c(j)) with D(j) = c(j)
+/// and L(i,j) = c(i)/D(j).
+///
+/// \param A    Symmetric sparse matrix in CRS format
+/// \param sym  Symbolic analysis from sparse_ldlt_symbolic()
+/// \return     Numeric factorization result containing L (unit lower) and D
+///
+/// \throws std::runtime_error if a zero pivot is encountered (D(j) == 0)
+template <typename Value, typename Parameters>
+ldlt_numeric<Value> sparse_ldlt_numeric(
+    const mat::compressed2D<Value, Parameters>& A,
+    const ldlt_symbolic& sym)
+{
+    using size_type = std::size_t;
+    size_type n = sym.n;
+    if (A.num_rows() != n || A.num_cols() != n) {
+        throw std::invalid_argument(
+            "sparse_ldlt_numeric: matrix dimensions ("
+            + std::to_string(A.num_rows()) + "x" + std::to_string(A.num_cols())
+            + ") do not match symbolic analysis (n=" + std::to_string(n) + ")");
+    }
+
+    // Apply symmetric permutation and convert to CSC
+    auto PA = util::symmetric_permute(A, sym.perm);
+    auto C = util::crs_to_csc(PA);
+
+    // Allocate L in CSC format using predicted column counts.
+    // For LDL^T, L is unit lower triangular so we don't store the diagonal in L.
+    // However, col_counts from the symbolic phase include the diagonal.
+    // We allocate with col_counts (which includes diagonal) and store a 1.0
+    // placeholder on the diagonal to keep the CSC structure consistent with
+    // the existing triangular solve infrastructure.
+    util::csc_matrix<Value> L;
+    L.nrows = n;
+    L.ncols = n;
+    L.col_ptr.resize(n + 1);
+    L.col_ptr[0] = 0;
+    for (size_type j = 0; j < n; ++j)
+        L.col_ptr[j + 1] = L.col_ptr[j] + sym.col_counts[j];
+
+    size_type nnz_L = L.col_ptr[n];
+    L.row_ind.resize(nnz_L);
+    L.values.resize(nnz_L);
+
+    // Diagonal vector
+    std::vector<Value> D(n, Value{0});
+
+    // Working arrays
+    std::vector<Value> x(n, Value{0});    // dense workspace for column assembly
+    std::vector<size_type> nz(n, 0);      // next free slot in each column of L
+
+    // Up-looking LDL^T: process columns in order 0..n-1
+    for (size_type j = 0; j < n; ++j) {
+        // Scatter column j of C into dense workspace x
+        // Only the lower triangular part (rows >= j)
+        for (size_type p = C.col_ptr[j]; p < C.col_ptr[j + 1]; ++p) {
+            size_type i = C.row_ind[p];
+            if (i >= j) {
+                x[i] = C.values[p];
+            }
+        }
+
+        // Collect the set of columns k < j that affect column j
+        // by walking the etree from each row index i < j in column j of C
+        std::vector<size_type> affecting_cols;
+        for (size_type p = C.col_ptr[j]; p < C.col_ptr[j + 1]; ++p) {
+            size_type i = C.row_ind[p];
+            if (i >= j) continue;
+            size_type node = i;
+            while (node != analysis::no_parent && node < j) {
+                affecting_cols.push_back(node);
+                node = sym.parent[node];
+            }
+        }
+
+        // Remove duplicates and sort
+        std::sort(affecting_cols.begin(), affecting_cols.end());
+        affecting_cols.erase(
+            std::unique(affecting_cols.begin(), affecting_cols.end()),
+            affecting_cols.end());
+
+        // For each affecting column k, subtract L(j,k) * D(k) * L(:,k) from x
+        for (size_type col_k : affecting_cols) {
+            // Find L(j, col_k): search column col_k of L for row j
+            Value ljk = Value{0};
+            size_type col_start = L.col_ptr[col_k];
+            size_type col_end = L.col_ptr[col_k] + nz[col_k];
+            for (size_type p = col_start; p < col_end; ++p) {
+                if (L.row_ind[p] == j) {
+                    ljk = L.values[p];
+                    break;
+                }
+            }
+
+            if (ljk == Value{0}) continue;
+
+            Value ljk_dk = ljk * D[col_k];
+
+            // Subtract ljk * D(k) * L(i, col_k) from x(i) for i >= j
+            // For row j: x[j] -= ljk * D(k) * ljk = ljk^2 * D(k)
+            x[j] -= ljk_dk * ljk;
+
+            // For rows i > j: x[i] -= ljk * D(k) * L(i, col_k)
+            for (size_type p = col_start; p < col_end; ++p) {
+                size_type i = L.row_ind[p];
+                if (i > j) {
+                    x[i] -= ljk_dk * L.values[p];
+                }
+            }
+        }
+
+        // D(j) = x[j] (the accumulated diagonal value)
+        Value dj = x[j];
+        if (dj == Value{0}) {
+            throw std::runtime_error(
+                "sparse_ldlt_numeric: zero pivot at column " + std::to_string(j));
+        }
+        D[j] = dj;
+
+        // Guarded write into column j of L
+        size_type col_capacity = sym.col_counts[j];
+        auto push_entry = [&](size_type row, Value val) {
+            if (nz[j] >= col_capacity) {
+                throw std::runtime_error(
+                    "sparse_ldlt_numeric: column count underestimated at column "
+                    + std::to_string(j));
+            }
+            size_type pos = L.col_ptr[j] + nz[j];
+            L.row_ind[pos] = row;
+            L.values[pos] = val;
+            ++nz[j];
+        };
+
+        // Store diagonal as 1.0 (unit lower triangular)
+        push_entry(j, Value{1});
+
+        // Store off-diagonal entries L(i,j) = x[i] / D(j) for i > j
+        for (size_type p = C.col_ptr[j]; p < C.col_ptr[j + 1]; ++p) {
+            size_type i = C.row_ind[p];
+            if (i > j && x[i] != Value{0}) {
+                push_entry(i, x[i] / dj);
+            }
+        }
+
+        // Also store fill-in entries: rows where x[i] != 0 but not in C(:,j)
+        for (size_type col_k : affecting_cols) {
+            size_type col_start = L.col_ptr[col_k];
+            size_type col_end = L.col_ptr[col_k] + nz[col_k];
+            for (size_type p = col_start; p < col_end; ++p) {
+                size_type i = L.row_ind[p];
+                if (i > j && x[i] != Value{0}) {
+                    bool already = false;
+                    for (size_type q = L.col_ptr[j]; q < L.col_ptr[j] + nz[j]; ++q) {
+                        if (L.row_ind[q] == i) { already = true; break; }
+                    }
+                    if (!already) {
+                        push_entry(i, x[i] / dj);
+                    }
+                }
+            }
+        }
+
+        // Clear workspace for rows we touched
+        for (size_type p = C.col_ptr[j]; p < C.col_ptr[j + 1]; ++p)
+            x[C.row_ind[p]] = Value{0};
+        for (size_type col_k : affecting_cols) {
+            size_type col_start = L.col_ptr[col_k];
+            size_type col_end = L.col_ptr[col_k] + nz[col_k];
+            for (size_type p = col_start; p < col_end; ++p)
+                x[L.row_ind[p]] = Value{0};
+        }
+        x[j] = Value{0};
+
+        // Sort row indices within this column for consistent ordering
+        size_type col_begin = L.col_ptr[j];
+        size_type col_actual_end = L.col_ptr[j] + nz[j];
+
+        // Insertion sort (columns are typically small)
+        for (size_type a = col_begin + 1; a < col_actual_end; ++a) {
+            size_type key_idx = L.row_ind[a];
+            Value key_val = L.values[a];
+            size_type b = a;
+            while (b > col_begin && L.row_ind[b - 1] > key_idx) {
+                L.row_ind[b] = L.row_ind[b - 1];
+                L.values[b] = L.values[b - 1];
+                --b;
+            }
+            L.row_ind[b] = key_idx;
+            L.values[b] = key_val;
+        }
+    }
+
+    // Trim L to actual nnz
+    size_type actual_nnz = 0;
+    for (size_type j = 0; j < n; ++j)
+        actual_nnz += nz[j];
+
+    if (actual_nnz < nnz_L) {
+        util::csc_matrix<Value> L_compact;
+        L_compact.nrows = n;
+        L_compact.ncols = n;
+        L_compact.col_ptr.resize(n + 1);
+        L_compact.row_ind.resize(actual_nnz);
+        L_compact.values.resize(actual_nnz);
+
+        L_compact.col_ptr[0] = 0;
+        size_type pos = 0;
+        for (size_type j = 0; j < n; ++j) {
+            for (size_type k = 0; k < nz[j]; ++k) {
+                L_compact.row_ind[pos] = L.row_ind[L.col_ptr[j] + k];
+                L_compact.values[pos] = L.values[L.col_ptr[j] + k];
+                ++pos;
+            }
+            L_compact.col_ptr[j + 1] = pos;
+        }
+        L = std::move(L_compact);
+    }
+
+    ldlt_numeric<Value> result;
+    result.L = std::move(L);
+    result.D = std::move(D);
+    result.symbolic = sym;
+    return result;
+}
+
+/// One-shot sparse LDL^T solve: factor and solve A*x = b.
+template <typename Value, typename Parameters, typename VecX, typename VecB,
+          typename Ordering>
+void sparse_ldlt_solve(
+    const mat::compressed2D<Value, Parameters>& A,
+    VecX& x, const VecB& b,
+    const Ordering& ordering)
+{
+    auto sym = sparse_ldlt_symbolic(A, ordering);
+    auto num = sparse_ldlt_numeric(A, sym);
+    num.solve(x, b);
+}
+
+/// One-shot sparse LDL^T solve without ordering (natural ordering).
+template <typename Value, typename Parameters, typename VecX, typename VecB>
+void sparse_ldlt_solve(
+    const mat::compressed2D<Value, Parameters>& A,
+    VecX& x, const VecB& b)
+{
+    auto sym = sparse_ldlt_symbolic(A);
+    auto num = sparse_ldlt_numeric(A, sym);
+    num.solve(x, b);
+}
+
+} // namespace mtl::sparse::factorization

--- a/include/mtl/sparse/factorization/sparse_ldlt.hpp
+++ b/include/mtl/sparse/factorization/sparse_ldlt.hpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <limits>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -105,14 +106,17 @@ ldlt_symbolic sparse_ldlt_symbolic(
 
 /// Perform numeric LDL^T factorization using pre-computed symbolic analysis.
 ///
-/// Up-looking (left-looking) LDL^T: for each column j, compute L(:,j)
-/// and D(j) by subtracting contributions from previously factored columns.
-/// Identical to Cholesky but replaces L(j,j) = sqrt(c(j)) with D(j) = c(j)
-/// and L(i,j) = c(i)/D(j).
+/// Up-looking (left-looking) LDL^T using marker-based reach and single-pass
+/// scatter for O(nnz(L)) work. For each column j:
+///   1. Scatter lower-triangular entries of permuted A(:,j) into workspace
+///   2. Compute reach of j in the etree using markers (no sort/unique needed)
+///   3. For each reached column k, scatter L(j,k)*D(k)*L(:,k) in one pass
+///   4. Store D(j) and L(j+1:n, j) = x/D(j)
 ///
 /// \param A    Symmetric sparse matrix in CRS format
 /// \param sym  Symbolic analysis from sparse_ldlt_symbolic()
-/// \return     Numeric factorization result containing L (unit lower) and D
+/// \return     Numeric factorization result containing L (unit lower, no
+///             diagonal stored) and D
 ///
 /// \throws std::runtime_error if a zero pivot is encountered (D(j) == 0)
 template <typename Value, typename Parameters>
@@ -133,19 +137,17 @@ ldlt_numeric<Value> sparse_ldlt_numeric(
     auto PA = util::symmetric_permute(A, sym.perm);
     auto C = util::crs_to_csc(PA);
 
-    // Allocate L in CSC format using predicted column counts.
-    // For LDL^T, L is unit lower triangular so we don't store the diagonal in L.
-    // However, col_counts from the symbolic phase include the diagonal.
-    // We allocate with col_counts (which includes diagonal) and store a 1.0
-    // placeholder on the diagonal to keep the CSC structure consistent with
-    // the existing triangular solve infrastructure.
+    // Allocate L in CSC format. col_counts includes the diagonal, but we
+    // don't store the unit diagonal — allocate col_counts[j]-1 per column.
     util::csc_matrix<Value> L;
     L.nrows = n;
     L.ncols = n;
     L.col_ptr.resize(n + 1);
     L.col_ptr[0] = 0;
-    for (size_type j = 0; j < n; ++j)
-        L.col_ptr[j + 1] = L.col_ptr[j] + sym.col_counts[j];
+    for (size_type j = 0; j < n; ++j) {
+        size_type off_diag = (sym.col_counts[j] > 0) ? sym.col_counts[j] - 1 : 0;
+        L.col_ptr[j + 1] = L.col_ptr[j] + off_diag;
+    }
 
     size_type nnz_L = L.col_ptr[n];
     L.row_ind.resize(nnz_L);
@@ -155,66 +157,77 @@ ldlt_numeric<Value> sparse_ldlt_numeric(
     std::vector<Value> D(n, Value{0});
 
     // Working arrays
-    std::vector<Value> x(n, Value{0});    // dense workspace for column assembly
-    std::vector<size_type> nz(n, 0);      // next free slot in each column of L
+    std::vector<Value> x(n, Value{0});      // dense workspace for column assembly
+    std::vector<size_type> nz(n, 0);        // next free slot in each column of L
+
+    // Reach workspace: marker-based etree walk (avoids sort/unique per column)
+    constexpr size_type unmarked = std::numeric_limits<size_type>::max();
+    std::vector<size_type> mark(n, unmarked);  // mark[k] = j if col k is in reach of j
+    std::vector<size_type> reach_stack(n);     // stack for reach computation
+    std::vector<size_type> reach_list;         // accumulated reach in topological order
+    reach_list.reserve(n);
 
     // Up-looking LDL^T: process columns in order 0..n-1
     for (size_type j = 0; j < n; ++j) {
-        // Scatter column j of C into dense workspace x
-        // Only the lower triangular part (rows >= j)
+        // Scatter column j of C into dense workspace x (lower triangle only)
         for (size_type p = C.col_ptr[j]; p < C.col_ptr[j + 1]; ++p) {
             size_type i = C.row_ind[p];
-            if (i >= j) {
+            if (i >= j)
                 x[i] = C.values[p];
-            }
         }
 
-        // Collect the set of columns k < j that affect column j
-        // by walking the etree from each row index i < j in column j of C
-        std::vector<size_type> affecting_cols;
+        // Compute reach: walk etree from each row i < j in C(:,j),
+        // marking nodes and collecting in topological (ascending) order.
+        reach_list.clear();
         for (size_type p = C.col_ptr[j]; p < C.col_ptr[j + 1]; ++p) {
             size_type i = C.row_ind[p];
             if (i >= j) continue;
+
+            // Walk from i up the etree, pushing unmarked nodes onto stack
+            size_type stack_top = 0;
             size_type node = i;
-            while (node != analysis::no_parent && node < j) {
-                affecting_cols.push_back(node);
+            while (node != analysis::no_parent && node < j && mark[node] != j) {
+                reach_stack[stack_top++] = node;
+                mark[node] = j;
                 node = sym.parent[node];
             }
+            // Pop stack in reverse to get topological (ascending) order
+            while (stack_top > 0)
+                reach_list.push_back(reach_stack[--stack_top]);
         }
 
-        // Remove duplicates and sort
-        std::sort(affecting_cols.begin(), affecting_cols.end());
-        affecting_cols.erase(
-            std::unique(affecting_cols.begin(), affecting_cols.end()),
-            affecting_cols.end());
+        // Sort reach_list ascending so we process columns in order
+        std::sort(reach_list.begin(), reach_list.end());
 
-        // For each affecting column k, subtract L(j,k) * D(k) * L(:,k) from x
-        for (size_type col_k : affecting_cols) {
-            // Find L(j, col_k): search column col_k of L for row j
-            Value ljk = Value{0};
+        // For each reached column k, single-pass scatter:
+        // find L(j,k) on the fly, then subtract L(j,k)*D(k)*L(:,k) from x
+        for (size_type col_k : reach_list) {
             size_type col_start = L.col_ptr[col_k];
             size_type col_end = L.col_ptr[col_k] + nz[col_k];
+
+            // Find L(j, col_k) in column col_k of L
+            // Since rows are sorted ascending and all > col_k, we can scan
+            Value ljk = Value{0};
             for (size_type p = col_start; p < col_end; ++p) {
                 if (L.row_ind[p] == j) {
                     ljk = L.values[p];
                     break;
                 }
+                if (L.row_ind[p] > j) break;  // sorted — won't find it
             }
 
             if (ljk == Value{0}) continue;
 
             Value ljk_dk = ljk * D[col_k];
 
-            // Subtract ljk * D(k) * L(i, col_k) from x(i) for i >= j
-            // For row j: x[j] -= ljk * D(k) * ljk = ljk^2 * D(k)
+            // Subtract from diagonal: x[j] -= ljk^2 * D(k)
             x[j] -= ljk_dk * ljk;
 
-            // For rows i > j: x[i] -= ljk * D(k) * L(i, col_k)
+            // Subtract from off-diagonals: x[i] -= ljk*D(k)*L(i,k) for i > j
             for (size_type p = col_start; p < col_end; ++p) {
                 size_type i = L.row_ind[p];
-                if (i > j) {
+                if (i > j)
                     x[i] -= ljk_dk * L.values[p];
-                }
             }
         }
 
@@ -226,8 +239,8 @@ ldlt_numeric<Value> sparse_ldlt_numeric(
         }
         D[j] = dj;
 
-        // Guarded write into column j of L
-        size_type col_capacity = sym.col_counts[j];
+        // Guarded write into column j of L (off-diagonal entries only)
+        size_type col_capacity = (sym.col_counts[j] > 0) ? sym.col_counts[j] - 1 : 0;
         auto push_entry = [&](size_type row, Value val) {
             if (nz[j] >= col_capacity) {
                 throw std::runtime_error(
@@ -240,31 +253,31 @@ ldlt_numeric<Value> sparse_ldlt_numeric(
             ++nz[j];
         };
 
-        // Store diagonal as 1.0 (unit lower triangular)
-        push_entry(j, Value{1});
-
-        // Store off-diagonal entries L(i,j) = x[i] / D(j) for i > j
+        // Collect all rows i > j where x[i] != 0 (original entries + fill-in)
+        // We use a marker to track which rows have been emitted
+        // First: rows from original matrix C(:,j)
         for (size_type p = C.col_ptr[j]; p < C.col_ptr[j + 1]; ++p) {
             size_type i = C.row_ind[p];
-            if (i > j && x[i] != Value{0}) {
+            if (i > j && x[i] != Value{0})
                 push_entry(i, x[i] / dj);
-            }
         }
 
-        // Also store fill-in entries: rows where x[i] != 0 but not in C(:,j)
-        for (size_type col_k : affecting_cols) {
+        // Fill-in entries: rows touched by L(:,k) scatter but not in C(:,j)
+        // Use a simple flag based on whether x[i] is still nonzero after
+        // subtracting entries we already stored
+        for (size_type col_k : reach_list) {
             size_type col_start = L.col_ptr[col_k];
             size_type col_end = L.col_ptr[col_k] + nz[col_k];
             for (size_type p = col_start; p < col_end; ++p) {
                 size_type i = L.row_ind[p];
                 if (i > j && x[i] != Value{0}) {
+                    // Check if already stored
                     bool already = false;
                     for (size_type q = L.col_ptr[j]; q < L.col_ptr[j] + nz[j]; ++q) {
                         if (L.row_ind[q] == i) { already = true; break; }
                     }
-                    if (!already) {
+                    if (!already)
                         push_entry(i, x[i] / dj);
-                    }
                 }
             }
         }
@@ -272,7 +285,7 @@ ldlt_numeric<Value> sparse_ldlt_numeric(
         // Clear workspace for rows we touched
         for (size_type p = C.col_ptr[j]; p < C.col_ptr[j + 1]; ++p)
             x[C.row_ind[p]] = Value{0};
-        for (size_type col_k : affecting_cols) {
+        for (size_type col_k : reach_list) {
             size_type col_start = L.col_ptr[col_k];
             size_type col_end = L.col_ptr[col_k] + nz[col_k];
             for (size_type p = col_start; p < col_end; ++p)

--- a/include/mtl/sparse/factorization/sparse_ldlt.hpp
+++ b/include/mtl/sparse/factorization/sparse_ldlt.hpp
@@ -162,9 +162,10 @@ ldlt_numeric<Value> sparse_ldlt_numeric(
 
     // Reach workspace: marker-based etree walk (avoids sort/unique per column)
     constexpr size_type unmarked = std::numeric_limits<size_type>::max();
-    std::vector<size_type> mark(n, unmarked);  // mark[k] = j if col k is in reach of j
-    std::vector<size_type> reach_stack(n);     // stack for reach computation
-    std::vector<size_type> reach_list;         // accumulated reach in topological order
+    std::vector<size_type> mark(n, unmarked);    // mark[k] = j if col k is in reach of j
+    std::vector<size_type> emitted(n, unmarked); // emitted[i] = j if row i already stored in L(:,j)
+    std::vector<size_type> reach_stack(n);       // stack for reach computation
+    std::vector<size_type> reach_list;           // accumulated reach in topological order
     reach_list.reserve(n);
 
     // Up-looking LDL^T: process columns in order 0..n-1
@@ -253,31 +254,26 @@ ldlt_numeric<Value> sparse_ldlt_numeric(
             ++nz[j];
         };
 
-        // Collect all rows i > j where x[i] != 0 (original entries + fill-in)
-        // We use a marker to track which rows have been emitted
+        // Collect all rows i > j where x[i] != 0 (original entries + fill-in).
+        // Use emitted[i] == j as epoch marker to avoid quadratic dedupe scans.
         // First: rows from original matrix C(:,j)
         for (size_type p = C.col_ptr[j]; p < C.col_ptr[j + 1]; ++p) {
             size_type i = C.row_ind[p];
-            if (i > j && x[i] != Value{0})
+            if (i > j && x[i] != Value{0}) {
                 push_entry(i, x[i] / dj);
+                emitted[i] = j;
+            }
         }
 
         // Fill-in entries: rows touched by L(:,k) scatter but not in C(:,j)
-        // Use a simple flag based on whether x[i] is still nonzero after
-        // subtracting entries we already stored
         for (size_type col_k : reach_list) {
             size_type col_start = L.col_ptr[col_k];
             size_type col_end = L.col_ptr[col_k] + nz[col_k];
             for (size_type p = col_start; p < col_end; ++p) {
                 size_type i = L.row_ind[p];
-                if (i > j && x[i] != Value{0}) {
-                    // Check if already stored
-                    bool already = false;
-                    for (size_type q = L.col_ptr[j]; q < L.col_ptr[j] + nz[j]; ++q) {
-                        if (L.row_ind[q] == i) { already = true; break; }
-                    }
-                    if (!already)
-                        push_entry(i, x[i] / dj);
+                if (i > j && x[i] != Value{0} && emitted[i] != j) {
+                    push_entry(i, x[i] / dj);
+                    emitted[i] = j;
                 }
             }
         }

--- a/include/mtl/sparse/factorization/triangular_solve.hpp
+++ b/include/mtl/sparse/factorization/triangular_solve.hpp
@@ -217,4 +217,48 @@ void dense_lower_transpose_solve(
     }
 }
 
+/// Dense unit lower triangular solve: solve Lx = b where L is unit lower
+/// triangular in CSC format (diagonal entries in L are ignored; assumed 1).
+/// b is overwritten with the solution x.
+template <typename Value, typename SizeType>
+void dense_unit_lower_solve(
+    const util::csc_matrix<Value, SizeType>& L,
+    std::vector<Value>& x)
+{
+    SizeType n = L.ncols;
+
+    for (SizeType j = 0; j < n; ++j) {
+        // Skip diagonal entry (implicit 1), scatter off-diagonal entries
+        for (SizeType p = L.col_ptr[j]; p < L.col_ptr[j + 1]; ++p) {
+            SizeType i = L.row_ind[p];
+            if (i > j) {
+                x[i] -= L.values[p] * x[j];
+            }
+        }
+    }
+}
+
+/// Dense unit lower triangular transpose solve: solve L^T x = b where L is
+/// unit lower triangular in CSC (diagonal entries ignored; assumed 1).
+/// Processes columns in reverse order. b is overwritten with x.
+template <typename Value, typename SizeType>
+void dense_unit_lower_transpose_solve(
+    const util::csc_matrix<Value, SizeType>& L,
+    std::vector<Value>& x)
+{
+    SizeType n = L.ncols;
+
+    for (SizeType j = n; j > 0; --j) {
+        SizeType col = j - 1;
+        // Gather: subtract contributions from off-diagonal entries below diagonal
+        for (SizeType p = L.col_ptr[col]; p < L.col_ptr[col + 1]; ++p) {
+            SizeType i = L.row_ind[p];
+            if (i > col) {
+                x[col] -= L.values[p] * x[i];
+            }
+        }
+        // No diagonal division (unit diagonal)
+    }
+}
+
 } // namespace mtl::sparse::factorization

--- a/include/mtl/sparse/sparse.hpp
+++ b/include/mtl/sparse/sparse.hpp
@@ -16,6 +16,7 @@
 // Factorization infrastructure
 #include <mtl/sparse/factorization/triangular_solve.hpp>
 #include <mtl/sparse/factorization/sparse_cholesky.hpp>
+#include <mtl/sparse/factorization/sparse_ldlt.hpp>
 #include <mtl/sparse/factorization/sparse_qr.hpp>
 #include <mtl/sparse/factorization/sparse_lu.hpp>
 

--- a/tests/regression/dense/test_ldlt.cpp
+++ b/tests/regression/dense/test_ldlt.cpp
@@ -1,0 +1,117 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
+#include <cmath>
+#include <cstddef>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/operation/ldlt.hpp>
+#include <mtl/operation/operators.hpp>
+#include <mtl/operation/norms.hpp>
+#include <mtl/generators/randspd.hpp>
+#include <mtl/generators/lehmer.hpp>
+#include <mtl/generators/moler.hpp>
+#include <mtl/generators/minij.hpp>
+
+using namespace mtl;
+
+namespace {
+
+template <typename Gen>
+mat::dense2D<typename Gen::value_type> materialize(const Gen& g) {
+    using V = typename Gen::value_type;
+    auto n = g.num_rows(), m = g.num_cols();
+    mat::dense2D<V> A(n, m);
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < m; ++j)
+            A(i, j) = g(i, j);
+    return A;
+}
+
+mat::dense2D<double> copy_matrix(const mat::dense2D<double>& A) {
+    auto n = A.num_rows(), m = A.num_cols();
+    mat::dense2D<double> B(n, m);
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < m; ++j)
+            B(i, j) = A(i, j);
+    return B;
+}
+
+double ldlt_solve_report(const char* matrix_name, int n,
+                         const mat::dense2D<double>& A,
+                         const vec::dense_vector<double>& b,
+                         double tol) {
+    auto LDLt = copy_matrix(A);
+    int info = ldlt_factor(LDLt);
+    REQUIRE(info == 0);
+
+    vec::dense_vector<double> x(A.num_rows());
+    ldlt_solve(LDLt, x, b);
+
+    auto r = A * x;
+    double res_norm = 0.0;
+    for (std::size_t i = 0; i < A.num_rows(); ++i) {
+        double d = r(i) - b(i);
+        res_norm += d * d;
+    }
+    res_norm = std::sqrt(res_norm);
+    double A_norm = frobenius_norm(A);
+    double x_norm = two_norm(x);
+    double be = (A_norm * x_norm > 0.0) ? res_norm / (A_norm * x_norm) : res_norm;
+
+    std::cout << std::left << std::setw(12) << matrix_name
+              << "  n=" << std::setw(6) << n
+              << "  backward_err=" << std::scientific << std::setprecision(3) << be
+              << "  tol=" << tol
+              << (be < tol ? "  PASS" : "  FAIL")
+              << std::defaultfloat << std::endl;
+    return be;
+}
+
+} // anonymous namespace
+
+TEST_CASE("LDL^T regression: randspd (kappa=100)", "[regression][dense][ldlt]") {
+    auto n = GENERATE(100, 500, 1000);
+    auto A = generators::randspd<double>(static_cast<std::size_t>(n), 100.0);
+    vec::dense_vector<double> x_exact(n, 1.0);
+    auto b = A * x_exact;
+    double tol = double(n) * std::numeric_limits<double>::epsilon();
+    double be = ldlt_solve_report("randspd", n, A, b, tol);
+    REQUIRE(be < tol);
+}
+
+TEST_CASE("LDL^T regression: Lehmer matrix", "[regression][dense][ldlt]") {
+    auto n = GENERATE(100, 500, 1000);
+    auto A = materialize(generators::lehmer<double>(n));
+    vec::dense_vector<double> x_exact(n, 1.0);
+    auto b = A * x_exact;
+    double tol = double(n) * std::numeric_limits<double>::epsilon();
+    double be = ldlt_solve_report("Lehmer", n, A, b, tol);
+    REQUIRE(be < tol);
+}
+
+TEST_CASE("LDL^T regression: Moler matrix", "[regression][dense][ldlt]") {
+    auto n = GENERATE(100, 500);
+    auto A = generators::moler<double>(n);
+    vec::dense_vector<double> x_exact(n, 1.0);
+    auto b = A * x_exact;
+    double tol = double(n) * 1000.0 * std::numeric_limits<double>::epsilon();
+    double be = ldlt_solve_report("Moler", n, A, b, tol);
+    REQUIRE(be < tol);
+}
+
+TEST_CASE("LDL^T regression: Minij matrix (SPD)", "[regression][dense][ldlt]") {
+    auto n = GENERATE(100, 500, 1000);
+    auto A = materialize(generators::minij<double>(n));
+    vec::dense_vector<double> x_exact(n, 1.0);
+    auto b = A * x_exact;
+    double tol = double(n) * std::numeric_limits<double>::epsilon();
+    double be = ldlt_solve_report("Minij", n, A, b, tol);
+    REQUIRE(be < tol);
+}

--- a/tests/regression/sparse/test_sparse_ldlt.cpp
+++ b/tests/regression/sparse/test_sparse_ldlt.cpp
@@ -1,0 +1,101 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
+#include <cmath>
+#include <cstddef>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+
+#include <mtl/mat/compressed2D.hpp>
+#include <mtl/mat/inserter.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/sparse/factorization/sparse_ldlt.hpp>
+#include <mtl/sparse/ordering/rcm.hpp>
+#include <mtl/sparse/ordering/amd.hpp>
+#include <mtl/generators/laplacian.hpp>
+#include <mtl/generators/poisson.hpp>
+
+using namespace mtl;
+using namespace mtl::sparse;
+
+namespace {
+
+/// SpMV residual: ||Ax - b|| / ||b||
+double relative_residual(const mat::compressed2D<double>& A,
+                         const vec::dense_vector<double>& x,
+                         const vec::dense_vector<double>& b) {
+    std::size_t n = b.size();
+    const auto& starts = A.ref_major();
+    const auto& indices = A.ref_minor();
+    const auto& data = A.ref_data();
+    double res_norm = 0.0, b_norm = 0.0;
+    for (std::size_t i = 0; i < n; ++i) {
+        double Ax_i = 0.0;
+        for (std::size_t k = starts[i]; k < starts[i + 1]; ++k)
+            Ax_i += data[k] * x(indices[k]);
+        double ri = Ax_i - b(i);
+        res_norm += ri * ri;
+        b_norm += b(i) * b(i);
+    }
+    if (b_norm == 0.0) return std::sqrt(res_norm);
+    return std::sqrt(res_norm / b_norm);
+}
+
+void report(const char* matrix, const char* ordering, std::size_t n,
+            std::size_t nnz, double rr, double tol) {
+    std::cout << std::left << std::setw(14) << matrix
+              << std::setw(6) << ordering
+              << "  n=" << std::setw(7) << n
+              << "  nnz=" << std::setw(8) << nnz
+              << "  residual=" << std::scientific << std::setprecision(3) << rr
+              << "  tol=" << tol
+              << (rr < tol ? "  PASS" : "  FAIL")
+              << std::defaultfloat << std::endl;
+}
+
+} // anonymous namespace
+
+TEST_CASE("Sparse LDL^T regression: 1D Laplacian", "[regression][sparse][ldlt]") {
+    auto n = GENERATE(1000, 5000, 10000, 50000);
+
+    auto A = generators::laplacian_1d<double>(n);
+    vec::dense_vector<double> b(n, 1.0);
+    vec::dense_vector<double> x(n, 0.0);
+
+    factorization::sparse_ldlt_solve(A, x, b);
+    double rr = relative_residual(A, x, b);
+    double tol = double(n) * double(n) * std::numeric_limits<double>::epsilon();
+    report("Laplacian-1D", "nat", n, A.nnz(), rr, tol);
+    REQUIRE(rr < tol);
+}
+
+TEST_CASE("Sparse LDL^T regression: 2D Laplacian with AMD", "[regression][sparse][ldlt]") {
+    auto k = GENERATE(32, 71, 100);
+    std::size_t n = std::size_t(k) * std::size_t(k);
+
+    auto A = generators::laplacian_2d<double>(k, k);
+    vec::dense_vector<double> b(n, 1.0);
+    vec::dense_vector<double> x(n, 0.0);
+
+    factorization::sparse_ldlt_solve(A, x, b, ordering::amd{});
+    double rr = relative_residual(A, x, b);
+    double tol = double(n) * std::numeric_limits<double>::epsilon();
+    report("Laplacian-2D", "AMD", n, A.nnz(), rr, tol);
+    REQUIRE(rr < tol);
+}
+
+TEST_CASE("Sparse LDL^T regression: 2D Poisson with AMD", "[regression][sparse][ldlt]") {
+    auto k = GENERATE(32, 71, 100);
+    std::size_t n = std::size_t(k) * std::size_t(k);
+
+    auto A = generators::poisson2d_dirichlet<double>(k, k);
+    vec::dense_vector<double> b(n, 1.0);
+    vec::dense_vector<double> x(n, 0.0);
+
+    factorization::sparse_ldlt_solve(A, x, b, ordering::amd{});
+    double rr = relative_residual(A, x, b);
+    double tol = double(n) * std::numeric_limits<double>::epsilon();
+    report("Poisson-2D", "AMD", n, A.nnz(), rr, tol);
+    REQUIRE(rr < tol);
+}

--- a/tests/unit/operation/test_ldlt.cpp
+++ b/tests/unit/operation/test_ldlt.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
+#include <stdexcept>
 #include <mtl/mat/dense2D.hpp>
 #include <mtl/vec/dense_vector.hpp>
 #include <mtl/operation/ldlt.hpp>
@@ -117,6 +118,11 @@ TEST_CASE("LDL^T detects zero pivot", "[operation][ldlt]") {
     int info = ldlt_factor(A);
     REQUIRE(info != 0);  // D(0,0) = 0 → returns 1
     REQUIRE(info == 1);
+
+    // Verify ldlt_solve throws on zero diagonal
+    vec::dense_vector<double> b = {1.0, 2.0};
+    vec::dense_vector<double> x(2);
+    REQUIRE_THROWS_AS(ldlt_solve(A, x, b), std::domain_error);
 }
 
 TEST_CASE("LDL^T on randspd with known eigenvalues", "[operation][ldlt][generator]") {
@@ -242,7 +248,8 @@ TEST_CASE("LDL^T on 1x1 matrix", "[operation][ldlt]") {
     // Re-create for solve (factor overwrites D on diagonal)
     mat::dense2D<double> Af(1, 1);
     Af(0, 0) = 7.0;
-    ldlt_factor(Af);
+    int info_af = ldlt_factor(Af);
+    REQUIRE(info_af == 0);
 
     vec::dense_vector<double> b = {21.0};
     vec::dense_vector<double> x(1);

--- a/tests/unit/operation/test_ldlt.cpp
+++ b/tests/unit/operation/test_ldlt.cpp
@@ -230,3 +230,28 @@ TEST_CASE("LDL^T on Lehmer matrix", "[operation][ldlt][generator]") {
     for (std::size_t i = 0; i < n; ++i)
         REQUIRE_THAT(r(i), Catch::Matchers::WithinAbs(b(i), 1e-8));
 }
+
+TEST_CASE("LDL^T on 1x1 matrix", "[operation][ldlt]") {
+    mat::dense2D<double> A(1, 1);
+    A(0, 0) = 7.0;
+
+    int info = ldlt_factor(A);
+    REQUIRE(info == 0);
+    REQUIRE_THAT(A(0, 0), Catch::Matchers::WithinAbs(7.0, 1e-14));
+
+    // Re-create for solve (factor overwrites D on diagonal)
+    mat::dense2D<double> Af(1, 1);
+    Af(0, 0) = 7.0;
+    ldlt_factor(Af);
+
+    vec::dense_vector<double> b = {21.0};
+    vec::dense_vector<double> x(1);
+    ldlt_solve(Af, x, b);
+    REQUIRE_THAT(x(0), Catch::Matchers::WithinAbs(3.0, 1e-12));
+}
+
+TEST_CASE("LDL^T on empty (0x0) matrix", "[operation][ldlt]") {
+    mat::dense2D<double> A(0, 0);
+    int info = ldlt_factor(A);
+    REQUIRE(info == 0);
+}

--- a/tests/unit/operation/test_ldlt.cpp
+++ b/tests/unit/operation/test_ldlt.cpp
@@ -1,0 +1,232 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/operation/ldlt.hpp>
+#include <mtl/operation/operators.hpp>
+#include <mtl/operation/norms.hpp>
+#include <mtl/operation/trans.hpp>
+#include <mtl/generators/randspd.hpp>
+#include <mtl/generators/pascal.hpp>
+#include <mtl/generators/moler.hpp>
+#include <mtl/generators/lehmer.hpp>
+
+using namespace mtl;
+
+TEST_CASE("LDL^T factorization: L*D*L^T reproduces A", "[operation][ldlt]") {
+    // SPD matrix: A = {{4,2,1},{2,5,3},{1,3,6}}
+    mat::dense2D<double> A(3, 3);
+    A(0,0) = 4; A(0,1) = 2; A(0,2) = 1;
+    A(1,0) = 2; A(1,1) = 5; A(1,2) = 3;
+    A(2,0) = 1; A(2,1) = 3; A(2,2) = 6;
+
+    mat::dense2D<double> Aorig(3, 3);
+    for (std::size_t i = 0; i < 3; ++i)
+        for (std::size_t j = 0; j < 3; ++j)
+            Aorig(i, j) = A(i, j);
+
+    int info = ldlt_factor(A);
+    REQUIRE(info == 0);
+
+    // Extract L (unit lower triangular) and D from A
+    mat::dense2D<double> L(3, 3);
+    mat::dense2D<double> D(3, 3);
+    for (std::size_t i = 0; i < 3; ++i) {
+        for (std::size_t j = 0; j < 3; ++j) {
+            if (i == j) {
+                L(i, j) = 1.0;  // unit diagonal
+                D(i, j) = A(i, j);  // D on diagonal of A
+            } else if (j < i) {
+                L(i, j) = A(i, j);  // strictly lower triangle
+                D(i, j) = 0.0;
+            } else {
+                L(i, j) = 0.0;
+                D(i, j) = 0.0;
+            }
+        }
+    }
+
+    // L * D * L^T should equal Aorig
+    auto LDLt = L * D * trans(L);
+    for (std::size_t i = 0; i < 3; ++i)
+        for (std::size_t j = 0; j < 3; ++j)
+            REQUIRE_THAT(LDLt(i, j), Catch::Matchers::WithinAbs(Aorig(i, j), 1e-10));
+}
+
+TEST_CASE("LDL^T solve", "[operation][ldlt]") {
+    mat::dense2D<double> A(3, 3);
+    A(0,0) = 4; A(0,1) = 2; A(0,2) = 1;
+    A(1,0) = 2; A(1,1) = 5; A(1,2) = 3;
+    A(2,0) = 1; A(2,1) = 3; A(2,2) = 6;
+
+    mat::dense2D<double> Aorig(3, 3);
+    for (std::size_t i = 0; i < 3; ++i)
+        for (std::size_t j = 0; j < 3; ++j)
+            Aorig(i, j) = A(i, j);
+
+    vec::dense_vector<double> b = {1.0, 2.0, 3.0};
+    vec::dense_vector<double> x(3);
+
+    int info = ldlt_factor(A);
+    REQUIRE(info == 0);
+    ldlt_solve(A, x, b);
+
+    // Verify Aorig * x = b
+    auto r = Aorig * x;
+    for (std::size_t i = 0; i < 3; ++i)
+        REQUIRE_THAT(r(i), Catch::Matchers::WithinAbs(b(i), 1e-10));
+}
+
+TEST_CASE("LDL^T handles symmetric indefinite matrix", "[operation][ldlt]") {
+    // Symmetric indefinite: eigenvalues of different signs
+    // A = {{1, 2}, {2, -1}}  eigenvalues: +/- sqrt(5)
+    mat::dense2D<double> A(2, 2);
+    A(0,0) = 1;  A(0,1) = 2;
+    A(1,0) = 2;  A(1,1) = -1;
+
+    mat::dense2D<double> Aorig(2, 2);
+    for (std::size_t i = 0; i < 2; ++i)
+        for (std::size_t j = 0; j < 2; ++j)
+            Aorig(i, j) = A(i, j);
+
+    int info = ldlt_factor(A);
+    REQUIRE(info == 0);
+
+    // D should have entries of different signs
+    // D(0) = 1, D(1) = -1 - 4/1 = -5
+    REQUIRE_THAT(A(0, 0), Catch::Matchers::WithinAbs(1.0, 1e-12));
+    REQUIRE_THAT(A(1, 1), Catch::Matchers::WithinAbs(-5.0, 1e-12));
+
+    // Solve
+    vec::dense_vector<double> b = {5.0, 3.0};
+    vec::dense_vector<double> x(2);
+    ldlt_solve(A, x, b);
+
+    auto r = Aorig * x;
+    for (std::size_t i = 0; i < 2; ++i)
+        REQUIRE_THAT(r(i), Catch::Matchers::WithinAbs(b(i), 1e-10));
+}
+
+TEST_CASE("LDL^T detects zero pivot", "[operation][ldlt]") {
+    // Singular: A = {{0, 1}, {1, 0}}
+    mat::dense2D<double> A(2, 2);
+    A(0,0) = 0;  A(0,1) = 1;
+    A(1,0) = 1;  A(1,1) = 0;
+
+    int info = ldlt_factor(A);
+    REQUIRE(info != 0);  // D(0,0) = 0 → returns 1
+    REQUIRE(info == 1);
+}
+
+TEST_CASE("LDL^T on randspd with known eigenvalues", "[operation][ldlt][generator]") {
+    constexpr std::size_t n = 5;
+    auto A = generators::randspd<double>(n, {8.0, 4.0, 2.0, 1.0, 0.5});
+
+    mat::dense2D<double> Aorig(n, n);
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j)
+            Aorig(i, j) = A(i, j);
+
+    int info = ldlt_factor(A);
+    REQUIRE(info == 0);
+
+    // Extract L and D, verify L*D*L^T = A
+    mat::dense2D<double> L(n, n);
+    mat::dense2D<double> D(n, n);
+    for (std::size_t i = 0; i < n; ++i) {
+        for (std::size_t j = 0; j < n; ++j) {
+            if (i == j) {
+                L(i, j) = 1.0;
+                D(i, j) = A(i, j);
+            } else if (j < i) {
+                L(i, j) = A(i, j);
+                D(i, j) = 0.0;
+            } else {
+                L(i, j) = 0.0;
+                D(i, j) = 0.0;
+            }
+        }
+    }
+
+    auto LDLt = L * D * trans(L);
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j)
+            REQUIRE_THAT(LDLt(i, j), Catch::Matchers::WithinAbs(Aorig(i, j), 1e-10));
+}
+
+TEST_CASE("LDL^T on Pascal matrix", "[operation][ldlt][generator]") {
+    constexpr std::size_t n = 6;
+    auto A = generators::pascal<double>(n);
+
+    mat::dense2D<double> Aorig(n, n);
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j)
+            Aorig(i, j) = A(i, j);
+
+    int info = ldlt_factor(A);
+    REQUIRE(info == 0);
+
+    // Pascal LDL^T: L should have integer entries (Pascal's triangle)
+    // and D should be all 1s
+    for (std::size_t j = 0; j < n; ++j)
+        REQUIRE_THAT(A(j, j), Catch::Matchers::WithinAbs(1.0, 1e-10));
+}
+
+TEST_CASE("LDL^T on Moler matrix", "[operation][ldlt][generator]") {
+    constexpr std::size_t n = 6;
+    auto A = generators::moler<double>(n);
+
+    mat::dense2D<double> Aorig(n, n);
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j)
+            Aorig(i, j) = A(i, j);
+
+    int info = ldlt_factor(A);
+    REQUIRE(info == 0);
+
+    mat::dense2D<double> L(n, n);
+    mat::dense2D<double> D(n, n);
+    for (std::size_t i = 0; i < n; ++i) {
+        for (std::size_t j = 0; j < n; ++j) {
+            if (i == j) { L(i, j) = 1.0; D(i, j) = A(i, j); }
+            else if (j < i) { L(i, j) = A(i, j); D(i, j) = 0.0; }
+            else { L(i, j) = 0.0; D(i, j) = 0.0; }
+        }
+    }
+
+    auto LDLt = L * D * trans(L);
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j)
+            REQUIRE_THAT(LDLt(i, j), Catch::Matchers::WithinAbs(Aorig(i, j), 1e-8));
+}
+
+TEST_CASE("LDL^T on Lehmer matrix", "[operation][ldlt][generator]") {
+    constexpr std::size_t n = 6;
+    generators::lehmer<double> L_gen(n);
+    mat::dense2D<double> A(n, n);
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j)
+            A(i, j) = L_gen(i, j);
+
+    mat::dense2D<double> Aorig(n, n);
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j)
+            Aorig(i, j) = A(i, j);
+
+    int info = ldlt_factor(A);
+    REQUIRE(info == 0);
+
+    // All D entries should be positive (Lehmer is SPD)
+    for (std::size_t j = 0; j < n; ++j)
+        REQUIRE(A(j, j) > 0.0);
+
+    // Verify via solve
+    vec::dense_vector<double> b(n, 1.0);
+    vec::dense_vector<double> x(n);
+    ldlt_solve(A, x, b);
+
+    auto r = Aorig * x;
+    for (std::size_t i = 0; i < n; ++i)
+        REQUIRE_THAT(r(i), Catch::Matchers::WithinAbs(b(i), 1e-8));
+}

--- a/tests/unit/sparse/test_sparse_ldlt.cpp
+++ b/tests/unit/sparse/test_sparse_ldlt.cpp
@@ -78,22 +78,36 @@ TEST_CASE("Sparse LDL^T symbolic with RCM ordering", "[sparse][ldlt]") {
     REQUIRE(sym.nnz_L > 0);
 }
 
+TEST_CASE("Sparse LDL^T rejects rectangular matrix", "[sparse][ldlt]") {
+    mat::compressed2D<double> A(3, 4);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        ins[0][0] << 1.0;
+        ins[1][1] << 2.0;
+        ins[2][2] << 3.0;
+    }
+
+    REQUIRE_THROWS_AS(
+        factorization::sparse_ldlt_symbolic(A),
+        std::invalid_argument);
+}
+
 TEST_CASE("Sparse LDL^T numeric: 3x3 SPD matrix", "[sparse][ldlt]") {
     auto A = make_spd_tridiag(3);
 
     auto sym = factorization::sparse_ldlt_symbolic(A);
     auto num = factorization::sparse_ldlt_numeric(A, sym);
 
-    // Verify L structure
+    // Verify L structure: unit lower triangular with no diagonal stored
     const auto& L = num.L;
     REQUIRE(L.nrows == 3);
     REQUIRE(L.ncols == 3);
 
-    // Verify unit diagonal in L
+    // L stores only strictly-lower entries (no diagonal — unit diagonal is implicit)
+    // For a tridiagonal 3x3, each column except the last has 1 off-diagonal entry
     for (std::size_t j = 0; j < 3; ++j) {
-        REQUIRE(L.col_ptr[j] < L.col_ptr[j + 1]);
-        REQUIRE(L.row_ind[L.col_ptr[j]] == j);
-        REQUIRE_THAT(L.values[L.col_ptr[j]], Catch::Matchers::WithinAbs(1.0, 1e-14));
+        for (std::size_t p = L.col_ptr[j]; p < L.col_ptr[j + 1]; ++p)
+            REQUIRE(L.row_ind[p] > j);  // all entries strictly below diagonal
     }
 
     // Verify D has positive entries (SPD matrix)

--- a/tests/unit/sparse/test_sparse_ldlt.cpp
+++ b/tests/unit/sparse/test_sparse_ldlt.cpp
@@ -1,0 +1,280 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <cmath>
+#include <cstddef>
+#include <stdexcept>
+#include <mtl/mat/compressed2D.hpp>
+#include <mtl/mat/inserter.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/sparse/factorization/sparse_ldlt.hpp>
+#include <mtl/sparse/ordering/rcm.hpp>
+
+using namespace mtl;
+using namespace mtl::sparse;
+
+// Helper: build a symmetric SPD tridiagonal matrix of size n
+// A(i,i) = 4, A(i,i+1) = A(i+1,i) = -1
+static mat::compressed2D<double> make_spd_tridiag(std::size_t n) {
+    mat::compressed2D<double> A(n, n);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        for (std::size_t i = 0; i < n; ++i) {
+            ins[i][i] << 4.0;
+            if (i + 1 < n) {
+                ins[i][i + 1] << -1.0;
+                ins[i + 1][i] << -1.0;
+            }
+        }
+    }
+    return A;
+}
+
+// Helper: compute residual norm ||Ax - b|| / ||b||
+static double relative_residual(
+    const mat::compressed2D<double>& A,
+    const vec::dense_vector<double>& x,
+    const vec::dense_vector<double>& b)
+{
+    std::size_t n = b.size();
+    double res_norm = 0.0;
+    double b_norm = 0.0;
+    for (std::size_t i = 0; i < n; ++i) {
+        double Ax_i = 0.0;
+        const auto& starts = A.ref_major();
+        const auto& indices = A.ref_minor();
+        const auto& data = A.ref_data();
+        for (std::size_t k = starts[i]; k < starts[i + 1]; ++k)
+            Ax_i += data[k] * x(indices[k]);
+        double ri = Ax_i - b(i);
+        res_norm += ri * ri;
+        b_norm += b(i) * b(i);
+    }
+    if (b_norm == 0.0)
+        return std::sqrt(res_norm);
+    return std::sqrt(res_norm) / std::sqrt(b_norm);
+}
+
+TEST_CASE("Sparse LDL^T symbolic analysis", "[sparse][ldlt]") {
+    auto A = make_spd_tridiag(5);
+
+    auto sym = factorization::sparse_ldlt_symbolic(A);
+
+    REQUIRE(sym.n == 5);
+    REQUIRE(sym.perm.size() == 5);
+    REQUIRE(sym.pinv.size() == 5);
+    REQUIRE(sym.parent.size() == 5);
+    REQUIRE(sym.col_counts.size() == 5);
+    REQUIRE(sym.nnz_L > 0);
+}
+
+TEST_CASE("Sparse LDL^T symbolic with RCM ordering", "[sparse][ldlt]") {
+    auto A = make_spd_tridiag(5);
+
+    auto sym = factorization::sparse_ldlt_symbolic(A, ordering::rcm{});
+
+    REQUIRE(sym.n == 5);
+    REQUIRE(sym.perm.size() == 5);
+    REQUIRE(sym.nnz_L > 0);
+}
+
+TEST_CASE("Sparse LDL^T numeric: 3x3 SPD matrix", "[sparse][ldlt]") {
+    auto A = make_spd_tridiag(3);
+
+    auto sym = factorization::sparse_ldlt_symbolic(A);
+    auto num = factorization::sparse_ldlt_numeric(A, sym);
+
+    // Verify L structure
+    const auto& L = num.L;
+    REQUIRE(L.nrows == 3);
+    REQUIRE(L.ncols == 3);
+
+    // Verify unit diagonal in L
+    for (std::size_t j = 0; j < 3; ++j) {
+        REQUIRE(L.col_ptr[j] < L.col_ptr[j + 1]);
+        REQUIRE(L.row_ind[L.col_ptr[j]] == j);
+        REQUIRE_THAT(L.values[L.col_ptr[j]], Catch::Matchers::WithinAbs(1.0, 1e-14));
+    }
+
+    // Verify D has positive entries (SPD matrix)
+    REQUIRE(num.D.size() == 3);
+    for (std::size_t j = 0; j < 3; ++j)
+        REQUIRE(num.D[j] > 0.0);
+}
+
+TEST_CASE("Sparse LDL^T solve: 3x3 tridiagonal", "[sparse][ldlt]") {
+    auto A = make_spd_tridiag(3);
+
+    vec::dense_vector<double> b = {1.0, 2.0, 3.0};
+    vec::dense_vector<double> x(3, 0.0);
+
+    factorization::sparse_ldlt_solve(A, x, b);
+
+    double rr = relative_residual(A, x, b);
+    REQUIRE(rr < 1e-12);
+}
+
+TEST_CASE("Sparse LDL^T solve: 5x5 tridiagonal", "[sparse][ldlt]") {
+    auto A = make_spd_tridiag(5);
+
+    vec::dense_vector<double> b = {1.0, 0.0, -1.0, 2.0, 0.5};
+    vec::dense_vector<double> x(5, 0.0);
+
+    factorization::sparse_ldlt_solve(A, x, b);
+
+    double rr = relative_residual(A, x, b);
+    REQUIRE(rr < 1e-12);
+}
+
+TEST_CASE("Sparse LDL^T solve with RCM ordering", "[sparse][ldlt]") {
+    auto A = make_spd_tridiag(5);
+
+    vec::dense_vector<double> b = {1.0, 2.0, 3.0, 4.0, 5.0};
+    vec::dense_vector<double> x(5, 0.0);
+
+    factorization::sparse_ldlt_solve(A, x, b, ordering::rcm{});
+
+    double rr = relative_residual(A, x, b);
+    REQUIRE(rr < 1e-12);
+}
+
+TEST_CASE("Sparse LDL^T solve: dense SPD via sparse", "[sparse][ldlt]") {
+    // Fully dense 3x3 SPD matrix:
+    // A = [[10  2  1]
+    //      [ 2  5  3]
+    //      [ 1  3  8]]
+    mat::compressed2D<double> A(3, 3);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        ins[0][0] << 10.0; ins[0][1] << 2.0;  ins[0][2] << 1.0;
+        ins[1][0] << 2.0;  ins[1][1] << 5.0;  ins[1][2] << 3.0;
+        ins[2][0] << 1.0;  ins[2][1] << 3.0;  ins[2][2] << 8.0;
+    }
+
+    vec::dense_vector<double> b = {13.0, 10.0, 12.0};
+    vec::dense_vector<double> x(3, 0.0);
+
+    factorization::sparse_ldlt_solve(A, x, b);
+
+    double rr = relative_residual(A, x, b);
+    REQUIRE(rr < 1e-12);
+}
+
+TEST_CASE("Sparse LDL^T reuse symbolic for same pattern", "[sparse][ldlt]") {
+    auto A1 = make_spd_tridiag(4);
+
+    // A2: same pattern but different values
+    mat::compressed2D<double> A2(4, 4);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A2);
+        for (std::size_t i = 0; i < 4; ++i) {
+            ins[i][i] << 6.0;
+            if (i + 1 < 4) {
+                ins[i][i + 1] << -2.0;
+                ins[i + 1][i] << -2.0;
+            }
+        }
+    }
+
+    auto sym = factorization::sparse_ldlt_symbolic(A1);
+
+    auto num1 = factorization::sparse_ldlt_numeric(A1, sym);
+    auto num2 = factorization::sparse_ldlt_numeric(A2, sym);
+
+    vec::dense_vector<double> b = {1.0, 2.0, 3.0, 4.0};
+
+    vec::dense_vector<double> x1(4, 0.0);
+    num1.solve(x1, b);
+    REQUIRE(relative_residual(A1, x1, b) < 1e-12);
+
+    vec::dense_vector<double> x2(4, 0.0);
+    num2.solve(x2, b);
+    REQUIRE(relative_residual(A2, x2, b) < 1e-12);
+}
+
+TEST_CASE("Sparse LDL^T throws for zero pivot", "[sparse][ldlt]") {
+    // Singular matrix with zero pivot
+    mat::compressed2D<double> A(2, 2);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        ins[0][0] << 0.0;
+        ins[0][1] << 1.0;
+        ins[1][0] << 1.0;
+        ins[1][1] << 0.0;
+    }
+
+    auto sym = factorization::sparse_ldlt_symbolic(A);
+    REQUIRE_THROWS_AS(
+        factorization::sparse_ldlt_numeric(A, sym),
+        std::runtime_error);
+}
+
+TEST_CASE("Sparse LDL^T solve: 1x1 matrix", "[sparse][ldlt]") {
+    mat::compressed2D<double> A(1, 1);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        ins[0][0] << 4.0;
+    }
+
+    vec::dense_vector<double> b = {8.0};
+    vec::dense_vector<double> x(1, 0.0);
+
+    factorization::sparse_ldlt_solve(A, x, b);
+
+    REQUIRE_THAT(x(0), Catch::Matchers::WithinAbs(2.0, 1e-12));
+}
+
+TEST_CASE("Sparse LDL^T solve: arrow matrix", "[sparse][ldlt]") {
+    mat::compressed2D<double> A(4, 4);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        ins[0][0] << 10.0;
+        for (std::size_t i = 1; i < 4; ++i) {
+            ins[0][i] << 1.0;
+            ins[i][0] << 1.0;
+            ins[i][i] << 5.0;
+        }
+    }
+
+    vec::dense_vector<double> b = {13.0, 6.0, 6.0, 6.0};
+    vec::dense_vector<double> x(4, 0.0);
+
+    factorization::sparse_ldlt_solve(A, x, b);
+
+    double rr = relative_residual(A, x, b);
+    REQUIRE(rr < 1e-12);
+}
+
+TEST_CASE("Sparse LDL^T solve: larger 10x10 system", "[sparse][ldlt]") {
+    std::size_t n = 10;
+    auto A = make_spd_tridiag(n);
+
+    vec::dense_vector<double> b(n, 1.0);
+    vec::dense_vector<double> x(n, 0.0);
+
+    factorization::sparse_ldlt_solve(A, x, b, ordering::rcm{});
+
+    double rr = relative_residual(A, x, b);
+    REQUIRE(rr < 1e-12);
+}
+
+TEST_CASE("Sparse LDL^T handles symmetric indefinite matrix", "[sparse][ldlt]") {
+    // Symmetric indefinite: A = [[1, 3], [3, 1]]
+    // Eigenvalues: 4, -2 (indefinite)
+    mat::compressed2D<double> A(2, 2);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        ins[0][0] << 1.0;
+        ins[0][1] << 3.0;
+        ins[1][0] << 3.0;
+        ins[1][1] << 1.0;
+    }
+
+    vec::dense_vector<double> b = {4.0, 4.0};
+    vec::dense_vector<double> x(2, 0.0);
+
+    factorization::sparse_ldlt_solve(A, x, b);
+
+    double rr = relative_residual(A, x, b);
+    REQUIRE(rr < 1e-12);
+}


### PR DESCRIPTION
## Summary
- Add dense and sparse LDL^T factorization (A = L·D·L^T) — the square-root-free variant of Cholesky
- Avoids all `sqrt` operations, eliminating precision loss for ill-conditioned matrices (critical for UKF covariance factorization)
- Works for symmetric indefinite matrices (D can have negative entries), only fails on zero pivots
- Sparse symbolic phase reuses `cholesky_symbolic` directly (identical elimination tree and fill-in)

## Changes
- `include/mtl/operation/ldlt.hpp` — dense `ldlt_factor` + `ldlt_solve` (namespace `mtl::`)
- `include/mtl/sparse/factorization/sparse_ldlt.hpp` — sparse `ldlt_symbolic`, `ldlt_numeric`, `sparse_ldlt_solve` (namespace `mtl::sparse::factorization::`)
- `include/mtl/sparse/factorization/triangular_solve.hpp` — add `dense_unit_lower_solve` and `dense_unit_lower_transpose_solve`
- `include/mtl/mtl.hpp` — add umbrella include for `ldlt.hpp`
- `include/mtl/sparse/sparse.hpp` — add umbrella include for `sparse_ldlt.hpp`
- `tests/unit/operation/test_ldlt.cpp` — 8 test cases: SPD, indefinite, zero pivot, generators (randspd, Pascal, Moler, Lehmer)
- `tests/unit/sparse/test_sparse_ldlt.cpp` — 13 test cases: symbolic, numeric, solve, ordering, reuse, indefinite, edge cases
- `tests/regression/dense/test_ldlt.cpp` — randspd, Lehmer, Moler, Minij at n=100–1000
- `tests/regression/sparse/test_sparse_ldlt.cpp` — 1D Laplacian (1K–50K), 2D Laplacian + Poisson with AMD

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| op_test_ldlt | OK | 8/8 PASS (104 assertions) | OK | 8/8 PASS |
| sparse_test_sparse_ldlt | OK | 13/13 PASS (35 assertions) | OK | 13/13 PASS |
| Full suite (96 tests) | OK | 96/96 PASS | OK | 96/96 PASS |

## Test plan
- [x] Tier 1 CI passes (8 platforms: Linux GCC/Clang x64+ARM64, macOS, Windows MSVC/Clang-CL)
- [x] Tier 2 regression CI passes (dense + sparse LDL^T at scale)
- [x] CodeRabbit review addressed
- [x] Promote to ready when satisfied: `gh pr ready`

Resolves #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LDLᵀ factorization and linear solves for dense symmetric matrices (in-place, singular detection).
  * Added sparse LDLᵀ factorization and solver with optional ordering support and unit-triangular sparse solves.
  * Exposed LDLT and sparse LDLT facilities through umbrella headers and added dense unit-lower triangular solve utilities.

* **Tests**
  * Added extensive unit and regression tests validating dense and sparse LDLᵀ factorization and solves across many matrix types and sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->