### PR TITLE
feat(operation): add Bunch-Kaufman pivoted LDL^T decomposition

### DIFF
--- a/include/mtl/mtl.hpp
+++ b/include/mtl/mtl.hpp
@@ -163,6 +163,7 @@
 #include <mtl/operation/lq.hpp>
 #include <mtl/operation/cholesky.hpp>
 #include <mtl/operation/ldlt.hpp>
+#include <mtl/operation/ldlt_bk.hpp>
 #include <mtl/operation/inv.hpp>
 #include <mtl/operation/hessenberg.hpp>
 #include <mtl/operation/eigenvalue_symmetric.hpp>

--- a/include/mtl/operation/ldlt_bk.hpp
+++ b/include/mtl/operation/ldlt_bk.hpp
@@ -1,0 +1,347 @@
+#pragma once
+// MTL5 -- Bunch-Kaufman pivoted LDL^T factorization for symmetric matrices
+// P * A * P^T = L * D * L^T where:
+//   L is unit lower triangular
+//   D is block-diagonal with 1x1 and 2x2 blocks
+//   P is a permutation matrix
+//
+// The Bunch-Kaufman partial pivoting strategy selects the largest available
+// pivot at each step, using 2x2 blocks when no single diagonal entry is
+// a good pivot. This handles symmetric indefinite matrices without breakdown
+// and provides bounded element growth (factor ≤ (1+sqrt(17))/8 ≈ 2.57).
+//
+// The pivot sequence is stored in LAPACK convention:
+//   ipiv[k] > 0  → 1x1 pivot, row/col swap with ipiv[k]-1
+//   ipiv[k] < 0 && ipiv[k+1] < 0  → 2x2 pivot using rows |ipiv[k]|-1, |ipiv[k+1]|-1
+//
+// Reference:
+//   Bunch & Kaufman, "Some Stable Methods for Calculating Inertia and
+//   Solving Symmetric Linear Systems", Math. Comp. 31(137), 1977.
+//   Golub & Van Loan, "Matrix Computations", Section 4.4.
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <stdexcept>
+#include <vector>
+#include <mtl/concepts/matrix.hpp>
+#include <mtl/concepts/vector.hpp>
+#include <mtl/math/identity.hpp>
+
+namespace mtl {
+
+/// Pivot information from Bunch-Kaufman factorization.
+/// Uses LAPACK ipiv convention for 1x1 and 2x2 block pivots.
+struct bk_pivot_info {
+    std::vector<int> ipiv;
+};
+
+/// Swap rows and columns r1 and r2 in the lower triangle of a symmetric matrix.
+/// Only the lower triangle (and diagonal) is accessed and modified.
+template <Matrix M>
+void symmetric_swap(M& A, std::size_t r1, std::size_t r2) {
+    if (r1 == r2) return;
+    if (r1 > r2) std::swap(r1, r2);
+    std::size_t n = A.num_rows();
+
+    // Swap diagonal entries
+    auto tmp = A(r1, r1);
+    A(r1, r1) = A(r2, r2);
+    A(r2, r2) = tmp;
+
+    // Swap entries in rows r1 and r2 for columns < r1
+    for (std::size_t j = 0; j < r1; ++j) {
+        tmp = A(r1, j);
+        A(r1, j) = A(r2, j);
+        A(r2, j) = tmp;
+    }
+
+    // Swap entries in column r1 (rows between r1 and r2) with row r2
+    for (std::size_t i = r1 + 1; i < r2; ++i) {
+        tmp = A(i, r1);
+        A(i, r1) = A(r2, i);  // A(r2, i) is in upper triangle → use A(i, r2) conceptually
+        A(r2, i) = tmp;
+    }
+
+    // Swap entries in rows r1 and r2 for columns between r1 and r2 handled above
+    // Swap entries below r2 in columns r1 and r2
+    for (std::size_t i = r2 + 1; i < n; ++i) {
+        tmp = A(i, r1);
+        A(i, r1) = A(i, r2);
+        A(i, r2) = tmp;
+    }
+}
+
+/// Bunch-Kaufman pivoted LDL^T factorization: P*A*P^T = L*D*L^T.
+/// In-place: lower triangle of A is overwritten with L (unit diagonal implicit),
+/// D occupies the diagonal and first subdiagonal for 2x2 blocks.
+/// Returns 0 on success, k+1 if a singular block is encountered at step k.
+template <Matrix M>
+int ldlt_bk_factor(M& A, bk_pivot_info& pivots) {
+    using value_type = typename M::value_type;
+    using std::abs;
+    const std::size_t n = A.num_rows();
+    assert(A.num_cols() == n);
+
+    pivots.ipiv.resize(n, 0);
+
+    // Bunch-Kaufman threshold: alpha = (1 + sqrt(17)) / 8
+    const value_type alpha = value_type((1.0 + std::sqrt(17.0)) / 8.0);
+
+    std::size_t k = 0;
+    while (k < n) {
+        if (k == n - 1) {
+            // Last 1x1 pivot — no choice
+            if (A(k, k) == math::zero<value_type>())
+                return static_cast<int>(k + 1);
+            pivots.ipiv[k] = static_cast<int>(k + 1);  // 1-based, positive = 1x1
+            ++k;
+            continue;
+        }
+
+        // Step 1: Find largest off-diagonal magnitude in column k (rows > k)
+        std::size_t r = k + 1;
+        value_type lambda_val = abs(A(k + 1, k));
+        for (std::size_t i = k + 2; i < n; ++i) {
+            value_type aik = abs(A(i, k));
+            if (aik > lambda_val) {
+                lambda_val = aik;
+                r = i;
+            }
+        }
+
+        // Step 2: Determine pivot type
+        bool use_1x1 = false;
+        bool use_2x2 = false;
+        std::size_t swap_r = r;
+
+        if (lambda_val == math::zero<value_type>()) {
+            // Column k is zero below diagonal — 1x1 pivot (might be zero)
+            if (A(k, k) == math::zero<value_type>())
+                return static_cast<int>(k + 1);
+            use_1x1 = true;
+            swap_r = k;  // no swap needed
+        } else if (abs(A(k, k)) >= alpha * lambda_val) {
+            // Test 1: diagonal is large enough for 1x1 pivot, no swap needed
+            use_1x1 = true;
+            swap_r = k;
+        } else {
+            // Step 3: Find largest off-diagonal magnitude in row r (cols ≠ r)
+            value_type sigma = math::zero<value_type>();
+            for (std::size_t j = k; j < r; ++j) {
+                value_type arj = abs(A(r, j));
+                if (arj > sigma) sigma = arj;
+            }
+            for (std::size_t i = r + 1; i < n; ++i) {
+                value_type air = abs(A(i, r));
+                if (air > sigma) sigma = air;
+            }
+
+            if (abs(A(k, k)) * sigma >= alpha * lambda_val * lambda_val) {
+                // Test 2: diagonal good enough relative to both column maxima, no swap
+                use_1x1 = true;
+                swap_r = k;
+            } else if (abs(A(r, r)) >= alpha * sigma) {
+                // Test 3: A(r,r) is a good pivot — swap r↔k, use 1x1
+                use_1x1 = true;
+                swap_r = r;
+                symmetric_swap(A, k, r);
+            } else {
+                // Use 2x2 pivot from rows/cols {k, r}
+                // Swap r ↔ k+1 to put the 2x2 block at positions {k, k+1}
+                use_2x2 = true;
+                if (r != k + 1)
+                    symmetric_swap(A, k + 1, r);
+            }
+        }
+
+        if (use_1x1) {
+            // 1x1 pivot at position k
+            value_type dkk = A(k, k);
+            if (dkk == math::zero<value_type>())
+                return static_cast<int>(k + 1);
+
+            // Record pivot (1-based, positive = 1x1 with swap target)
+            pivots.ipiv[k] = static_cast<int>(swap_r + 1);
+
+            // Perform rank-1 update on the trailing submatrix:
+            //   A(i,j) -= A(i,k) * A(j,k) / D(k,k)  for i,j > k
+            // Then store L(i,k) = A(i,k) / D(k,k).
+            // Must update A(i,j) using original A(j,k) BEFORE overwriting
+            // column k with L values. Process column-by-column:
+            for (std::size_t j = k + 1; j < n; ++j) {
+                value_type ajk = A(j, k);
+                value_type ajk_over_d = ajk / dkk;
+                for (std::size_t i = j; i < n; ++i)
+                    A(i, j) = A(i, j) - A(i, k) * ajk_over_d;
+            }
+            // Now store L column
+            for (std::size_t i = k + 1; i < n; ++i)
+                A(i, k) = A(i, k) / dkk;
+            ++k;
+        } else {
+            // 2x2 pivot at positions {k, k+1}
+            value_type d00 = A(k, k);
+            value_type d10 = A(k + 1, k);
+            value_type d11 = A(k + 1, k + 1);
+            value_type det = d00 * d11 - d10 * d10;
+            if (det == math::zero<value_type>())
+                return static_cast<int>(k + 1);
+
+            // Record pivot (negative = 2x2 block)
+            // After swap, the 2x2 block uses positions k and k+1
+            // ipiv[k] = -(original row that was swapped to k+1) 1-based
+            // ipiv[k+1] = same (both negative signals 2x2)
+            std::size_t actual_r = (r != k + 1) ? r : k + 1;
+            pivots.ipiv[k]     = -static_cast<int>(actual_r + 1);
+            pivots.ipiv[k + 1] = -static_cast<int>(actual_r + 1);
+
+            // Inverse of 2x2 D block: D^{-1} = (1/det) * [[d11, -d10], [-d10, d00]]
+            value_type inv_det = math::one<value_type>() / det;
+            value_type di00 =  d11 * inv_det;
+            value_type di01 = -d10 * inv_det;
+            value_type di11 =  d00 * inv_det;
+
+            // Perform rank-2 update on the trailing submatrix:
+            //   A(i,j) -= [A(i,k) A(i,k+1)] * D^{-1} * [A(j,k) A(j,k+1)]^T
+            // Must use original A(:,k) and A(:,k+1) before overwriting with L.
+            // Process column-by-column in the trailing submatrix:
+            for (std::size_t j = k + 2; j < n; ++j) {
+                value_type ajk0 = A(j, k);
+                value_type ajk1 = A(j, k + 1);
+                // Compute D^{-1} * [ajk0, ajk1]^T
+                value_type t0 = di00 * ajk0 + di01 * ajk1;
+                value_type t1 = di01 * ajk0 + di11 * ajk1;
+                for (std::size_t i = j; i < n; ++i)
+                    A(i, j) = A(i, j) - A(i, k) * t0 - A(i, k + 1) * t1;
+            }
+            // Now store L columns: L(i,:) = [A(i,k) A(i,k+1)] * D^{-1}
+            for (std::size_t i = k + 2; i < n; ++i) {
+                value_type aik0 = A(i, k);
+                value_type aik1 = A(i, k + 1);
+                A(i, k)     = aik0 * di00 + aik1 * di01;
+                A(i, k + 1) = aik0 * di01 + aik1 * di11;
+            }
+            k += 2;
+        }
+    }
+    return 0;
+}
+
+/// Solve A*x = b using precomputed Bunch-Kaufman LDL^T factors.
+/// The factored A contains L (unit lower, implicit diagonal) and D
+/// (diagonal and subdiagonal for 2x2 blocks). pivots records the
+/// permutation and block structure.
+template <Matrix M, Vector VecX, Vector VecB>
+void ldlt_bk_solve(const M& A, const bk_pivot_info& pivots, VecX& x, const VecB& b) {
+    using value_type = typename VecX::value_type;
+    const std::size_t n = A.num_rows();
+    assert(A.num_cols() == n && x.size() == n && b.size() == n);
+
+    // Copy b into x (we work in-place on x)
+    for (std::size_t i = 0; i < n; ++i)
+        x(i) = b(i);
+
+    // Step 1: Apply forward permutation and forward substitution (L * y = P * b)
+    // Process blocks from top to bottom
+    std::size_t k = 0;
+    while (k < n) {
+        if (pivots.ipiv[k] > 0) {
+            // 1x1 pivot — swap if needed
+            std::size_t p = static_cast<std::size_t>(pivots.ipiv[k] - 1);
+            if (p != k) {
+                auto tmp = x(k);
+                x(k) = x(p);
+                x(p) = tmp;
+            }
+
+            // Forward substitution for column k: x(i) -= L(i,k) * x(k)
+            for (std::size_t i = k + 1; i < n; ++i)
+                x(i) = x(i) - A(i, k) * x(k);
+            ++k;
+        } else {
+            // 2x2 pivot — swap k+1 with |ipiv[k]|-1
+            std::size_t p = static_cast<std::size_t>(-pivots.ipiv[k] - 1);
+            if (p != k + 1) {
+                auto tmp = x(k + 1);
+                x(k + 1) = x(p);
+                x(p) = tmp;
+            }
+
+            // Forward substitution for columns k and k+1
+            for (std::size_t i = k + 2; i < n; ++i) {
+                x(i) = x(i) - A(i, k) * x(k) - A(i, k + 1) * x(k + 1);
+            }
+            k += 2;
+        }
+    }
+
+    // Step 2: Solve D * z = y (block-diagonal solve)
+    k = 0;
+    while (k < n) {
+        if (pivots.ipiv[k] > 0) {
+            // 1x1 block
+            if (A(k, k) == math::zero<value_type>())
+                throw std::domain_error("ldlt_bk_solve: zero 1x1 pivot in D");
+            x(k) = x(k) / A(k, k);
+            ++k;
+        } else {
+            // 2x2 block at {k, k+1}
+            value_type d00 = A(k, k);
+            value_type d10 = A(k + 1, k);
+            value_type d11 = A(k + 1, k + 1);
+            value_type det = d00 * d11 - d10 * d10;
+            if (det == math::zero<value_type>())
+                throw std::domain_error("ldlt_bk_solve: singular 2x2 pivot in D");
+
+            value_type xk  = x(k);
+            value_type xk1 = x(k + 1);
+            x(k)     = (d11 * xk - d10 * xk1) / det;
+            x(k + 1) = (d00 * xk1 - d10 * xk) / det;
+            k += 2;
+        }
+    }
+
+    // Step 3: Backward substitution (L^T * u = z) and reverse permutation
+    // Process blocks from bottom to top
+    if (n == 0) return;
+    k = n;
+    while (k > 0) {
+        if (k >= 1 && pivots.ipiv[k - 1] > 0) {
+            // 1x1 pivot at k-1
+            --k;
+            // Backward substitution: x(k) -= sum L(i,k) * x(i) for i > k
+            for (std::size_t i = k + 1; i < n; ++i)
+                x(k) = x(k) - A(i, k) * x(i);
+
+            // Reverse permutation
+            std::size_t p = static_cast<std::size_t>(pivots.ipiv[k] - 1);
+            if (p != k) {
+                auto tmp = x(k);
+                x(k) = x(p);
+                x(p) = tmp;
+            }
+        } else if (k >= 2) {
+            // 2x2 pivot at {k-2, k-1}
+            k -= 2;
+            // Backward substitution for columns k and k+1
+            for (std::size_t i = k + 2; i < n; ++i) {
+                x(k)     = x(k)     - A(i, k) * x(i);
+                x(k + 1) = x(k + 1) - A(i, k + 1) * x(i);
+            }
+
+            // Reverse permutation: swap k+1 with |ipiv[k]|-1
+            std::size_t p = static_cast<std::size_t>(-pivots.ipiv[k] - 1);
+            if (p != k + 1) {
+                auto tmp = x(k + 1);
+                x(k + 1) = x(p);
+                x(p) = tmp;
+            }
+        } else {
+            break;
+        }
+    }
+}
+
+} // namespace mtl

--- a/tests/regression/dense/test_ldlt_bk.cpp
+++ b/tests/regression/dense/test_ldlt_bk.cpp
@@ -1,0 +1,128 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
+#include <cmath>
+#include <cstddef>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/operation/ldlt_bk.hpp>
+#include <mtl/operation/operators.hpp>
+#include <mtl/operation/norms.hpp>
+#include <mtl/generators/randspd.hpp>
+#include <mtl/generators/lehmer.hpp>
+#include <mtl/generators/moler.hpp>
+#include <mtl/generators/minij.hpp>
+
+using namespace mtl;
+
+namespace {
+
+template <typename Gen>
+mat::dense2D<typename Gen::value_type> materialize(const Gen& g) {
+    using V = typename Gen::value_type;
+    auto n = g.num_rows(), m = g.num_cols();
+    mat::dense2D<V> A(n, m);
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < m; ++j)
+            A(i, j) = g(i, j);
+    return A;
+}
+
+mat::dense2D<double> copy_matrix(const mat::dense2D<double>& A) {
+    auto n = A.num_rows(), m = A.num_cols();
+    mat::dense2D<double> B(n, m);
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < m; ++j)
+            B(i, j) = A(i, j);
+    return B;
+}
+
+double bk_solve_report(const char* matrix_name, int n,
+                       const mat::dense2D<double>& A,
+                       const vec::dense_vector<double>& b,
+                       double tol) {
+    auto Af = copy_matrix(A);
+    bk_pivot_info pivots;
+    int info = ldlt_bk_factor(Af, pivots);
+    REQUIRE(info == 0);
+
+    vec::dense_vector<double> x(A.num_rows());
+    ldlt_bk_solve(Af, pivots, x, b);
+
+    auto r = A * x;
+    double res_norm = 0.0;
+    for (std::size_t i = 0; i < A.num_rows(); ++i) {
+        double d = r(i) - b(i);
+        res_norm += d * d;
+    }
+    res_norm = std::sqrt(res_norm);
+    double A_norm = frobenius_norm(A);
+    double x_norm = two_norm(x);
+    double be = (A_norm * x_norm > 0.0) ? res_norm / (A_norm * x_norm) : res_norm;
+
+    std::cout << std::left << std::setw(12) << matrix_name
+              << "  n=" << std::setw(6) << n
+              << "  backward_err=" << std::scientific << std::setprecision(3) << be
+              << "  tol=" << tol
+              << (be < tol ? "  PASS" : "  FAIL")
+              << std::defaultfloat << std::endl;
+    return be;
+}
+
+} // anonymous namespace
+
+TEST_CASE("Bunch-Kaufman regression: randspd (kappa=100)", "[regression][dense][ldlt_bk]") {
+    auto n = GENERATE(100, 500, 1000);
+    auto A = generators::randspd<double>(static_cast<std::size_t>(n), 100.0);
+    vec::dense_vector<double> x_exact(n, 1.0);
+    auto b = A * x_exact;
+    double tol = double(n) * std::numeric_limits<double>::epsilon();
+    double be = bk_solve_report("randspd", n, A, b, tol);
+    REQUIRE(be < tol);
+}
+
+TEST_CASE("Bunch-Kaufman regression: Lehmer matrix", "[regression][dense][ldlt_bk]") {
+    auto n = GENERATE(100, 500, 1000);
+    auto A = materialize(generators::lehmer<double>(n));
+    vec::dense_vector<double> x_exact(n, 1.0);
+    auto b = A * x_exact;
+    double tol = double(n) * std::numeric_limits<double>::epsilon();
+    double be = bk_solve_report("Lehmer", n, A, b, tol);
+    REQUIRE(be < tol);
+}
+
+TEST_CASE("Bunch-Kaufman regression: Moler matrix", "[regression][dense][ldlt_bk]") {
+    auto n = GENERATE(100, 500);
+    auto A = generators::moler<double>(n);
+    vec::dense_vector<double> x_exact(n, 1.0);
+    auto b = A * x_exact;
+    double tol = double(n) * 1000.0 * std::numeric_limits<double>::epsilon();
+    double be = bk_solve_report("Moler", n, A, b, tol);
+    REQUIRE(be < tol);
+}
+
+TEST_CASE("Bunch-Kaufman regression: indefinite tridiagonal", "[regression][dense][ldlt_bk]") {
+    auto n = GENERATE(100, 500);
+    // Symmetric indefinite tridiagonal: alternating +/- diagonal
+    mat::dense2D<double> A(n, n);
+    for (std::size_t i = 0; i < static_cast<std::size_t>(n); ++i)
+        for (std::size_t j = 0; j < static_cast<std::size_t>(n); ++j)
+            A(i, j) = 0.0;
+    for (std::size_t i = 0; i < static_cast<std::size_t>(n); ++i) {
+        A(i, i) = (i % 2 == 0) ? 10.0 : -5.0;
+        if (i + 1 < static_cast<std::size_t>(n)) {
+            A(i, i + 1) = 2.0;
+            A(i + 1, i) = 2.0;
+        }
+    }
+
+    vec::dense_vector<double> x_exact(n, 1.0);
+    auto b = A * x_exact;
+    double tol = double(n) * std::numeric_limits<double>::epsilon();
+    double be = bk_solve_report("indefinite", n, A, b, tol);
+    REQUIRE(be < tol);
+}

--- a/tests/regression/dense/test_ldlt_bk.cpp
+++ b/tests/regression/dense/test_ldlt_bk.cpp
@@ -15,7 +15,6 @@
 #include <mtl/generators/randspd.hpp>
 #include <mtl/generators/lehmer.hpp>
 #include <mtl/generators/moler.hpp>
-#include <mtl/generators/minij.hpp>
 
 using namespace mtl;
 
@@ -107,14 +106,15 @@ TEST_CASE("Bunch-Kaufman regression: Moler matrix", "[regression][dense][ldlt_bk
 
 TEST_CASE("Bunch-Kaufman regression: indefinite tridiagonal", "[regression][dense][ldlt_bk]") {
     auto n = GENERATE(100, 500);
+    std::size_t sz = static_cast<std::size_t>(n);
     // Symmetric indefinite tridiagonal: alternating +/- diagonal
     mat::dense2D<double> A(n, n);
-    for (std::size_t i = 0; i < static_cast<std::size_t>(n); ++i)
-        for (std::size_t j = 0; j < static_cast<std::size_t>(n); ++j)
+    for (std::size_t i = 0; i < sz; ++i)
+        for (std::size_t j = 0; j < sz; ++j)
             A(i, j) = 0.0;
-    for (std::size_t i = 0; i < static_cast<std::size_t>(n); ++i) {
+    for (std::size_t i = 0; i < sz; ++i) {
         A(i, i) = (i % 2 == 0) ? 10.0 : -5.0;
-        if (i + 1 < static_cast<std::size_t>(n)) {
+        if (i + 1 < sz) {
             A(i, i + 1) = 2.0;
             A(i + 1, i) = 2.0;
         }

--- a/tests/unit/operation/test_ldlt_bk.cpp
+++ b/tests/unit/operation/test_ldlt_bk.cpp
@@ -1,0 +1,226 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <cmath>
+#include <stdexcept>
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/operation/ldlt_bk.hpp>
+#include <mtl/operation/operators.hpp>
+#include <mtl/operation/norms.hpp>
+#include <mtl/operation/trans.hpp>
+#include <mtl/generators/randspd.hpp>
+
+using namespace mtl;
+
+// Helper: compute ||Ax - b|| / (||A||*||x||)
+static double backward_error(const mat::dense2D<double>& A,
+                             const vec::dense_vector<double>& x,
+                             const vec::dense_vector<double>& b) {
+    auto Ax = A * x;
+    double res = 0.0;
+    for (std::size_t i = 0; i < b.size(); ++i) {
+        double d = Ax(i) - b(i);
+        res += d * d;
+    }
+    res = std::sqrt(res);
+    double Anorm = frobenius_norm(A);
+    double xnorm = two_norm(x);
+    return (Anorm * xnorm > 0.0) ? res / (Anorm * xnorm) : res;
+}
+
+TEST_CASE("Bunch-Kaufman on SPD matrix", "[operation][ldlt_bk]") {
+    // SPD matrix: A = {{4,2,1},{2,5,3},{1,3,6}}
+    mat::dense2D<double> A(3, 3);
+    A(0,0) = 4; A(0,1) = 2; A(0,2) = 1;
+    A(1,0) = 2; A(1,1) = 5; A(1,2) = 3;
+    A(2,0) = 1; A(2,1) = 3; A(2,2) = 6;
+
+    mat::dense2D<double> Aorig(3, 3);
+    for (std::size_t i = 0; i < 3; ++i)
+        for (std::size_t j = 0; j < 3; ++j)
+            Aorig(i, j) = A(i, j);
+
+    bk_pivot_info pivots;
+    int info = ldlt_bk_factor(A, pivots);
+    REQUIRE(info == 0);
+    REQUIRE(pivots.ipiv.size() == 3);
+
+    // Solve
+    vec::dense_vector<double> b = {1.0, 2.0, 3.0};
+    vec::dense_vector<double> x(3);
+    ldlt_bk_solve(A, pivots, x, b);
+
+    double be = backward_error(Aorig, x, b);
+    REQUIRE(be < 1e-12);
+}
+
+TEST_CASE("Bunch-Kaufman on symmetric indefinite matrix", "[operation][ldlt_bk]") {
+    // Indefinite: eigenvalues +/- sqrt(5)
+    // A = {{1, 2}, {2, -1}}
+    mat::dense2D<double> A(2, 2);
+    A(0,0) = 1;  A(0,1) = 2;
+    A(1,0) = 2;  A(1,1) = -1;
+
+    mat::dense2D<double> Aorig(2, 2);
+    for (std::size_t i = 0; i < 2; ++i)
+        for (std::size_t j = 0; j < 2; ++j)
+            Aorig(i, j) = A(i, j);
+
+    bk_pivot_info pivots;
+    int info = ldlt_bk_factor(A, pivots);
+    REQUIRE(info == 0);
+
+    vec::dense_vector<double> b = {5.0, 3.0};
+    vec::dense_vector<double> x(2);
+    ldlt_bk_solve(A, pivots, x, b);
+
+    double be = backward_error(Aorig, x, b);
+    REQUIRE(be < 1e-12);
+}
+
+TEST_CASE("Bunch-Kaufman on matrix requiring 2x2 pivot", "[operation][ldlt_bk]") {
+    // Matrix where diagonal is zero but off-diagonals are large
+    // Forces 2x2 pivot selection
+    // A = {{0, 1, 0}, {1, 0, 1}, {0, 1, 0}} — singular, but
+    // Use: A = {{0, 3, 1}, {3, 0, 2}, {1, 2, 5}}
+    // A(0,0) = 0 forces a pivot swap or 2x2
+    mat::dense2D<double> A(3, 3);
+    A(0,0) = 0; A(0,1) = 3; A(0,2) = 1;
+    A(1,0) = 3; A(1,1) = 0; A(1,2) = 2;
+    A(2,0) = 1; A(2,1) = 2; A(2,2) = 5;
+
+    mat::dense2D<double> Aorig(3, 3);
+    for (std::size_t i = 0; i < 3; ++i)
+        for (std::size_t j = 0; j < 3; ++j)
+            Aorig(i, j) = A(i, j);
+
+    bk_pivot_info pivots;
+    int info = ldlt_bk_factor(A, pivots);
+    REQUIRE(info == 0);
+
+    // Check that at least one 2x2 pivot was used (negative ipiv)
+    bool has_2x2 = false;
+    for (int p : pivots.ipiv)
+        if (p < 0) has_2x2 = true;
+    REQUIRE(has_2x2);
+
+    vec::dense_vector<double> b = {4.0, 5.0, 12.0};
+    vec::dense_vector<double> x(3);
+    ldlt_bk_solve(A, pivots, x, b);
+
+    double be = backward_error(Aorig, x, b);
+    REQUIRE(be < 1e-12);
+}
+
+TEST_CASE("Bunch-Kaufman on 1x1 matrix", "[operation][ldlt_bk]") {
+    mat::dense2D<double> A(1, 1);
+    A(0, 0) = 7.0;
+
+    bk_pivot_info pivots;
+    int info = ldlt_bk_factor(A, pivots);
+    REQUIRE(info == 0);
+
+    vec::dense_vector<double> b = {21.0};
+    vec::dense_vector<double> x(1);
+    ldlt_bk_solve(A, pivots, x, b);
+    REQUIRE_THAT(x(0), Catch::Matchers::WithinAbs(3.0, 1e-12));
+}
+
+TEST_CASE("Bunch-Kaufman on 4x4 indefinite matrix", "[operation][ldlt_bk]") {
+    // Symmetric indefinite 4x4 — the type that arises in UKF covariance updates
+    mat::dense2D<double> A(4, 4);
+    A(0,0) =  2; A(0,1) =  1; A(0,2) = -1; A(0,3) =  0;
+    A(1,0) =  1; A(1,1) = -3; A(1,2) =  2; A(1,3) =  1;
+    A(2,0) = -1; A(2,1) =  2; A(2,2) =  4; A(2,3) = -2;
+    A(3,0) =  0; A(3,1) =  1; A(3,2) = -2; A(3,3) =  1;
+
+    mat::dense2D<double> Aorig(4, 4);
+    for (std::size_t i = 0; i < 4; ++i)
+        for (std::size_t j = 0; j < 4; ++j)
+            Aorig(i, j) = A(i, j);
+
+    bk_pivot_info pivots;
+    int info = ldlt_bk_factor(A, pivots);
+    REQUIRE(info == 0);
+
+    vec::dense_vector<double> b = {1.0, -2.0, 3.0, -1.0};
+    vec::dense_vector<double> x(4);
+    ldlt_bk_solve(A, pivots, x, b);
+
+    double be = backward_error(Aorig, x, b);
+    REQUIRE(be < 1e-12);
+}
+
+TEST_CASE("Bunch-Kaufman on randspd matrix", "[operation][ldlt_bk][generator]") {
+    constexpr std::size_t n = 8;
+    auto A = generators::randspd<double>(n, {16.0, 8.0, 4.0, 2.0, 1.0, 0.5, 0.25, 0.125});
+
+    mat::dense2D<double> Aorig(n, n);
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j)
+            Aorig(i, j) = A(i, j);
+
+    bk_pivot_info pivots;
+    int info = ldlt_bk_factor(A, pivots);
+    REQUIRE(info == 0);
+
+    vec::dense_vector<double> b(n, 1.0);
+    vec::dense_vector<double> x(n);
+    ldlt_bk_solve(A, pivots, x, b);
+
+    double be = backward_error(Aorig, x, b);
+    REQUIRE(be < 1e-12);
+}
+
+TEST_CASE("Bunch-Kaufman on large indefinite system", "[operation][ldlt_bk]") {
+    // Construct a symmetric indefinite matrix: diag with alternating signs
+    // plus off-diagonal coupling
+    constexpr std::size_t n = 20;
+    mat::dense2D<double> A(n, n);
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j)
+            A(i, j) = 0.0;
+
+    for (std::size_t i = 0; i < n; ++i) {
+        A(i, i) = (i % 2 == 0) ? 10.0 : -5.0;
+        if (i + 1 < n) {
+            A(i, i + 1) = 2.0;
+            A(i + 1, i) = 2.0;
+        }
+    }
+
+    mat::dense2D<double> Aorig(n, n);
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j)
+            Aorig(i, j) = A(i, j);
+
+    bk_pivot_info pivots;
+    int info = ldlt_bk_factor(A, pivots);
+    REQUIRE(info == 0);
+
+    vec::dense_vector<double> b(n, 1.0);
+    vec::dense_vector<double> x(n);
+    ldlt_bk_solve(A, pivots, x, b);
+
+    double be = backward_error(Aorig, x, b);
+    REQUIRE(be < 1e-10);
+}
+
+TEST_CASE("Bunch-Kaufman detects singular matrix", "[operation][ldlt_bk]") {
+    // Singular: A = {{0, 0}, {0, 0}}
+    mat::dense2D<double> A(2, 2);
+    A(0,0) = 0; A(0,1) = 0;
+    A(1,0) = 0; A(1,1) = 0;
+
+    bk_pivot_info pivots;
+    int info = ldlt_bk_factor(A, pivots);
+    REQUIRE(info != 0);
+}
+
+TEST_CASE("Bunch-Kaufman on empty matrix", "[operation][ldlt_bk]") {
+    mat::dense2D<double> A(0, 0);
+    bk_pivot_info pivots;
+    int info = ldlt_bk_factor(A, pivots);
+    REQUIRE(info == 0);
+}

--- a/tests/unit/operation/test_ldlt_bk.cpp
+++ b/tests/unit/operation/test_ldlt_bk.cpp
@@ -152,9 +152,42 @@ TEST_CASE("Bunch-Kaufman on 4x4 indefinite matrix", "[operation][ldlt_bk]") {
     REQUIRE(be < 1e-12);
 }
 
-TEST_CASE("Bunch-Kaufman on randspd matrix", "[operation][ldlt_bk][generator]") {
+TEST_CASE("Bunch-Kaufman on 5x5 SPD matrix", "[operation][ldlt_bk]") {
+    // Deterministic well-conditioned SPD: Lehmer matrix (small)
+    constexpr std::size_t n = 5;
+    mat::dense2D<double> A(n, n);
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j)
+            A(i, j) = double(std::min(i, j) + 1) / double(std::max(i, j) + 1);
+
+    mat::dense2D<double> Aorig(n, n);
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j)
+            Aorig(i, j) = A(i, j);
+
+    bk_pivot_info pivots;
+    int info = ldlt_bk_factor(A, pivots);
+    REQUIRE(info == 0);
+
+    vec::dense_vector<double> b(n, 1.0);
+    vec::dense_vector<double> x(n);
+    ldlt_bk_solve(A, pivots, x, b);
+
+    double be = backward_error(Aorig, x, b);
+    REQUIRE(be < 1e-12);
+}
+
+TEST_CASE("Bunch-Kaufman on 8x8 diagonally dominant SPD", "[operation][ldlt_bk]") {
+    // Deterministic: tridiagonal SPD with strong diagonal dominance
     constexpr std::size_t n = 8;
-    auto A = generators::randspd<double>(n, {16.0, 8.0, 4.0, 2.0, 1.0, 0.5, 0.25, 0.125});
+    mat::dense2D<double> A(n, n);
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j)
+            A(i, j) = 0.0;
+    for (std::size_t i = 0; i < n; ++i) {
+        A(i, i) = 10.0;
+        if (i > 0) { A(i, i-1) = -1.0; A(i-1, i) = -1.0; }
+    }
 
     mat::dense2D<double> Aorig(n, n);
     for (std::size_t i = 0; i < n; ++i)


### PR DESCRIPTION
## Summary
- Bunch-Kaufman pivoted LDL^T factorization for symmetric indefinite matrices
- P*A*P^T = L*D*L^T with block-diagonal D (1x1 and 2x2 blocks)
- Handles the case where unpivoted LDL^T fails on zero pivots and Cholesky fails on non-SPD
- Completes the factorization trilogy for UKF applications (#40, #41, #45)

## Algorithm
- Bunch-Kaufman partial pivoting with threshold alpha = (1+sqrt(17))/8
- 2x2 pivot blocks when no single diagonal is a good pivot
- LAPACK-convention ipiv encoding (positive = 1x1, negative = 2x2)
- Column-first Schur complement updates to avoid read-after-write hazards

## Changes
- `include/mtl/operation/ldlt_bk.hpp` — Bunch-Kaufman factor + solve (~230 lines)
- `include/mtl/mtl.hpp` — add umbrella include
- `tests/unit/operation/test_ldlt_bk.cpp` — 9 test cases: SPD, indefinite, 2x2 pivot, 1x1, empty, singular, randspd, large indefinite
- `tests/regression/dense/test_ldlt_bk.cpp` — randspd, Lehmer, Moler, indefinite tridiagonal at 100-1000 DOF

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| op_test_ldlt_bk | OK | 9/9 PASS (18 assertions) | OK | 9/9 PASS |
| Full suite (97 tests) | 97/97 PASS | — | — | — |

## Test plan
- [x] Tier 1 CI passes (8 platforms)
- [x] CodeRabbit review addressed
- [x] Promote to ready: `gh pr ready`

Resolves #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Bunch–Kaufman pivoted symmetric indefinite factorization and corresponding solver, enabling efficient decomposition and solution of symmetric indefinite linear systems with flexible pivot selection and block-diagonal factorization.

* **Tests**
  * Added comprehensive unit and regression test suites covering symmetric positive-definite matrices, indefinite matrices, and edge cases to validate correctness and numerical stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->