### PR TITLE
feat(operation): add eigenvector extraction to symmetric eigenvalue solver

### DIFF
--- a/include/mtl/operation/eigenvalue_symmetric.hpp
+++ b/include/mtl/operation/eigenvalue_symmetric.hpp
@@ -151,4 +151,161 @@ auto eigenvalue_symmetric(const M& A, typename M::value_type tol = 1e-10,
     return result;
 }
 
+/// Compute eigenvalues and eigenvectors of a symmetric matrix.
+/// Returns {eigenvalues, eigenvectors} where:
+///   eigenvalues:  dense_vector of size n, sorted ascending
+///   eigenvectors: dense2D of size n×n, column k = eigenvector for eigenvalues(k)
+///
+/// The algorithm accumulates similarity transforms (Householder reflectors
+/// from tridiagonalization + Givens rotations from QR iteration) into Q,
+/// so that A = Q * diag(eigenvalues) * Q^T.
+template <Matrix M>
+auto eigen_symmetric(const M& A, typename M::value_type tol = 1e-10,
+                     typename M::size_type max_iter = 0) {
+    using value_type = typename M::value_type;
+    using size_type  = typename M::size_type;
+    using std::abs;
+    using std::sqrt;
+    const size_type n = A.num_rows();
+    assert(n == A.num_cols());
+
+    struct EigenResult {
+        vec::dense_vector<value_type> eigenvalues;
+        mat::dense2D<value_type> eigenvectors;
+    };
+
+    if (n == 0) return EigenResult{vec::dense_vector<value_type>(0), mat::dense2D<value_type>(0, 0)};
+
+    if (max_iter == 0) max_iter = 30 * n;
+
+    // Copy A into T for tridiagonalization
+    mat::dense2D<value_type> T(n, n);
+    for (size_type i = 0; i < n; ++i)
+        for (size_type j = 0; j < n; ++j)
+            T(i, j) = A(i, j);
+
+    // Initialize Q = I (will accumulate all transforms)
+    mat::dense2D<value_type> Q(n, n);
+    for (size_type i = 0; i < n; ++i)
+        for (size_type j = 0; j < n; ++j)
+            Q(i, j) = (i == j) ? math::one<value_type>() : math::zero<value_type>();
+
+    // === Phase 1: Tridiagonalize via Householder, accumulating into Q ===
+    if (n >= 3) {
+        size_type k = n - 2;
+        for (size_type j = 0; j < k; ++j) {
+            // Extract column T(j+1:n-1, j)
+            size_type len = n - j - 1;
+            vec::dense_vector<value_type> col(len);
+            for (size_type i = 0; i < len; ++i)
+                col(i) = T(j + 1 + i, j);
+
+            auto [v, beta] = householder(col);
+
+            // Apply from left: T = (I - beta*v*v^T) * T
+            apply_householder_left(T, v, beta, j + 1, j);
+            // Apply from right: T = T * (I - beta*v*v^T)
+            apply_householder_right(T, v, beta, 0, j + 1);
+
+            // Accumulate into Q: Q = Q * (I - beta*v*v^T)
+            apply_householder_right(Q, v, beta, 0, j + 1);
+        }
+    }
+
+    // Extract diagonal (d) and subdiagonal (e) from tridiagonal T
+    vec::dense_vector<value_type> d(n), e(n);
+    for (size_type i = 0; i < n; ++i)
+        d(i) = T(i, i);
+    for (size_type i = 0; i + 1 < n; ++i)
+        e(i) = T(i + 1, i);
+    e(n - 1) = math::zero<value_type>();
+
+    // === Phase 2: Implicit QR iteration, accumulating Givens rotations into Q ===
+    for (size_type iter = 0; iter < max_iter; ++iter) {
+        size_type p = 0;
+        size_type q = 0;
+
+        // Find trailing block of zeros (converged eigenvalues)
+        for (size_type i = n; i > 1; --i) {
+            if (abs(e(i - 2)) > tol * (abs(d(i - 2)) + abs(d(i - 1)))) break;
+            e(i - 2) = math::zero<value_type>();
+            q++;
+        }
+        if (q >= n - 1) break;
+
+        size_type end = n - q;
+
+        // Find start of active block
+        for (size_type i = end - 1; i > 0; --i) {
+            if (abs(e(i - 1)) <= tol * (abs(d(i - 1)) + abs(d(i)))) {
+                e(i - 1) = math::zero<value_type>();
+                p = i;
+                break;
+            }
+        }
+
+        if (end - p < 2) continue;
+
+        // Wilkinson shift
+        value_type a = d(end - 2);
+        value_type b = e(end - 2);
+        value_type c = d(end - 1);
+        value_type delta = (a - c) / value_type(2);
+        value_type sign_delta = (delta >= 0) ? value_type(1) : value_type(-1);
+        value_type mu = c - b * b / (delta + sign_delta * sqrt(delta * delta + b * b));
+
+        // Implicit QR step with Givens rotations
+        value_type x = d(p) - mu;
+        value_type z = e(p);
+
+        for (size_type k = p; k + 1 < end; ++k) {
+            value_type r = sqrt(x * x + z * z);
+            value_type cs = x / r;
+            value_type sn = z / r;
+
+            if (k > p) e(k - 1) = r;
+
+            value_type d0 = d(k);
+            value_type d1 = d(k + 1);
+            value_type ek = e(k);
+
+            d(k)     = cs * cs * d0 + value_type(2) * cs * sn * ek + sn * sn * d1;
+            d(k + 1) = sn * sn * d0 - value_type(2) * cs * sn * ek + cs * cs * d1;
+            e(k)     = cs * sn * (d1 - d0) + (cs * cs - sn * sn) * ek;
+
+            if (k + 2 < end) {
+                x = e(k);
+                z = sn * e(k + 1);
+                e(k + 1) *= cs;
+            }
+
+            // Accumulate Givens rotation into Q: Q = Q * G(k, k+1, theta)
+            // Q(:,k) and Q(:,k+1) updated
+            for (size_type i = 0; i < n; ++i) {
+                value_type qik  = Q(i, k);
+                value_type qik1 = Q(i, k + 1);
+                Q(i, k)     = cs * qik + sn * qik1;
+                Q(i, k + 1) = -sn * qik + cs * qik1;
+            }
+        }
+    }
+
+    // === Phase 3: Sort eigenvalues and reorder eigenvectors to match ===
+    std::vector<std::pair<value_type, size_type>> eig_idx(n);
+    for (size_type i = 0; i < n; ++i)
+        eig_idx[i] = {d(i), i};
+    std::sort(eig_idx.begin(), eig_idx.end());
+
+    vec::dense_vector<value_type> eigenvalues(n);
+    mat::dense2D<value_type> eigenvectors(n, n);
+    for (size_type k = 0; k < n; ++k) {
+        eigenvalues(k) = eig_idx[k].first;
+        size_type orig = eig_idx[k].second;
+        for (size_type i = 0; i < n; ++i)
+            eigenvectors(i, k) = Q(i, orig);
+    }
+
+    return EigenResult{eigenvalues, eigenvectors};
+}
+
 } // namespace mtl

--- a/tests/unit/operation/test_eigen_symmetric.cpp
+++ b/tests/unit/operation/test_eigen_symmetric.cpp
@@ -1,0 +1,177 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <cmath>
+#include <cstddef>
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/operation/eigenvalue_symmetric.hpp>
+#include <mtl/operation/operators.hpp>
+#include <mtl/operation/norms.hpp>
+#include <mtl/operation/trans.hpp>
+#include <mtl/math/identity.hpp>
+
+using namespace mtl;
+
+// Helper: max eigenpair residual ||Av - λv|| / (||A|| * ||v||)
+static double max_eigenpair_residual(const mat::dense2D<double>& A,
+                                      const vec::dense_vector<double>& eigs,
+                                      const mat::dense2D<double>& V) {
+    std::size_t n = A.num_rows();
+    double Anorm = frobenius_norm(A);
+    double max_res = 0.0;
+    for (std::size_t k = 0; k < n; ++k) {
+        // Compute Av - λv
+        double res_sq = 0.0;
+        double v_sq = 0.0;
+        for (std::size_t i = 0; i < n; ++i) {
+            double Av_i = 0.0;
+            for (std::size_t j = 0; j < n; ++j)
+                Av_i += A(i, j) * V(j, k);
+            double ri = Av_i - eigs(k) * V(i, k);
+            res_sq += ri * ri;
+            v_sq += V(i, k) * V(i, k);
+        }
+        double res = std::sqrt(res_sq) / (Anorm * std::sqrt(v_sq));
+        if (res > max_res) max_res = res;
+    }
+    return max_res;
+}
+
+// Helper: orthonormality error ||V^T V - I||_F
+static double orthonormality_error(const mat::dense2D<double>& V) {
+    std::size_t n = V.num_rows();
+    auto VtV = trans(V) * V;
+    double err = 0.0;
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j) {
+            double expected = (i == j) ? 1.0 : 0.0;
+            double d = VtV(i, j) - expected;
+            err += d * d;
+        }
+    return std::sqrt(err);
+}
+
+TEST_CASE("eigen_symmetric: 2x2 diagonal matrix", "[operation][eigen]") {
+    mat::dense2D<double> A(2, 2);
+    A(0,0) = 3; A(0,1) = 0;
+    A(1,0) = 0; A(1,1) = 1;
+
+    auto [eigs, V] = eigen_symmetric(A);
+
+    REQUIRE(eigs.size() == 2);
+    REQUIRE_THAT(eigs(0), Catch::Matchers::WithinAbs(1.0, 1e-10));
+    REQUIRE_THAT(eigs(1), Catch::Matchers::WithinAbs(3.0, 1e-10));
+
+    REQUIRE(orthonormality_error(V) < 1e-12);
+    REQUIRE(max_eigenpair_residual(A, eigs, V) < 1e-12);
+}
+
+TEST_CASE("eigen_symmetric: 3x3 SPD matrix", "[operation][eigen]") {
+    mat::dense2D<double> A(3, 3);
+    A(0,0) = 4; A(0,1) = 2; A(0,2) = 1;
+    A(1,0) = 2; A(1,1) = 5; A(1,2) = 3;
+    A(2,0) = 1; A(2,1) = 3; A(2,2) = 6;
+
+    auto [eigs, V] = eigen_symmetric(A);
+
+    REQUIRE(eigs.size() == 3);
+    // Eigenvalues should be positive (SPD)
+    for (std::size_t i = 0; i < 3; ++i)
+        REQUIRE(eigs(i) > 0.0);
+
+    // Sorted ascending
+    for (std::size_t i = 0; i + 1 < 3; ++i)
+        REQUIRE(eigs(i) <= eigs(i + 1));
+
+    // Sum of eigenvalues = trace
+    double trace = A(0,0) + A(1,1) + A(2,2);
+    double eig_sum = eigs(0) + eigs(1) + eigs(2);
+    REQUIRE_THAT(eig_sum, Catch::Matchers::WithinAbs(trace, 1e-10));
+
+    REQUIRE(orthonormality_error(V) < 1e-12);
+    REQUIRE(max_eigenpair_residual(A, eigs, V) < 1e-12);
+}
+
+TEST_CASE("eigen_symmetric: spectral reconstruction A = V*Lambda*V^T", "[operation][eigen]") {
+    mat::dense2D<double> A(3, 3);
+    A(0,0) = 2; A(0,1) = 1; A(0,2) = 0;
+    A(1,0) = 1; A(1,1) = 3; A(1,2) = 1;
+    A(2,0) = 0; A(2,1) = 1; A(2,2) = 4;
+
+    auto [eigs, V] = eigen_symmetric(A);
+
+    // Reconstruct: A_rec = V * diag(eigs) * V^T
+    std::size_t n = 3;
+    mat::dense2D<double> Lambda(n, n);
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j)
+            Lambda(i, j) = (i == j) ? eigs(i) : 0.0;
+
+    auto A_rec = V * Lambda * trans(V);
+
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j)
+            REQUIRE_THAT(A_rec(i, j), Catch::Matchers::WithinAbs(A(i, j), 1e-10));
+}
+
+TEST_CASE("eigen_symmetric: 1x1 matrix", "[operation][eigen]") {
+    mat::dense2D<double> A(1, 1);
+    A(0, 0) = 7.5;
+
+    auto [eigs, V] = eigen_symmetric(A);
+
+    REQUIRE(eigs.size() == 1);
+    REQUIRE_THAT(eigs(0), Catch::Matchers::WithinAbs(7.5, 1e-12));
+    REQUIRE_THAT(V(0, 0), Catch::Matchers::WithinAbs(1.0, 1e-12));
+}
+
+TEST_CASE("eigen_symmetric: 4x4 with known eigenvalues", "[operation][eigen]") {
+    // Diagonal: eigenvalues are the diagonal entries
+    mat::dense2D<double> A(4, 4);
+    for (std::size_t i = 0; i < 4; ++i)
+        for (std::size_t j = 0; j < 4; ++j)
+            A(i, j) = 0.0;
+    A(0,0) = 10; A(1,1) = 1; A(2,2) = 5; A(3,3) = 3;
+
+    auto [eigs, V] = eigen_symmetric(A);
+
+    REQUIRE_THAT(eigs(0), Catch::Matchers::WithinAbs(1.0, 1e-10));
+    REQUIRE_THAT(eigs(1), Catch::Matchers::WithinAbs(3.0, 1e-10));
+    REQUIRE_THAT(eigs(2), Catch::Matchers::WithinAbs(5.0, 1e-10));
+    REQUIRE_THAT(eigs(3), Catch::Matchers::WithinAbs(10.0, 1e-10));
+
+    REQUIRE(orthonormality_error(V) < 1e-12);
+    REQUIRE(max_eigenpair_residual(A, eigs, V) < 1e-12);
+}
+
+TEST_CASE("eigen_symmetric: 6x6 Lehmer matrix", "[operation][eigen]") {
+    constexpr std::size_t n = 6;
+    mat::dense2D<double> A(n, n);
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j)
+            A(i, j) = double(std::min(i, j) + 1) / double(std::max(i, j) + 1);
+
+    auto [eigs, V] = eigen_symmetric(A);
+
+    // All eigenvalues positive (Lehmer is SPD)
+    for (std::size_t i = 0; i < n; ++i)
+        REQUIRE(eigs(i) > 0.0);
+
+    double tol = double(n) * 1e-14;
+    REQUIRE(orthonormality_error(V) < tol);
+    REQUIRE(max_eigenpair_residual(A, eigs, V) < tol);
+}
+
+TEST_CASE("eigen_symmetric: backward compat eigenvalue_symmetric still works", "[operation][eigen]") {
+    mat::dense2D<double> A(3, 3);
+    A(0,0) = 4; A(0,1) = 2; A(0,2) = 1;
+    A(1,0) = 2; A(1,1) = 5; A(1,2) = 3;
+    A(2,0) = 1; A(2,1) = 3; A(2,2) = 6;
+
+    auto eigs = eigenvalue_symmetric(A);
+    REQUIRE(eigs.size() == 3);
+    double trace = 15.0;
+    double sum = eigs(0) + eigs(1) + eigs(2);
+    REQUIRE_THAT(sum, Catch::Matchers::WithinAbs(trace, 1e-10));
+}


### PR DESCRIPTION
## Summary
- Add `eigen_symmetric(A)` returning `{eigenvalues, eigenvectors}` via structured binding
- Accumulates Householder reflectors (tridiagonalization) and Givens rotations (QR iteration) into orthogonal Q
- Existing `eigenvalue_symmetric()` (values only) kept for backward compatibility

## Algorithm
1. Tridiagonalize via Householder, accumulating reflectors into Q (initialized to I)
2. Implicit QR iteration with Wilkinson shift, accumulating Givens rotations into Q
3. Sort eigenvalues ascending, reorder Q columns to match

## Changes
- `include/mtl/operation/eigenvalue_symmetric.hpp` — add `eigen_symmetric()` function (~130 lines)
- `tests/unit/operation/test_eigen_symmetric.cpp` — 7 test cases: diagonal, SPD, spectral reconstruction, 1x1, known eigenvalues, Lehmer, backward compatibility

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| op_test_eigen_symmetric | OK | 7/7 PASS (42 assertions) | OK | 7/7 PASS |
| Full suite (98 tests) | 98/98 PASS | — | — | — |

## Test plan
- [x] Tier 1 CI passes (8 platforms)
- [ ] CodeRabbit review addressed
- [ ] Promote to ready: `gh pr ready`

Resolves #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Symmetric matrix eigensystem computation now fully supported. The library can now compute both eigenvalues and corresponding eigenvectors for symmetric matrices. The computed eigenvalues are automatically sorted in ascending order with matching eigenvectors.

* **Tests**
  * Added comprehensive test coverage for the new functionality, validating results across multiple matrix configurations and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->