### PR TITLE
fix(examples): replace Unicode characters with ASCII for Windows console

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -29,7 +29,7 @@ All examples are auto-discovered by CMake. Each `.cpp` file produces a target na
 
 ## phase01_core_types/
 
-**Vectors, matrices, and the C++20 concept system.** Introduces the fundamental data types — dense vectors, dense matrices, and sparse matrices via the RAII inserter pattern. Demonstrates the concept hierarchy (`Scalar`, `Field`, `OrderedField`, `Matrix`, `Vector`, `DenseMatrix`, `SparseMatrix`) and the category traits that drive compile-time dispatch. Shows how custom number types plug into MTL5 by satisfying the same concepts.
+**Vectors, matrices, and the C++20 concept system.** Introduces the fundamental data types -- dense vectors, dense matrices, and sparse matrices via the RAII inserter pattern. Demonstrates the concept hierarchy (`Scalar`, `Field`, `OrderedField`, `Matrix`, `Vector`, `DenseMatrix`, `SparseMatrix`) and the category traits that drive compile-time dispatch. Shows how custom number types plug into MTL5 by satisfying the same concepts.
 
 | Example | Description |
 |---------|-------------|
@@ -56,13 +56,13 @@ All examples are auto-discovered by CMake. Each `.cpp` file produces a target na
 | Example | Description |
 |---------|-------------|
 | `heat_equation_1d.cpp` | 1D steady-state heat equation solved by CG (SPD system) |
-| `convection_diffusion.cpp` | Non-symmetric system from convection — CG fails, BiCGSTAB succeeds |
+| `convection_diffusion.cpp` | Non-symmetric system from convection -- CG fails, BiCGSTAB succeeds |
 
 ---
 
 ## phase04_sparse_assembly/
 
-**2D sparse assembly and stationary iterative methods.** Scales up to two dimensions with the 5-point Laplacian stencil, assembling larger sparse systems with the compressed2D inserter. Introduces GMRES for non-symmetric systems and compares classical smoothers — Jacobi, Gauss-Seidel, and SOR — showing how relaxation parameters affect convergence.
+**2D sparse assembly and stationary iterative methods.** Scales up to two dimensions with the 5-point Laplacian stencil, assembling larger sparse systems with the compressed2D inserter. Introduces GMRES for non-symmetric systems and compares classical smoothers -- Jacobi, Gauss-Seidel, and SOR -- showing how relaxation parameters affect convergence.
 
 | Example | Description |
 |---------|-------------|
@@ -95,7 +95,7 @@ All examples are auto-discovered by CMake. Each `.cpp` file produces a target na
 
 ## phase07_sparse_formats/
 
-**Sparse storage formats and structured matrix views.** Compares COO (coordinate), CRS (compressed row), and ELLPACK storage with their space/time tradeoffs. Introduces structured views — Hermitian, banded, upper/lower triangular — that reinterpret existing storage without copying data.
+**Sparse storage formats and structured matrix views.** Compares COO (coordinate), CRS (compressed row), and ELLPACK storage with their space/time tradeoffs. Introduces structured views -- Hermitian, banded, upper/lower triangular -- that reinterpret existing storage without copying data.
 
 | Example | Description |
 |---------|-------------|
@@ -129,7 +129,7 @@ All examples are auto-discovered by CMake. Each `.cpp` file produces a target na
 
 ## phase10_matrix_views/
 
-**Triangular views and permutation matrices.** Demonstrates extracting upper, lower, strict-upper, and strict-lower views from matrices — essential for working with LU and Cholesky factors. Shows permutation matrices for row/column reordering with O(n) matvec.
+**Triangular views and permutation matrices.** Demonstrates extracting upper, lower, strict-upper, and strict-lower views from matrices -- essential for working with LU and Cholesky factors. Shows permutation matrices for row/column reordering with O(n) matvec.
 
 | Example | Description |
 |---------|-------------|
@@ -151,7 +151,7 @@ All examples are auto-discovered by CMake. Each `.cpp` file produces a target na
 
 ## phase12_transcendental_functions/
 
-**Element-wise transcendental operations for applied mathematics.** Applies MTL5's vectorized math functions — exp, log, sin, cos, tanh, erf — to real-world domains: signal processing (modulated waveforms, spectral analysis), neural network activation functions (sigmoid, ReLU, GELU), radioactive decay chains, and coordinate transformations in 2D/3D geometry.
+**Element-wise transcendental operations for applied mathematics.** Applies MTL5's vectorized math functions -- exp, log, sin, cos, tanh, erf -- to real-world domains: signal processing (modulated waveforms, spectral analysis), neural network activation functions (sigmoid, ReLU, GELU), radioactive decay chains, and coordinate transformations in 2D/3D geometry.
 
 | Example | Description |
 |---------|-------------|
@@ -164,7 +164,7 @@ All examples are auto-discovered by CMake. Each `.cpp` file produces a target na
 
 ## phase13_krylov_multigrid/
 
-**Advanced iterative solvers: Krylov subspace methods and multigrid.** Compares Krylov solvers — CGS, QMR, TFQMR, IDR(s) — on non-symmetric sparse systems, showing convergence characteristics and breakdown behavior. Demonstrates geometric multigrid with restriction, prolongation, and V-cycle smoothing for the 1D Poisson equation.
+**Advanced iterative solvers: Krylov subspace methods and multigrid.** Compares Krylov solvers -- CGS, QMR, TFQMR, IDR(s) -- on non-symmetric sparse systems, showing convergence characteristics and breakdown behavior. Demonstrates geometric multigrid with restriction, prolongation, and V-cycle smoothing for the 1D Poisson equation.
 
 | Example | Description |
 |---------|-------------|
@@ -186,7 +186,7 @@ All examples are auto-discovered by CMake. Each `.cpp` file produces a target na
 
 ## phase15_sparse_direct/
 
-**Sparse direct solvers with unified dispatch.** The culmination of MTL5's sparse direct solver infrastructure: native Cholesky (LL^T), LU (PA=LU with pivoting), and QR (Householder) factorizations with AMD and COLAMD fill-reducing orderings. Demonstrates the unified dispatch that automatically selects the best backend — SuiteSparse (UMFPACK, CHOLMOD, SPQR) for production `double` systems, native solvers for custom number types. Shows fill-in reduction from different orderings on a 2D Laplacian.
+**Sparse direct solvers with unified dispatch.** The culmination of MTL5's sparse direct solver infrastructure: native Cholesky (LL^T), LU (PA=LU with pivoting), and QR (Householder) factorizations with AMD and COLAMD fill-reducing orderings. Demonstrates the unified dispatch that automatically selects the best backend -- SuiteSparse (UMFPACK, CHOLMOD, SPQR) for production `double` systems, native solvers for custom number types. Shows fill-in reduction from different orderings on a 2D Laplacian.
 
 | Example | Description |
 |---------|-------------|

--- a/examples/phase01_core_types/concepts_and_traits.cpp
+++ b/examples/phase01_core_types/concepts_and_traits.cpp
@@ -1,4 +1,4 @@
-// concepts_and_traits.cpp — C++20 Concepts and Type Traits in MTL5
+// concepts_and_traits.cpp -- C++20 Concepts and Type Traits in MTL5
 //
 // This example demonstrates the concept hierarchy and type trait system
 // that enables MTL5's generic programming model:
@@ -45,9 +45,9 @@ int main() {
     // ---- Scalar concept hierarchy ----
     std::cout << "1. Scalar Concept Hierarchy\n\n";
 
-    std::cout << "   Scalar<T> — arithmetic ops (+, -, *, unary-, zero)\n";
-    std::cout << "   Field<T>  — Scalar + division\n";
-    std::cout << "   OrderedField<T> — Field + total ordering (<, >, <=, >=)\n\n";
+    std::cout << "   Scalar<T> -- arithmetic ops (+, -, *, unary-, zero)\n";
+    std::cout << "   Field<T>  -- Scalar + division\n";
+    std::cout << "   OrderedField<T> -- Field + total ordering (<, >, <=, >=)\n\n";
 
     std::cout << "   Built-in types:\n";
     std::cout << "     Scalar<int>:    " << std::boolalpha << Scalar<int> << '\n';
@@ -70,11 +70,11 @@ int main() {
     // ---- Matrix/Vector concepts ----
     std::cout << "\n2. Matrix and Vector Concepts\n\n";
 
-    std::cout << "   Collection<T> — has value_type, size_type, size()\n";
-    std::cout << "   Vector<T>     — Collection + v(i) access\n";
-    std::cout << "   Matrix<T>     — Collection + m(r,c), num_rows, num_cols\n";
-    std::cout << "   DenseMatrix<T>  — Matrix + category == tag::dense\n";
-    std::cout << "   SparseMatrix<T> — Matrix + category == tag::sparse\n\n";
+    std::cout << "   Collection<T> -- has value_type, size_type, size()\n";
+    std::cout << "   Vector<T>     -- Collection + v(i) access\n";
+    std::cout << "   Matrix<T>     -- Collection + m(r,c), num_rows, num_cols\n";
+    std::cout << "   DenseMatrix<T>  -- Matrix + category == tag::dense\n";
+    std::cout << "   SparseMatrix<T> -- Matrix + category == tag::sparse\n\n";
 
     using DenseVec  = vec::dense_vector<double>;
     using DenseMat  = mat::dense2D<double>;
@@ -102,9 +102,9 @@ int main() {
               << std::is_same_v<traits::category_t<SparseMat>, tag::sparse> << '\n';
 
     std::cout << "\n   These traits drive if-constexpr dispatch in operations:\n";
-    std::cout << "   - Dense float/double → BLAS/LAPACK when available\n";
-    std::cout << "   - Sparse float/double → SuiteSparse when available\n";
-    std::cout << "   - Any type → generic template implementation\n";
+    std::cout << "   - Dense float/double -> BLAS/LAPACK when available\n";
+    std::cout << "   - Sparse float/double -> SuiteSparse when available\n";
+    std::cout << "   - Any type -> generic template implementation\n";
 
     // ---- Mixed-type expressions ----
     std::cout << "\n4. Mixed-Type Expressions\n\n";
@@ -115,9 +115,9 @@ int main() {
 
     vec::dense_vector<double> x_dbl = {1.5, 2.5};
 
-    // int matrix * double vector → double result (via std::common_type)
+    // int matrix * double vector -> double result (via std::common_type)
     auto y = A_int * x_dbl;
-    std::cout << "   int matrix * double vector → double result:\n";
+    std::cout << "   int matrix * double vector -> double result:\n";
     std::cout << "   [1 2] * [1.5] = [" << y(0) << "]\n";
     std::cout << "   [3 4]   [2.5]   [" << y(1) << "]\n";
 

--- a/examples/phase01_core_types/vectors_and_matrices.cpp
+++ b/examples/phase01_core_types/vectors_and_matrices.cpp
@@ -1,4 +1,4 @@
-// vectors_and_matrices.cpp — Dense Vectors and Matrices: The Building Blocks
+// vectors_and_matrices.cpp -- Dense Vectors and Matrices: The Building Blocks
 //
 // This example demonstrates the core data types of MTL5:
 //   - Dense vectors (column and row orientation)
@@ -13,7 +13,7 @@
 int main() {
     using namespace mtl;
 
-    std::cout << "MTL5 Phase 1: Core Types — Vectors and Matrices\n";
+    std::cout << "MTL5 Phase 1: Core Types -- Vectors and Matrices\n";
     std::cout << "================================================\n\n";
 
     // ---- Dense Vectors ----

--- a/examples/phase02_basic_operations/matrix_arithmetic.cpp
+++ b/examples/phase02_basic_operations/matrix_arithmetic.cpp
@@ -1,4 +1,4 @@
-// matrix_arithmetic.cpp — Matrix Addition, Scaling, and Matrix-Matrix Multiply
+// matrix_arithmetic.cpp -- Matrix Addition, Scaling, and Matrix-Matrix Multiply
 //
 // This example demonstrates matrix-level arithmetic operations:
 //   - Matrix addition and subtraction (expression templates)
@@ -44,7 +44,7 @@ int main() {
     print_dense("A", A);
     print_dense("B (10*I)", B);
 
-    auto C = A + B;  // expression template — evaluated when assigned
+    auto C = A + B;  // expression template -- evaluated when assigned
     mat::dense2D<double> C_mat = C;
     print_dense("A + B", C_mat);
 
@@ -128,7 +128,7 @@ int main() {
 
     std::cout << "   Dense  A*x = [" << y_d(0) << ", " << y_d(1) << ", " << y_d(2) << "]\n";
     std::cout << "   Sparse A*x = [" << y_s(0) << ", " << y_s(1) << ", " << y_s(2) << "]\n";
-    std::cout << "   (Identical results — same algorithm, different storage)\n";
+    std::cout << "   (Identical results -- same algorithm, different storage)\n";
 
     std::cout << '\n';
     return 0;

--- a/examples/phase02_basic_operations/norms_and_products.cpp
+++ b/examples/phase02_basic_operations/norms_and_products.cpp
@@ -1,4 +1,4 @@
-// norms_and_products.cpp — Vector Norms, Dot Products, and Matrix-Vector Multiply
+// norms_and_products.cpp -- Vector Norms, Dot Products, and Matrix-Vector Multiply
 //
 // This example demonstrates the fundamental numerical operations:
 //   - Vector norms: one_norm, two_norm, infinity_norm

--- a/examples/phase15_sparse_direct/sparse_direct_solvers.cpp
+++ b/examples/phase15_sparse_direct/sparse_direct_solvers.cpp
@@ -3,9 +3,9 @@
 // This example demonstrates MTL5's unified solve dispatch, which
 // automatically selects the best solver backend at compile time:
 //
-//   Sparse double + SuiteSparse → external solver (UMFPACK, CHOLMOD, SPQR)
-//   Sparse (any type)           → native solver + fill-reducing ordering
-//   Dense                       → dense factorization (with optional LAPACK)
+//   Sparse double + SuiteSparse -> external solver (UMFPACK, CHOLMOD, SPQR)
+//   Sparse (any type)           -> native solver + fill-reducing ordering
+//   Dense                       -> dense factorization (with optional LAPACK)
 //
 // The user writes one function call. The compiler picks the backend.
 
@@ -380,7 +380,7 @@ void demo_backend_summary() {
 // ---------------------------------------------------------------------------
 
 int main() {
-    std::cout << "MTL5 Sparse Direct Solvers — Unified Dispatch Demo\n";
+    std::cout << "MTL5 Sparse Direct Solvers -- Unified Dispatch Demo\n";
     std::cout << "==================================================\n\n";
 
     demo_unified_solve();

--- a/examples/ukf_bearing_only/README.md
+++ b/examples/ukf_bearing_only/README.md
@@ -14,7 +14,7 @@ Bearing-only measurements create extreme eigenvalue spread in P:
 - **Large eigenvalue**: along the line of sight (unobserved)
 
 After a few updates with R = 1e-4 (tight bearing), cond(P) can reach 10^6
-in double, 10^3 in float — exactly where Cholesky starts failing silently.
+in double, 10^3 in float -- exactly where Cholesky starts failing silently.
 
 ## The Silent Killer: Sigma-Point Mean Bias
 

--- a/examples/ukf_bearing_only/bearing_only_ukf.cpp
+++ b/examples/ukf_bearing_only/bearing_only_ukf.cpp
@@ -1,4 +1,4 @@
-// bearing_only_ukf.cpp — Bearing-only UKF stress test: Cholesky vs LDL^T
+// bearing_only_ukf.cpp -- Bearing-only UKF stress test: Cholesky vs LDL^T
 //
 // The canonical ill-conditioning generator for UKF sigma point factorization:
 // a 2D tracker with bearing-only measurements. The bearing direction is
@@ -75,7 +75,7 @@ struct Rng {
 };
 
 // ============================================================================
-// Bearing-only UKF — templated over Scalar
+// Bearing-only UKF -- templated over Scalar
 // ============================================================================
 
 static constexpr std::size_t NX = 4;  // [px, py, vx, vy]
@@ -238,13 +238,13 @@ bool generate_sigma_ldlt(
     }
 
     // Sigma = x +/- gamma * L * sqrt(D(k)) * e_k
-    // Negative D(k) means P is indefinite — report failure rather than
+    // Negative D(k) means P is indefinite -- report failure rather than
     // silently using abs(D(k)), which would produce sigma points for
     // L|D|L^T instead of P. This keeps the comparison fair: LDL^T
     // detects the problem; the caller decides how to recover.
     sigma[0] = x;
     for (std::size_t k = 0; k < NX; ++k) {
-        if (D(k) <= T(0)) return false;  // indefinite pivot — fail cleanly
+        if (D(k) <= T(0)) return false;  // indefinite pivot -- fail cleanly
         using std::sqrt;
         T sqrtDk = sqrt(D(k));
         vec::dense_vector<T> sp(NX), sm(NX);
@@ -320,7 +320,7 @@ std::vector<StepResult> run_bearing_only_ukf(int num_steps) {
     x_true(0) = T(0); x_true(1) = T(5);
     x_true(2) = T(2); x_true(3) = T(-0.5);
 
-    // Process noise (small — we want P conditioning to be driven by measurements)
+    // Process noise (small -- we want P conditioning to be driven by measurements)
     mat::dense2D<T> Q(NX, NX);
     for (std::size_t i = 0; i < NX; ++i)
         for (std::size_t j = 0; j < NX; ++j)
@@ -591,10 +591,10 @@ int main() {
               << "             range direction stays large -> extreme cond(P)\n"
               << "\n"
               << "Diagnostics:\n"
-              << "  cond(P)    — eigenvalue ratio (higher = harder)\n"
-              << "  Chol/LDLT  — did the factorization succeed?\n"
-              << "  bias       — sigma-point mean asymmetry (the silent killer)\n"
-              << "  resid      — ||P - reconstruct|| / ||P||\n";
+              << "  cond(P)    -- eigenvalue ratio (higher = harder)\n"
+              << "  Chol/LDLT  -- did the factorization succeed?\n"
+              << "  bias       -- sigma-point mean asymmetry (the silent killer)\n"
+              << "  resid      -- ||P - reconstruct|| / ||P||\n";
 
     constexpr int num_steps = 15;
 

--- a/examples/ukf_cholesky_vs_ldlt/ukf_comparison.cpp
+++ b/examples/ukf_cholesky_vs_ldlt/ukf_comparison.cpp
@@ -1,11 +1,11 @@
-// ukf_comparison.cpp — UKF numerical stability: Cholesky vs LDL^T
+// ukf_comparison.cpp -- UKF numerical stability: Cholesky vs LDL^T
 //
 // Demonstrates that the LDL^T (square-root-free Cholesky) decomposition
 // provides superior numerical stability for Unscented Kalman Filter sigma
 // point generation when the state covariance becomes ill-conditioned.
 //
 // System model:
-//   State: [px, py, vx, vy]^T — 2D position + velocity
+//   State: [px, py, vx, vy]^T -- 2D position + velocity
 //   Process: constant velocity with quadratic drag
 //   Measurement: range + bearing from a known beacon
 //
@@ -111,7 +111,7 @@ static double ldlt_residual(const mat::dense2D<double>& P) {
 }
 
 // ============================================================================
-// Simple pseudo-random number generator (Xoshiro128+ — no external deps)
+// Simple pseudo-random number generator (Xoshiro128+ -- no external deps)
 // ============================================================================
 
 struct Rng {
@@ -516,7 +516,7 @@ static void print_row(int step,
 {
     std::cout << std::setw(6) << step;
 
-    // Condition number (from LDLT — it runs longer when Cholesky diverges)
+    // Condition number (from LDLT -- it runs longer when Cholesky diverges)
     if (idx < ldlt.cond_P.size())
         std::cout << std::setw(14) << std::scientific << std::setprecision(2) << ldlt.cond_P[idx];
     else if (idx < chol.cond_P.size())
@@ -613,7 +613,7 @@ int main() {
               << "State:       [px, py, vx, vy] (4-state 2D tracking)\n"
               << "Process:     constant velocity + quadratic drag\n"
               << "Measurement: range + bearing from beacon at (10, 0)\n"
-              << "Key knob:    measurement noise R — smaller R drives P ill-conditioned\n"
+              << "Key knob:    measurement noise R -- smaller R drives P ill-conditioned\n"
               << "\n";
 
     constexpr int num_steps = 200;


### PR DESCRIPTION
## Summary
- Replace em dashes (U+2014 `--`) with `--` and right arrows (U+2192 `->`) with `->` across all example files
- The standard Windows console (cmd.exe, PowerShell) does not render these Unicode characters correctly

## Changes
9 files, 47 substitutions (character-for-character, no logic changes):
- `examples/README.md`
- `examples/phase01_core_types/concepts_and_traits.cpp`
- `examples/phase01_core_types/vectors_and_matrices.cpp`
- `examples/phase02_basic_operations/matrix_arithmetic.cpp`
- `examples/phase02_basic_operations/norms_and_products.cpp`
- `examples/phase15_sparse_direct/sparse_direct_solvers.cpp`
- `examples/ukf_bearing_only/bearing_only_ukf.cpp`
- `examples/ukf_bearing_only/README.md`
- `examples/ukf_cholesky_vs_ldlt/ukf_comparison.cpp`

## Test plan
- [x] 98/98 tests pass locally
- [x] Tier 1 CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized punctuation formatting across documentation and code comments for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->