### PR TITLE
fix(docs): remove LaTeX from H1 heading that becomes frontmatter title

### DIFF
--- a/docs/examples/ukf-cholesky-vs-ldlt.md
+++ b/docs/examples/ukf-cholesky-vs-ldlt.md
@@ -1,4 +1,4 @@
-# UKF Numerical Stability: Cholesky vs $LDL^T$ Decomposition
+# UKF Numerical Stability: Cholesky vs LDL^T Decomposition
 
 The Unscented Kalman Filter (UKF) generates sigma points from the state covariance matrix $P$ at every time step. This requires a matrix factorization that serves as a "square root" of $P$. The choice of factorization has a direct impact on filter stability, particularly when $P$ becomes ill-conditioned after informative observations.
 


### PR DESCRIPTION
## Root Cause

The sync pipeline (`sync-content.mjs`) extracts the H1 heading from each markdown file and places it into YAML frontmatter as the `title` field. Starlight renders frontmatter titles as **plain text** in:
- The page `<h1>` tag
- The sidebar navigation  
- The browser `<title>` tab
- Open Graph metadata

The remark-math/rehype-katex pipeline only processes the **document body**, not YAML frontmatter fields. So `$LDL^T$` in the title renders literally as `$LDL^T$` instead of math.

## Fix

Replace `$LDL^T$` with plain text `LDL^T` in the H1 heading. LaTeX notation is used throughout the body text where it renders correctly.

## Rule going forward

Keep H1 headings (which become page titles) in plain ASCII text. Use LaTeX `$...$` and `$$...$$` only in the document body.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated formatting in the UKF Cholesky vs LDL^T Decomposition documentation example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->