### PR TITLE
chore: remove non-ASCII (multibyte) characters from C++ source files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,28 @@ on:
     branches: [ main ]
 
 jobs:
-  # ── Tier 1: Fast unit tests on all platforms (~2 min) ───────────────
+  # -- ASCII guard: source files must contain only ASCII bytes ---------
+  # Fails fast if any C++ source under include/, tests/, examples/
+  # introduces non-ASCII (multibyte) characters.
+  ascii-check:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check for non-ASCII characters in source
+        run: |
+          hits=$(grep -rlP '[^\x00-\x7F]' \
+            --include='*.hpp' --include='*.cpp' --include='*.h' \
+            --include='*.cc' --include='*.cxx' \
+            include tests examples || true)
+          if [ -n "$hits" ]; then
+            echo "Non-ASCII characters found in:"
+            echo "$hits"
+            echo "Source files must be ASCII-only. See CONTRIBUTING / issue #59."
+            exit 1
+          fi
+          echo "OK: all source files are ASCII-only."
+
+  # -- Tier 1: Fast unit tests on all platforms (~2 min) ---------------
   # Runs on every push and every PR (draft or ready).
   build:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,19 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check for non-ASCII characters in source
         run: |
+          # grep -l exits 0 (matches), 1 (no matches), >1 (execution error).
+          # Don't mask >1 with '|| true' — a broken scan must fail CI, not pass.
+          set +e
           hits=$(grep -rlP '[^\x00-\x7F]' \
             --include='*.hpp' --include='*.cpp' --include='*.h' \
             --include='*.cc' --include='*.cxx' \
-            include tests examples || true)
+            include tests examples)
+          status=$?
+          set -e
+          if [ "$status" -gt 1 ]; then
+            echo "ASCII scan failed to execute (grep exit $status)."
+            exit "$status"
+          fi
           if [ -n "$hits" ]; then
             echo "Non-ASCII characters found in:"
             echo "$hits"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build directories
 build/
 build-*/
+build_*/
 cmake-build-*/
 
 # IDE

--- a/include/mtl/array/broadcast.hpp
+++ b/include/mtl/array/broadcast.hpp
@@ -16,7 +16,7 @@
 
 namespace mtl::array {
 
-// ── Broadcast expression ───────────────────────────────────────────
+// -- Broadcast expression -------------------------------------------
 
 /// Lazy expression for element-wise binary operations with broadcasting.
 template <typename LHS, typename RHS, typename Op, std::size_t N>
@@ -67,7 +67,7 @@ public:
     operator ndarray<value_type, N>() const { return eval(); }
 };
 
-// ── Functors ───────────────────────────────────────────────────────
+// -- Functors -------------------------------------------------------
 
 namespace ops {
     struct plus  { template <typename T, typename U> auto operator()(T a, U b) const { return a + b; } };
@@ -76,7 +76,7 @@ namespace ops {
     struct divides { template <typename T, typename U> auto operator()(T a, U b) const { return a / b; } };
 } // namespace ops
 
-// ── Operators ──────────────────────────────────────────────────────
+// -- Operators ------------------------------------------------------
 
 template <typename V1, std::size_t N, typename O1, typename V2, typename O2>
 auto operator+(const ndarray<V1, N, O1>& a, const ndarray<V2, N, O2>& b) {

--- a/include/mtl/array/interop.hpp
+++ b/include/mtl/array/interop.hpp
@@ -2,10 +2,10 @@
 // MTL5 -- Interop between ndarray and existing vector/matrix types
 //
 // Provides:
-//   - as_ndarray(vec)  → ndarray<T, 1> view (zero-copy)
-//   - as_ndarray(mat)  → ndarray<T, 2> view (zero-copy, row-major only)
-//   - as_vector(ndarray<T,1>) → dense_vector view (zero-copy)
-//   - as_matrix(ndarray<T,2>) → dense2D view (zero-copy, contiguous only)
+//   - as_ndarray(vec)  -> ndarray<T, 1> view (zero-copy)
+//   - as_ndarray(mat)  -> ndarray<T, 2> view (zero-copy, row-major only)
+//   - as_vector(ndarray<T,1>) -> dense_vector view (zero-copy)
+//   - as_matrix(ndarray<T,2>) -> dense2D view (zero-copy, contiguous only)
 //   - Generic algorithms: transform, reduce, flatten
 
 #include <array>
@@ -21,7 +21,7 @@
 
 namespace mtl::array {
 
-// ── Vector → ndarray view ──────────────────────────────────────────
+// -- Vector -> ndarray view ------------------------------------------
 
 /// Create a 1D ndarray view over a dense_vector (zero-copy).
 template <typename Value, typename Params>
@@ -35,7 +35,7 @@ ndarray<const Value, 1, c_order> as_ndarray(const vec::dense_vector<Value, Param
         const_cast<const Value*>(v.data()), shape<1>{v.size()});
 }
 
-// ── Matrix → ndarray view ──────────────────────────────────────────
+// -- Matrix -> ndarray view ------------------------------------------
 
 /// Create a 2D ndarray view over a dense2D matrix (zero-copy).
 /// Works for row-major matrices; column-major uses F-order strides.
@@ -68,7 +68,7 @@ auto as_ndarray(const mat::dense2D<Value, Params>& m) {
     }
 }
 
-// ── ndarray → vector view ──────────────────────────────────────────
+// -- ndarray -> vector view ------------------------------------------
 
 /// Create a dense_vector view over a 1D ndarray (zero-copy).
 /// Requires contiguous storage.
@@ -84,7 +84,7 @@ vec::dense_vector<const Value> as_vector(const ndarray<Value, 1, Order>& a) {
     return vec::dense_vector<const Value>(a.size(), const_cast<const Value*>(a.data()));
 }
 
-// ── ndarray → matrix view ──────────────────────────────────────────
+// -- ndarray -> matrix view ------------------------------------------
 
 /// Create a dense2D view over a 2D ndarray (zero-copy).
 /// Requires contiguous C-order (row-major) storage.
@@ -103,7 +103,7 @@ mat::dense2D<const Value> as_matrix(const ndarray<Value, 2, Order>& a) {
         a.extent(0), a.extent(1), const_cast<const Value*>(a.data()));
 }
 
-// ── Generic algorithms ─────────────────────────────────────────────
+// -- Generic algorithms ---------------------------------------------
 
 /// Element-wise transform: apply f to every element of a, writing to out.
 /// Works on any NdArray (ndarray, or adapted vector/matrix views).

--- a/include/mtl/array/ndarray.hpp
+++ b/include/mtl/array/ndarray.hpp
@@ -159,7 +159,7 @@ public:
         return mem_[compute_offset(idx, strides_)];
     }
 
-    /// Flat (linear) index access — only valid for contiguous arrays.
+    /// Flat (linear) index access - only valid for contiguous arrays.
     reference flat(size_type i) {
         assert(i < size());
         return mem_[i];

--- a/include/mtl/array/operations.hpp
+++ b/include/mtl/array/operations.hpp
@@ -15,7 +15,7 @@
 
 namespace mtl::array {
 
-// ── Full reductions (scalar result) ────────────────────────────────
+// -- Full reductions (scalar result) --------------------------------
 
 /// Sum all elements.
 template <typename V, std::size_t N, typename O>
@@ -57,7 +57,7 @@ V mean(const ndarray<V, N, O>& a) {
     return sum(a) / static_cast<V>(a.size());
 }
 
-// ── Axis reductions (ndarray result) ───────────────────────────────
+// -- Axis reductions (ndarray result) -------------------------------
 
 /// Sum along a specified axis, producing an ndarray of rank N-1.
 template <typename V, std::size_t N, typename O>

--- a/include/mtl/array/shape.hpp
+++ b/include/mtl/array/shape.hpp
@@ -16,7 +16,7 @@ namespace mtl::array {
 using c_order = tag::row_major;     // last index varies fastest (NumPy default)
 using f_order = tag::col_major;     // first index varies fastest (Fortran/MATLAB)
 
-// ── Shape ──────────────────────────────────────────────────────────
+// -- Shape ----------------------------------------------------------
 
 /// Static-rank shape: an array of N extents.
 template <std::size_t N>
@@ -49,7 +49,7 @@ public:
     constexpr bool operator==(const shape&) const = default;
 };
 
-// ── Strides ────────────────────────────────────────────────────────
+// -- Strides --------------------------------------------------------
 
 /// Compute C-order (row-major) strides: last dimension has stride 1.
 template <std::size_t N>
@@ -86,7 +86,7 @@ constexpr std::array<std::size_t, N> compute_strides(const shape<N>& sh) {
         return c_order_strides(sh);
 }
 
-// ── Offset computation ─────────────────────────────────────────────
+// -- Offset computation ---------------------------------------------
 
 /// Compute flat offset from multi-index and strides.
 template <std::size_t N>
@@ -99,7 +99,7 @@ constexpr std::size_t compute_offset(const std::array<std::size_t, N>& indices,
     return offset;
 }
 
-/// Variadic offset computation — converts (i, j, k, ...) to flat index.
+/// Variadic offset computation - converts (i, j, k, ...) to flat index.
 template <std::size_t N, typename... Indices>
 constexpr std::size_t offset_from(const std::array<std::size_t, N>& strides,
                                   Indices... indices) {
@@ -108,7 +108,7 @@ constexpr std::size_t offset_from(const std::array<std::size_t, N>& strides,
     return compute_offset(idx, strides);
 }
 
-// ── Broadcasting ───────────────────────────────────────────────────
+// -- Broadcasting ---------------------------------------------------
 
 /// Compute the broadcast shape of two shapes.
 /// Follows NumPy rules: trailing dimensions aligned, size-1 axes stretch.
@@ -141,7 +141,7 @@ constexpr std::array<std::size_t, N> broadcast_strides(const shape<N>& original,
     return result;
 }
 
-// ── Contiguity check ───────────────────────────────────────────────
+// -- Contiguity check -----------------------------------------------
 
 /// Check if strides correspond to a contiguous C-order layout.
 template <std::size_t N>

--- a/include/mtl/array/slice.hpp
+++ b/include/mtl/array/slice.hpp
@@ -2,9 +2,9 @@
 // MTL5 -- Slicing helpers for ndarray
 //
 // Provides slice descriptors that can be used with ndarray::slice():
-//   all       — select entire dimension
-//   range     — select a contiguous range with optional step
-//   integer   — select a single index (reduces rank by 1)
+//   all       - select entire dimension
+//   range     - select a contiguous range with optional step
+//   integer   - select a single index (reduces rank by 1)
 
 #include <array>
 #include <cstddef>
@@ -15,7 +15,7 @@
 
 namespace mtl::array {
 
-// ── Slice descriptors ──────────────────────────────────────────────
+// -- Slice descriptors ----------------------------------------------
 
 /// Select all elements along a dimension.
 struct all_t {};
@@ -35,11 +35,11 @@ struct range {
     }
 };
 
-// ── Slice implementation ───────────────────────────────────────────
+// -- Slice implementation -------------------------------------------
 
 namespace detail_slice {
 
-// Count how many integer (non-slice) arguments there are → rank reduction
+// Count how many integer (non-slice) arguments there are -> rank reduction
 template <typename T>
 struct is_index_arg : std::false_type {};
 
@@ -66,9 +66,9 @@ constexpr std::size_t count_kept_dims() {
 /// Slice an ndarray, returning a view with potentially reduced rank.
 ///
 /// Each argument is one of:
-///   - all       → keep the full dimension
-///   - range     → select a sub-range (adjusts shape + offset)
-///   - integer   → fix an index (reduces rank by 1)
+///   - all       -> keep the full dimension
+///   - range     -> select a sub-range (adjusts shape + offset)
+///   - integer   -> fix an index (reduces rank by 1)
 ///
 /// Returns an ndarray view with rank = N - (number of integer args).
 template <typename Value, std::size_t N, typename Order, typename... Args>

--- a/include/mtl/operation/eigenvalue_symmetric.hpp
+++ b/include/mtl/operation/eigenvalue_symmetric.hpp
@@ -154,7 +154,7 @@ auto eigenvalue_symmetric(const M& A, typename M::value_type tol = 1e-10,
 /// Compute eigenvalues and eigenvectors of a symmetric matrix.
 /// Returns {eigenvalues, eigenvectors} where:
 ///   eigenvalues:  dense_vector of size n, sorted ascending
-///   eigenvectors: dense2D of size n×n, column k = eigenvector for eigenvalues(k)
+///   eigenvectors: dense2D of size n x n, column k = eigenvector for eigenvalues(k)
 ///
 /// The algorithm accumulates similarity transforms (Householder reflectors
 /// from tridiagonalization + Givens rotations from QR iteration) into Q,

--- a/include/mtl/operation/ldlt.hpp
+++ b/include/mtl/operation/ldlt.hpp
@@ -5,7 +5,7 @@
 // diagonal of A is overwritten with D.
 //
 // Key advantages over LL^T Cholesky:
-//   - No square roots — avoids precision loss for ill-conditioned matrices
+//   - No square roots - avoids precision loss for ill-conditioned matrices
 //   - Works for symmetric indefinite matrices (D can have negative entries)
 //   - Same O(n^3/3) cost as Cholesky
 //

--- a/include/mtl/operation/ldlt_bk.hpp
+++ b/include/mtl/operation/ldlt_bk.hpp
@@ -8,11 +8,11 @@
 // The Bunch-Kaufman partial pivoting strategy selects the largest available
 // pivot at each step, using 2x2 blocks when no single diagonal entry is
 // a good pivot. This handles symmetric indefinite matrices without breakdown
-// and provides bounded element growth (factor ≤ (1+sqrt(17))/8 ≈ 2.57).
+// and provides bounded element growth (factor <= (1+sqrt(17))/8 ~= 2.57).
 //
 // The pivot sequence is stored in LAPACK convention:
-//   ipiv[k] > 0  → 1x1 pivot, row/col swap with ipiv[k]-1
-//   ipiv[k] < 0 && ipiv[k+1] < 0  → 2x2 pivot using rows |ipiv[k]|-1, |ipiv[k+1]|-1
+//   ipiv[k] > 0  -> 1x1 pivot, row/col swap with ipiv[k]-1
+//   ipiv[k] < 0 && ipiv[k+1] < 0  -> 2x2 pivot using rows |ipiv[k]|-1, |ipiv[k+1]|-1
 //
 // Reference:
 //   Bunch & Kaufman, "Some Stable Methods for Calculating Inertia and
@@ -60,7 +60,7 @@ void symmetric_swap(M& A, std::size_t r1, std::size_t r2) {
     // Swap entries in column r1 (rows between r1 and r2) with row r2
     for (std::size_t i = r1 + 1; i < r2; ++i) {
         tmp = A(i, r1);
-        A(i, r1) = A(r2, i);  // A(r2, i) is in upper triangle → use A(i, r2) conceptually
+        A(i, r1) = A(r2, i);  // A(r2, i) is in upper triangle -> use A(i, r2) conceptually
         A(r2, i) = tmp;
     }
 
@@ -92,7 +92,7 @@ int ldlt_bk_factor(M& A, bk_pivot_info& pivots) {
     std::size_t k = 0;
     while (k < n) {
         if (k == n - 1) {
-            // Last 1x1 pivot — no choice
+            // Last 1x1 pivot - no choice
             if (A(k, k) == math::zero<value_type>())
                 return static_cast<int>(k + 1);
             pivots.ipiv[k] = static_cast<int>(k + 1);  // 1-based, positive = 1x1
@@ -117,7 +117,7 @@ int ldlt_bk_factor(M& A, bk_pivot_info& pivots) {
         std::size_t swap_r = r;
 
         if (lambda_val == math::zero<value_type>()) {
-            // Column k is zero below diagonal — 1x1 pivot (might be zero)
+            // Column k is zero below diagonal - 1x1 pivot (might be zero)
             if (A(k, k) == math::zero<value_type>())
                 return static_cast<int>(k + 1);
             use_1x1 = true;
@@ -127,7 +127,7 @@ int ldlt_bk_factor(M& A, bk_pivot_info& pivots) {
             use_1x1 = true;
             swap_r = k;
         } else {
-            // Step 3: Find largest off-diagonal magnitude in row r (cols ≠ r)
+            // Step 3: Find largest off-diagonal magnitude in row r (cols != r)
             value_type sigma = math::zero<value_type>();
             for (std::size_t j = k; j < r; ++j) {
                 value_type arj = abs(A(r, j));
@@ -143,13 +143,13 @@ int ldlt_bk_factor(M& A, bk_pivot_info& pivots) {
                 use_1x1 = true;
                 swap_r = k;
             } else if (abs(A(r, r)) >= alpha * sigma) {
-                // Test 3: A(r,r) is a good pivot — swap r↔k, use 1x1
+                // Test 3: A(r,r) is a good pivot - swap r<->k, use 1x1
                 use_1x1 = true;
                 swap_r = r;
                 symmetric_swap(A, k, r);
             } else {
                 // Use 2x2 pivot from rows/cols {k, r}
-                // Swap r ↔ k+1 to put the 2x2 block at positions {k, k+1}
+                // Swap r <-> k+1 to put the 2x2 block at positions {k, k+1}
                 use_2x2 = true;
                 if (r != k + 1)
                     symmetric_swap(A, k + 1, r);
@@ -248,7 +248,7 @@ void ldlt_bk_solve(const M& A, const bk_pivot_info& pivots, VecX& x, const VecB&
     std::size_t k = 0;
     while (k < n) {
         if (pivots.ipiv[k] > 0) {
-            // 1x1 pivot — swap if needed
+            // 1x1 pivot - swap if needed
             std::size_t p = static_cast<std::size_t>(pivots.ipiv[k] - 1);
             if (p != k) {
                 auto tmp = x(k);
@@ -261,7 +261,7 @@ void ldlt_bk_solve(const M& A, const bk_pivot_info& pivots, VecX& x, const VecB&
                 x(i) = x(i) - A(i, k) * x(k);
             ++k;
         } else {
-            // 2x2 pivot — swap k+1 with |ipiv[k]|-1
+            // 2x2 pivot - swap k+1 with |ipiv[k]|-1
             std::size_t p = static_cast<std::size_t>(-pivots.ipiv[k] - 1);
             if (p != k + 1) {
                 auto tmp = x(k + 1);

--- a/include/mtl/operation/sparse_solve.hpp
+++ b/include/mtl/operation/sparse_solve.hpp
@@ -4,12 +4,12 @@
 // Provides top-level solve() free functions that automatically select the
 // best available backend based on matrix type and library availability:
 //
-//   Dense float/double + LAPACK  → LAPACK (existing in lu.hpp/cholesky.hpp/qr.hpp)
-//   Sparse float/double + UMFPACK → UMFPACK (for LU)
-//   Sparse float/double + CHOLMOD → CHOLMOD (for Cholesky)
-//   Sparse float/double + SPQR   → SPQR (for QR)
-//   Sparse (any type)             → native sparse solvers
-//   Dense (any type)              → dense generic solvers
+//   Dense float/double + LAPACK  -> LAPACK (existing in lu.hpp/cholesky.hpp/qr.hpp)
+//   Sparse float/double + UMFPACK -> UMFPACK (for LU)
+//   Sparse float/double + CHOLMOD -> CHOLMOD (for Cholesky)
+//   Sparse float/double + SPQR   -> SPQR (for QR)
+//   Sparse (any type)             -> native sparse solvers
+//   Dense (any type)              -> dense generic solvers
 //
 // The dispatch is entirely at compile time via if constexpr + traits.
 //

--- a/include/mtl/sparse/factorization/sparse_ldlt.hpp
+++ b/include/mtl/sparse/factorization/sparse_ldlt.hpp
@@ -11,7 +11,7 @@
 // as up-looking Cholesky but stores D separately and avoids sqrt.
 //
 // Key advantages over LL^T:
-//   - No square roots — avoids precision loss for ill-conditioned matrices
+//   - No square roots - avoids precision loss for ill-conditioned matrices
 //   - Works for symmetric indefinite matrices (D can have negative entries)
 //   - Only fails on zero pivots (D(j) == 0)
 //
@@ -37,7 +37,7 @@
 
 namespace mtl::sparse::factorization {
 
-/// Symbolic analysis result — identical to Cholesky since sparsity of L
+/// Symbolic analysis result - identical to Cholesky since sparsity of L
 /// is the same for LDL^T and LL^T.
 using ldlt_symbolic = cholesky_symbolic;
 
@@ -138,7 +138,7 @@ ldlt_numeric<Value> sparse_ldlt_numeric(
     auto C = util::crs_to_csc(PA);
 
     // Allocate L in CSC format. col_counts includes the diagonal, but we
-    // don't store the unit diagonal — allocate col_counts[j]-1 per column.
+    // don't store the unit diagonal - allocate col_counts[j]-1 per column.
     util::csc_matrix<Value> L;
     L.nrows = n;
     L.ncols = n;
@@ -214,7 +214,7 @@ ldlt_numeric<Value> sparse_ldlt_numeric(
                     ljk = L.values[p];
                     break;
                 }
-                if (L.row_ind[p] > j) break;  // sorted — won't find it
+                if (L.row_ind[p] > j) break;  // sorted - won't find it
             }
 
             if (ljk == Value{0}) continue;

--- a/include/mtl/sparse/factorization/triangular_solve.hpp
+++ b/include/mtl/sparse/factorization/triangular_solve.hpp
@@ -98,7 +98,7 @@ inline std::size_t reach(
 ///
 /// \param L       Lower triangular matrix in CSC format
 /// \param b       Dense right-hand side vector (overwritten with solution x)
-/// \param xi      Topological order from reach() — xi[top..n-1]
+/// \param xi      Topological order from reach() - xi[top..n-1]
 /// \param top     Starting index in xi (from reach())
 ///
 /// On entry, b contains the right-hand side. On exit, b contains the solution.

--- a/include/mtl/sparse/util/scatter.hpp
+++ b/include/mtl/sparse/util/scatter.hpp
@@ -20,7 +20,7 @@ public:
     explicit sparse_accumulator(SizeType n)
         : n_(n), x_(n, Value{0}), mark_(n, SizeType{0}), generation_(1) {}
 
-    /// Reset for a new column assembly. O(1) — just bumps the generation counter.
+    /// Reset for a new column assembly. O(1) - just bumps the generation counter.
     void clear() {
         ++generation_;
         // Handle wraparound (extremely unlikely in practice)

--- a/include/mtl/tensor/index.hpp
+++ b/include/mtl/tensor/index.hpp
@@ -4,7 +4,7 @@
 // Provides:
 //   - Index variance tags: up (contravariant) and down (covariant)
 //   - Named index objects: Index<'i'>, Index<'j'>, ...
-//   - contract(A(i,j), B(j,k)) — Einstein summation over repeated indices
+//   - contract(A(i,j), B(j,k)) - Einstein summation over repeated indices
 //   - Compile-time detection of repeated indices and validation
 
 #include <array>
@@ -15,15 +15,15 @@
 
 namespace mtl::tensor {
 
-// ── Index variance tags ────────────────────────────────────────────
+// -- Index variance tags --------------------------------------------
 
-/// Contravariant (upper) index — transforms inversely to basis vectors.
+/// Contravariant (upper) index - transforms inversely to basis vectors.
 struct up {};
 
-/// Covariant (lower) index — transforms with basis vectors.
+/// Covariant (lower) index - transforms with basis vectors.
 struct down {};
 
-// ── Named index objects ────────────────────────────────────────────
+// -- Named index objects --------------------------------------------
 
 /// Compile-time named index for Einstein notation.
 /// Usage: Index<'i'> i; Index<'j'> j;
@@ -32,7 +32,7 @@ struct Index {
     static constexpr char name = Name;
 };
 
-// ── Index expression (tensor bound to named indices) ───────────────
+// -- Index expression (tensor bound to named indices) ---------------
 
 /// A tensor expression with named indices attached.
 /// Created by: A(i, j) where i, j are Index objects.
@@ -43,7 +43,7 @@ struct indexed_tensor {
     static constexpr std::array<char, sizeof...(Names)> names{Names...};
 };
 
-// ── Binding tensors to indices ─────────────────────────────────────
+// -- Binding tensors to indices -------------------------------------
 
 /// Bind a rank-2 tensor to two named indices: A(i, j)
 template <typename V, std::size_t D, char I, char J>
@@ -57,7 +57,7 @@ auto bind(const tensor<V, 1, D>& t, Index<I>) {
     return indexed_tensor<tensor<V, 1, D>, I>{t};
 }
 
-// ── Contraction (Einstein summation) ───────────────────────────────
+// -- Contraction (Einstein summation) -------------------------------
 
 namespace detail_index {
 
@@ -147,7 +147,7 @@ auto contract(const indexed_tensor<tensor<V, 2, D>, AI, AJ>& a,
     return result;
 }
 
-// ── Outer product ──────────────────────────────────────────────────
+// -- Outer product --------------------------------------------------
 
 /// Outer product of two rank-1 tensors: C_ij = a_i * b_j
 template <typename V, std::size_t D>

--- a/include/mtl/tensor/metric.hpp
+++ b/include/mtl/tensor/metric.hpp
@@ -3,8 +3,8 @@
 //
 // A metric tensor g_ij enables converting between covariant and
 // contravariant components:
-//   raise:  T^i = g^ij * T_j     (covariant → contravariant)
-//   lower:  T_i = g_ij * T^j     (contravariant → covariant)
+//   raise:  T^i = g^ij * T_j     (covariant -> contravariant)
+//   lower:  T_i = g_ij * T^j     (contravariant -> covariant)
 //
 // Provides common metrics: Euclidean (identity) and Minkowski.
 
@@ -13,7 +13,7 @@
 
 namespace mtl::tensor {
 
-// ── Standard metrics ───────────────────────────────────────────────
+// -- Standard metrics -----------------------------------------------
 
 /// Euclidean metric: g_ij = delta_ij (identity matrix).
 template <typename V, std::size_t D>
@@ -33,7 +33,7 @@ tensor<V, 2, 4> minkowski_metric() {
     return g;
 }
 
-// ── Index raising/lowering for rank-1 tensors ──────────────────────
+// -- Index raising/lowering for rank-1 tensors ----------------------
 
 /// Lower a contravariant vector: v_i = g_ij * v^j
 template <typename V, std::size_t D>
@@ -54,7 +54,7 @@ tensor<V, 1, D> raise(const tensor<V, 1, D>& v, const tensor<V, 2, D>& g_inv) {
     return lower(v, g_inv); // same operation, just the metric meaning differs
 }
 
-// ── Index raising/lowering for rank-2 tensors ──────────────────────
+// -- Index raising/lowering for rank-2 tensors ----------------------
 
 /// Lower the first index of a rank-2 tensor: T_ij = g_ik * T^k_j
 template <typename V, std::size_t D>

--- a/include/mtl/tensor/symmetric.hpp
+++ b/include/mtl/tensor/symmetric.hpp
@@ -16,7 +16,7 @@
 
 namespace mtl::tensor {
 
-// ── Symmetric rank-2 tensor ────────────────────────────────────────
+// -- Symmetric rank-2 tensor ----------------------------------------
 
 namespace detail_sym {
 
@@ -130,7 +130,7 @@ V trace(const symmetric_tensor<V, D>& t) {
     return result;
 }
 
-// ── Antisymmetric rank-2 tensor ────────────────────────────────────
+// -- Antisymmetric rank-2 tensor ------------------------------------
 
 /// Antisymmetric (skew-symmetric) rank-2 tensor.
 /// T(i,j) == -T(j,i), T(i,i) == 0.

--- a/include/mtl/tensor/tensor.hpp
+++ b/include/mtl/tensor/tensor.hpp
@@ -26,7 +26,7 @@
 
 namespace mtl::tensor {
 
-// ── Helpers ────────────────────────────────────────────────────────
+// -- Helpers --------------------------------------------------------
 
 namespace detail {
 
@@ -66,7 +66,7 @@ constexpr std::size_t flat_index_arr(const std::array<std::size_t, Rank>& idx) {
 
 } // namespace detail
 
-// ── Core tensor class ──────────────────────────────────────────────
+// -- Core tensor class ----------------------------------------------
 
 /// Mathematical tensor with compile-time rank and spatial dimension.
 ///
@@ -213,7 +213,7 @@ private:
     }
 };
 
-// ── Free functions on tensor ───────────────────────────────────────
+// -- Free functions on tensor ---------------------------------------
 
 /// Trace of a rank-2 tensor: sum of diagonal elements.
 template <typename V, std::size_t D>

--- a/tests/regression/dense/test_eigenvalue.cpp
+++ b/tests/regression/dense/test_eigenvalue.cpp
@@ -82,5 +82,5 @@ TEST_CASE("Symmetric eigenvalue regression: Wilkinson", "[regression][dense][eig
     REQUIRE(std::abs(trace_eig - trace_A) < tol);
 }
 
-// NOTE: SVD regression test omitted — native SVD has accuracy issues beyond
+// NOTE: SVD regression test omitted - native SVD has accuracy issues beyond
 // n~20 (see known limitation). Tracked separately for investigation.

--- a/tests/regression/dense/test_qr.cpp
+++ b/tests/regression/dense/test_qr.cpp
@@ -155,7 +155,7 @@ TEST_CASE("QR regression: Vandermonde matrix", "[regression][dense][qr]") {
     auto Q = qr_extract_Q(Acopy, tau);
     auto R = qr_extract_R(Acopy);
 
-    // Vandermonde is ill-conditioned — relaxed tolerance
+    // Vandermonde is ill-conditioned - relaxed tolerance
     double tol = double(n) * 1e6 * std::numeric_limits<double>::epsilon();
     double fe = factorization_error(A, Q, R);
     double oe = orthogonality_error(Q);

--- a/tests/unit/array/test_interop.cpp
+++ b/tests/unit/array/test_interop.cpp
@@ -10,7 +10,7 @@
 using namespace mtl;
 using namespace mtl::array;
 
-// ── Vector → ndarray round-trip ────────────────────────────────────
+// -- Vector -> ndarray round-trip ------------------------------------
 
 TEST_CASE("dense_vector to ndarray view (zero-copy)", "[interop][vec]") {
     vec::dense_vector<double> v = {1.0, 2.0, 3.0, 4.0};
@@ -40,7 +40,7 @@ TEST_CASE("const dense_vector to const ndarray view", "[interop][vec]") {
     // a(0) = 5.0;  // should not compile (const)
 }
 
-// ── Matrix → ndarray round-trip ────────────────────────────────────
+// -- Matrix -> ndarray round-trip ------------------------------------
 
 TEST_CASE("dense2D to ndarray view (zero-copy)", "[interop][mat]") {
     mat::dense2D<double> m(3, 4);
@@ -65,7 +65,7 @@ TEST_CASE("mutation through ndarray view visible in matrix", "[interop][mat]") {
     REQUIRE(m(1, 1) == 77);
 }
 
-// ── ndarray → vector round-trip ────────────────────────────────────
+// -- ndarray -> vector round-trip ------------------------------------
 
 TEST_CASE("ndarray to dense_vector view", "[interop][vec]") {
     ndarray<double, 1> a(shape<1>{5});
@@ -89,7 +89,7 @@ TEST_CASE("ndarray to dense2D view", "[interop][mat]") {
     REQUIRE(m.data() == a.data());  // zero-copy
 }
 
-// ── Matrix → ndarray → slice row → verify 1D view ─────────────────
+// -- Matrix -> ndarray -> slice row -> verify 1D view -----------------
 
 TEST_CASE("matrix to ndarray, slice row, get vector view", "[interop][slice]") {
     mat::dense2D<int> m(3, 4);
@@ -98,7 +98,7 @@ TEST_CASE("matrix to ndarray, slice row, get vector view", "[interop][slice]") {
             m(i, j) = static_cast<int>(i * 4 + j);
 
     auto a = as_ndarray(m);
-    auto row1 = slice(a, 1, all);  // row 1 → 1D view
+    auto row1 = slice(a, 1, all);  // row 1 -> 1D view
 
     REQUIRE(row1.size() == 4);
     REQUIRE(row1(0) == 4);
@@ -111,7 +111,7 @@ TEST_CASE("matrix to ndarray, slice row, get vector view", "[interop][slice]") {
     REQUIRE(m(1, 2) == 99);
 }
 
-// ── Generic algorithms ─────────────────────────────────────────────
+// -- Generic algorithms ---------------------------------------------
 
 TEST_CASE("transform on ndarray", "[interop][algorithm]") {
     ndarray<int, 1> a(shape<1>{4});

--- a/tests/unit/array/test_ndarray.cpp
+++ b/tests/unit/array/test_ndarray.cpp
@@ -13,7 +13,7 @@
 using namespace mtl;
 using namespace mtl::array;
 
-// ── Shape tests ────────────────────────────────────────────────────
+// -- Shape tests ----------------------------------------------------
 
 TEST_CASE("shape construction and access", "[array][shape]") {
     shape<3> sh{4, 5, 6};
@@ -31,7 +31,7 @@ TEST_CASE("shape equality", "[array][shape]") {
     REQUIRE(a != c);
 }
 
-// ── Stride tests ───────────────────────────────────────────────────
+// -- Stride tests ---------------------------------------------------
 
 TEST_CASE("c-order strides", "[array][strides]") {
     shape<3> sh{2, 3, 4};
@@ -51,7 +51,7 @@ TEST_CASE("f-order strides", "[array][strides]") {
     REQUIRE(strides[2] == 6);
 }
 
-// ── Construction tests ─────────────────────────────────────────────
+// -- Construction tests ---------------------------------------------
 
 TEST_CASE("ndarray default construction", "[array][ctor]") {
     ndarray<double, 2> a;
@@ -81,7 +81,7 @@ TEST_CASE("ndarray fill construction", "[array][ctor]") {
     REQUIRE(a(1, 2) == 42);
 }
 
-// ── Concept satisfaction ───────────────────────────────────────────
+// -- Concept satisfaction -------------------------------------------
 
 TEST_CASE("ndarray satisfies NdArray concept", "[array][concept]") {
     STATIC_REQUIRE(Collection<ndarray<double, 2>>);
@@ -95,7 +95,7 @@ TEST_CASE("ndarray has dense category trait", "[array][trait]") {
     STATIC_REQUIRE(std::is_same_v<cat, tag::dense>);
 }
 
-// ── Element access ─────────────────────────────────────────────────
+// -- Element access -------------------------------------------------
 
 TEST_CASE("ndarray element access via operator()", "[array][access]") {
     ndarray<int, 2> a({3, 4});
@@ -142,7 +142,7 @@ TEST_CASE("ndarray F-order memory layout", "[array][layout]") {
     }
 }
 
-// ── View tests ─────────────────────────────────────────────────────
+// -- View tests -----------------------------------------------------
 
 TEST_CASE("ndarray view shares memory", "[array][view]") {
     ndarray<int, 2> a({3, 4}, 0);
@@ -168,7 +168,7 @@ TEST_CASE("ndarray external pointer constructor", "[array][view]") {
     REQUIRE(data[1] == 42);
 }
 
-// ── Reshape and transpose ──────────────────────────────────────────
+// -- Reshape and transpose ------------------------------------------
 
 TEST_CASE("ndarray reshape", "[array][reshape]") {
     ndarray<int, 2> a({3, 4});
@@ -196,7 +196,7 @@ TEST_CASE("ndarray transpose", "[array][transpose]") {
     REQUIRE(t(2, 1) == 6);
 }
 
-// ── Slicing tests ──────────────────────────────────────────────────
+// -- Slicing tests --------------------------------------------------
 
 TEST_CASE("slice with all keeps full dimension", "[array][slice]") {
     ndarray<int, 2> a({3, 4}, 0);
@@ -204,7 +204,7 @@ TEST_CASE("slice with all keeps full dimension", "[array][slice]") {
         for (std::size_t j = 0; j < 4; ++j)
             a(i, j) = static_cast<int>(i * 4 + j);
 
-    auto row = slice(a, 1, all);  // row 1 → 1D view
+    auto row = slice(a, 1, all);  // row 1 -> 1D view
     REQUIRE(row.size() == 4);
     REQUIRE(row(0) == 4);
     REQUIRE(row(1) == 5);
@@ -216,7 +216,7 @@ TEST_CASE("slice with integer reduces rank", "[array][slice]") {
     ndarray<int, 3> a({2, 3, 4}, 0);
     a(1, 2, 3) = 42;
 
-    auto s = slice(a, 1, all, all);  // fix first dim → 2D
+    auto s = slice(a, 1, all, all);  // fix first dim -> 2D
     REQUIRE(s.extent(0) == 3);
     REQUIRE(s.extent(1) == 4);
     REQUIRE(s(2, 3) == 42);
@@ -242,7 +242,7 @@ TEST_CASE("slice mutation visible in original", "[array][slice]") {
     REQUIRE(a(1, 2) == 99);
 }
 
-// ── Broadcasting tests ─────────────────────────────────────────────
+// -- Broadcasting tests ---------------------------------------------
 
 TEST_CASE("broadcast shape computation", "[array][broadcast]") {
     shape<3> a{4, 1, 6};
@@ -270,7 +270,7 @@ TEST_CASE("element-wise addition same shape", "[array][broadcast]") {
 }
 
 TEST_CASE("element-wise multiplication with broadcasting", "[array][broadcast]") {
-    // a is (3, 1), b is (1, 4) → result is (3, 4)
+    // a is (3, 1), b is (1, 4) -> result is (3, 4)
     ndarray<int, 2> a(shape<2>{3, 1});
     ndarray<int, 2> b(shape<2>{1, 4});
 
@@ -286,7 +286,7 @@ TEST_CASE("element-wise multiplication with broadcasting", "[array][broadcast]")
     REQUIRE(c(2, 3) == 12);
 }
 
-// ── Reduction tests ────────────────────────────────────────────────
+// -- Reduction tests ------------------------------------------------
 
 TEST_CASE("sum all elements", "[array][reduction]") {
     ndarray<int, 2> a({2, 3}, 5);
@@ -317,14 +317,14 @@ TEST_CASE("sum along axis", "[array][reduction]") {
     a(0, 0) = 1; a(0, 1) = 2; a(0, 2) = 3;
     a(1, 0) = 4; a(1, 1) = 5; a(1, 2) = 6;
 
-    // Sum along axis 0 → shape (3,)
+    // Sum along axis 0 -> shape (3,)
     auto s0 = sum_axis(a, 0);
     REQUIRE(s0.extent(0) == 3);
     REQUIRE(s0(0) == 5);   // 1+4
     REQUIRE(s0(1) == 7);   // 2+5
     REQUIRE(s0(2) == 9);   // 3+6
 
-    // Sum along axis 1 → shape (2,)
+    // Sum along axis 1 -> shape (2,)
     auto s1 = sum_axis(a, 1);
     REQUIRE(s1.extent(0) == 2);
     REQUIRE(s1(0) == 6);   // 1+2+3
@@ -342,7 +342,7 @@ TEST_CASE("mean along axis", "[array][reduction]") {
     REQUIRE(m(2) == Catch::Approx(4.5));
 }
 
-// ── Fill and compound assignment ───────────────────────────────────
+// -- Fill and compound assignment -----------------------------------
 
 TEST_CASE("ndarray fill", "[array][fill]") {
     ndarray<int, 2> a({3, 4});
@@ -364,7 +364,7 @@ TEST_CASE("ndarray compound assignment", "[array][ops]") {
     REQUIRE(a(2) == 26);
 }
 
-// ── 3D array test ──────────────────────────────────────────────────
+// -- 3D array test --------------------------------------------------
 
 TEST_CASE("3D ndarray construction and access", "[array][3d]") {
     ndarray<double, 3> vol({4, 5, 6});
@@ -375,7 +375,7 @@ TEST_CASE("3D ndarray construction and access", "[array][3d]") {
     REQUIRE(vol(2, 3, 4) == Catch::Approx(3.14));
 }
 
-// ── Contiguity ─────────────────────────────────────────────────────
+// -- Contiguity -----------------------------------------------------
 
 TEST_CASE("contiguity check", "[array][contiguous]") {
     ndarray<int, 2> a({3, 4});
@@ -391,7 +391,7 @@ TEST_CASE("contiguity check", "[array][contiguous]") {
     REQUIRE(!s.is_contiguous());
 }
 
-// ── Copy semantics ─────────────────────────────────────────────────
+// -- Copy semantics -------------------------------------------------
 
 TEST_CASE("ndarray copy is deep", "[array][copy]") {
     ndarray<int, 1> a(shape<1>{3});

--- a/tests/unit/operation/test_eigen_symmetric.cpp
+++ b/tests/unit/operation/test_eigen_symmetric.cpp
@@ -13,7 +13,7 @@
 
 using namespace mtl;
 
-// Helper: max eigenpair residual ||Av - λv|| / (||A|| * ||v||)
+// Helper: max eigenpair residual ||Av - lambda*v|| / (||A|| * ||v||)
 static double max_eigenpair_residual(const mat::dense2D<double>& A,
                                       const vec::dense_vector<double>& eigs,
                                       const mat::dense2D<double>& V) {
@@ -21,7 +21,7 @@ static double max_eigenpair_residual(const mat::dense2D<double>& A,
     double Anorm = frobenius_norm(A);
     double max_res = 0.0;
     for (std::size_t k = 0; k < n; ++k) {
-        // Compute Av - λv
+        // Compute Av - lambda*v
         double res_sq = 0.0;
         double v_sq = 0.0;
         for (std::size_t i = 0; i < n; ++i) {

--- a/tests/unit/operation/test_ldlt.cpp
+++ b/tests/unit/operation/test_ldlt.cpp
@@ -116,7 +116,7 @@ TEST_CASE("LDL^T detects zero pivot", "[operation][ldlt]") {
     A(1,0) = 1;  A(1,1) = 0;
 
     int info = ldlt_factor(A);
-    REQUIRE(info != 0);  // D(0,0) = 0 → returns 1
+    REQUIRE(info != 0);  // D(0,0) = 0 -> returns 1
     REQUIRE(info == 1);
 
     // Verify ldlt_solve throws on zero diagonal

--- a/tests/unit/operation/test_ldlt_bk.cpp
+++ b/tests/unit/operation/test_ldlt_bk.cpp
@@ -82,7 +82,7 @@ TEST_CASE("Bunch-Kaufman on symmetric indefinite matrix", "[operation][ldlt_bk]"
 TEST_CASE("Bunch-Kaufman on matrix requiring 2x2 pivot", "[operation][ldlt_bk]") {
     // Matrix where diagonal is zero but off-diagonals are large
     // Forces 2x2 pivot selection
-    // A = {{0, 1, 0}, {1, 0, 1}, {0, 1, 0}} — singular, but
+    // A = {{0, 1, 0}, {1, 0, 1}, {0, 1, 0}} - singular, but
     // Use: A = {{0, 3, 1}, {3, 0, 2}, {1, 2, 5}}
     // A(0,0) = 0 forces a pivot swap or 2x2
     mat::dense2D<double> A(3, 3);
@@ -128,7 +128,7 @@ TEST_CASE("Bunch-Kaufman on 1x1 matrix", "[operation][ldlt_bk]") {
 }
 
 TEST_CASE("Bunch-Kaufman on 4x4 indefinite matrix", "[operation][ldlt_bk]") {
-    // Symmetric indefinite 4x4 — the type that arises in UKF covariance updates
+    // Symmetric indefinite 4x4 - the type that arises in UKF covariance updates
     mat::dense2D<double> A(4, 4);
     A(0,0) =  2; A(0,1) =  1; A(0,2) = -1; A(0,3) =  0;
     A(1,0) =  1; A(1,1) = -3; A(1,2) =  2; A(1,3) =  1;

--- a/tests/unit/sparse/test_elimination_tree.cpp
+++ b/tests/unit/sparse/test_elimination_tree.cpp
@@ -46,7 +46,7 @@ TEST_CASE("Elimination tree of arrow matrix", "[sparse][etree]") {
     // The etree: parent[0] = no_parent (row 0 connects to all),
     // but since we process upper triangle: col 0 has entries at rows 0,
     // cols 1,2,3 have entry at row 0.
-    // etree: parent[1]=0? No — etree is: parent[j] = first subdiag nz in col j.
+    // etree: parent[1]=0? No - etree is: parent[j] = first subdiag nz in col j.
     // For upper triangular: column 0 has row 0 only (diag), so we look at
     // which columns have row index 0 in upper triangle.
     // Upper triangle entries: (0,0),(0,1),(0,2),(0,3),(1,1),(2,2),(3,3)

--- a/tests/unit/sparse/test_sparse_ldlt.cpp
+++ b/tests/unit/sparse/test_sparse_ldlt.cpp
@@ -103,7 +103,7 @@ TEST_CASE("Sparse LDL^T numeric: 3x3 SPD matrix", "[sparse][ldlt]") {
     REQUIRE(L.nrows == 3);
     REQUIRE(L.ncols == 3);
 
-    // L stores only strictly-lower entries (no diagonal — unit diagonal is implicit)
+    // L stores only strictly-lower entries (no diagonal - unit diagonal is implicit)
     // For a tridiagonal 3x3, each column except the last has 1 off-diagonal entry
     for (std::size_t j = 0; j < 3; ++j) {
         for (std::size_t p = L.col_ptr[j]; p < L.col_ptr[j + 1]; ++p)

--- a/tests/unit/tensor/test_tensor.cpp
+++ b/tests/unit/tensor/test_tensor.cpp
@@ -8,7 +8,7 @@
 
 using namespace mtl::tensor;
 
-// ── Core tensor construction ───────────────────────────────────────
+// -- Core tensor construction ---------------------------------------
 
 TEST_CASE("tensor default construction is zero", "[tensor][ctor]") {
     tensor<double, 2, 3> t;
@@ -41,7 +41,7 @@ TEST_CASE("tensor initializer list", "[tensor][ctor]") {
     REQUIRE(t(1, 1) == 4);
 }
 
-// ── Element access ─────────────────────────────────────────────────
+// -- Element access -------------------------------------------------
 
 TEST_CASE("tensor element access rank-1", "[tensor][access]") {
     tensor<double, 1, 3> v;
@@ -64,7 +64,7 @@ TEST_CASE("tensor element access rank-4", "[tensor][access]") {
     REQUIRE(t(1, 0, 1, 0) == 7);
 }
 
-// ── Arithmetic ─────────────────────────────────────────────────────
+// -- Arithmetic -----------------------------------------------------
 
 TEST_CASE("tensor addition", "[tensor][arithmetic]") {
     tensor<int, 2, 2> a{1, 2, 3, 4};
@@ -93,7 +93,7 @@ TEST_CASE("tensor negation", "[tensor][arithmetic]") {
     REQUIRE(neg(2) == -3);
 }
 
-// ── Trace ──────────────────────────────────────────────────────────
+// -- Trace ----------------------------------------------------------
 
 TEST_CASE("trace of rank-2 tensor", "[tensor][trace]") {
     tensor<double, 2, 3> t;
@@ -106,7 +106,7 @@ TEST_CASE("trace of identity", "[tensor][trace]") {
     REQUIRE(trace(I) == Catch::Approx(3.0));
 }
 
-// ── Determinant ────────────────────────────────────────────────────
+// -- Determinant ----------------------------------------------------
 
 TEST_CASE("determinant 2x2", "[tensor][det]") {
     tensor<double, 2, 2> t{1, 2, 3, 4};
@@ -127,14 +127,14 @@ TEST_CASE("determinant of identity", "[tensor][det]") {
     REQUIRE(determinant(identity<double, 3>()) == Catch::Approx(1.0));
 }
 
-// ── Frobenius norm ─────────────────────────────────────────────────
+// -- Frobenius norm -------------------------------------------------
 
 TEST_CASE("frobenius norm of identity", "[tensor][norm]") {
     auto I = identity<double, 3>();
     REQUIRE(frobenius_norm(I) == Catch::Approx(std::sqrt(3.0)));
 }
 
-// ── Transpose ──────────────────────────────────────────────────────
+// -- Transpose ------------------------------------------------------
 
 TEST_CASE("transpose of rank-2 tensor", "[tensor][transpose]") {
     tensor<int, 2, 3> t;
@@ -144,7 +144,7 @@ TEST_CASE("transpose of rank-2 tensor", "[tensor][transpose]") {
     REQUIRE(tt(0, 1) == 7);
 }
 
-// ── Einstein summation (contraction) ───────────────────────────────
+// -- Einstein summation (contraction) -------------------------------
 
 TEST_CASE("contract rank-2 tensors (matrix multiply)", "[tensor][contract]") {
     Index<'i'> i; Index<'j'> j; Index<'k'> k;
@@ -192,7 +192,7 @@ TEST_CASE("contraction identity * A = A", "[tensor][contract]") {
             REQUIRE(result(r, c) == Catch::Approx(A(r, c)));
 }
 
-// ── Outer product ──────────────────────────────────────────────────
+// -- Outer product --------------------------------------------------
 
 TEST_CASE("outer product of rank-1 tensors", "[tensor][outer]") {
     tensor<double, 1, 3> a;
@@ -206,7 +206,7 @@ TEST_CASE("outer product of rank-1 tensors", "[tensor][outer]") {
     REQUIRE(C(2, 1) == Catch::Approx(15.0));
 }
 
-// ── Symmetric tensor ───────────────────────────────────────────────
+// -- Symmetric tensor -----------------------------------------------
 
 TEST_CASE("symmetric tensor storage size", "[tensor][symmetric]") {
     STATIC_REQUIRE(symmetric_tensor<double, 3>::num_stored == 6);
@@ -241,7 +241,7 @@ TEST_CASE("symmetric tensor trace", "[tensor][symmetric]") {
     REQUIRE(trace(s) == Catch::Approx(6.0));
 }
 
-// ── Antisymmetric tensor ───────────────────────────────────────────
+// -- Antisymmetric tensor -------------------------------------------
 
 TEST_CASE("antisymmetric tensor storage size", "[tensor][antisymmetric]") {
     STATIC_REQUIRE(antisymmetric_tensor<double, 3>::num_stored == 3);
@@ -270,7 +270,7 @@ TEST_CASE("antisymmetric to full round-trip", "[tensor][antisymmetric]") {
     REQUIRE(trace(full) == Catch::Approx(0.0));
 }
 
-// ── Metric operations ──────────────────────────────────────────────
+// -- Metric operations ----------------------------------------------
 
 TEST_CASE("Euclidean metric raise/lower is identity", "[tensor][metric]") {
     auto g = euclidean_metric<double, 3>();
@@ -317,7 +317,7 @@ TEST_CASE("lower_first with identity is identity", "[tensor][metric]") {
             REQUIRE(lowered(i, j) == Catch::Approx(t(i, j)));
 }
 
-// ── Identity tensor ────────────────────────────────────────────────
+// -- Identity tensor ------------------------------------------------
 
 TEST_CASE("identity tensor properties", "[tensor][identity]") {
     auto I = identity<double, 3>();
@@ -328,7 +328,7 @@ TEST_CASE("identity tensor properties", "[tensor][identity]") {
     REQUIRE(I(1, 0) == 0.0);
 }
 
-// ── Equality ───────────────────────────────────────────────────────
+// -- Equality -------------------------------------------------------
 
 TEST_CASE("tensor equality", "[tensor][equality]") {
     tensor<int, 2, 2> a{1, 2, 3, 4};


### PR DESCRIPTION
Closes #59.

## What

Removes multibyte UTF-8 characters from all C++ source files (`*.hpp/*.cpp/*.h/*.cc/*.cxx` under `include/`, `tests/`, `examples/`). Every occurrence was inside a **comment** — no string literals or identifiers were touched — so the changes are cosmetic and behavior-preserving.

## Replacements

| Codepoint | Char | ASCII |
|-----------|------|-------|
| U+2500 BOX DRAWINGS LIGHT HORIZONTAL | `─` | `-` |
| U+2192 RIGHTWARDS ARROW | `→` | `->` |
| U+2014 EM DASH | `—` | `-` |
| U+2194 LEFT RIGHT ARROW | `↔` | `<->` |
| U+03BB GREEK SMALL LETTER LAMBDA | `λ` | `lambda` |
| U+2264 LESS-THAN OR EQUAL TO | `≤` | `<=` |
| U+2248 ALMOST EQUAL TO | `≈` | `~=` |
| U+2260 NOT EQUAL TO | `≠` | `!=` |
| U+00D7 MULTIPLICATION SIGN | `×` | `x` |

27 files cleaned.

## Regression guard

Adds an `ascii-check` CI job that fails if any source file under `include/`, `tests/`, or `examples/` contains non-ASCII bytes.

## Verification

```
$ grep -rlP '[^\x00-\x7F]' --include='*.hpp' --include='*.cpp' --include='*.h' --include='*.cc' --include='*.cxx' include tests examples
(no output)
```

- Configure + build: OK
- `ctest`: 100% — 99/99 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added antisymmetric tensor support with a storage‑efficient rank‑2 implementation.

* **Documentation**
  * Standardized and normalized documentation comments across headers and tests for consistent formatting and typography.

* **Chores**
  * Added an ASCII-check job to the CI workflow.
  * Extended .gitignore to cover additional build directory patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->