### PR TITLE
fix(tensor): prevent out-of-bounds write in antisymmetric_tensor::set on diagonal

### DIFF
--- a/include/mtl/tensor/symmetric.hpp
+++ b/include/mtl/tensor/symmetric.hpp
@@ -153,8 +153,14 @@ public:
     antisymmetric_tensor() = default;
 
     /// Set the (i,j) component where i < j. Setting (j,i) sets -(i,j).
+    /// Setting a diagonal element (i == j) is a no-op: the diagonal of an
+    /// antisymmetric tensor is structurally zero and has no storage slot.
     void set(size_type i, size_type j, const Value& val) {
-        assert(i != j && "Diagonal of antisymmetric tensor is always zero");
+        assert(i < Dim && j < Dim && "Index out of bounds");
+        // Guard the diagonal explicitly: asym2_index(i, i, Dim) returns the
+        // num_stored sentinel, so writing there would be out of bounds. The
+        // assert above is compiled out under NDEBUG, so this cannot rely on it.
+        if (i == j) return;
         if (i < j) {
             data_[detail_sym::asym2_index(i, j, Dim)] = val;
         } else {

--- a/tests/unit/tensor/test_tensor.cpp
+++ b/tests/unit/tensor/test_tensor.cpp
@@ -270,6 +270,35 @@ TEST_CASE("antisymmetric to full round-trip", "[tensor][antisymmetric]") {
     REQUIRE(trace(full) == Catch::Approx(0.0));
 }
 
+TEST_CASE("antisymmetric tensor set on diagonal is a safe no-op", "[tensor][antisymmetric]") {
+    // Regression test for issue #61: under NDEBUG the diagonal assert is
+    // compiled out, and set(i, i, val) fell into the else branch where
+    // asym2_index(i, i, Dim) returns the num_stored sentinel -> out-of-bounds
+    // write. set on the diagonal must instead be a no-op (diagonal == 0).
+    antisymmetric_tensor<double, 3> a;
+    a.set(0, 1, 1.0);
+    a.set(0, 2, 2.0);
+    a.set(1, 2, 3.0);
+
+    // Setting any diagonal element must not touch stored off-diagonal data...
+    a.set(0, 0, 99.0);
+    a.set(1, 1, 99.0);
+    a.set(2, 2, 99.0);
+
+    // ...the diagonal stays zero...
+    REQUIRE(a(0, 0) == 0.0);
+    REQUIRE(a(1, 1) == 0.0);
+    REQUIRE(a(2, 2) == 0.0);
+
+    // ...and the previously set components are unchanged.
+    REQUIRE(a(0, 1) == 1.0);
+    REQUIRE(a(0, 2) == 2.0);
+    REQUIRE(a(1, 2) == 3.0);
+    REQUIRE(a(1, 0) == -1.0);
+    REQUIRE(a(2, 0) == -2.0);
+    REQUIRE(a(2, 1) == -3.0);
+}
+
 // -- Metric operations ----------------------------------------------
 
 TEST_CASE("Euclidean metric raise/lower is identity", "[tensor][metric]") {


### PR DESCRIPTION
## Summary

- Fixes an out-of-bounds write in `antisymmetric_tensor::set` (`include/mtl/tensor/symmetric.hpp`) when called with a diagonal index (`i == j`).
- The diagonal was guarded only by `assert(i != j)`, which is compiled out under `NDEBUG`. For `i == j`, the `i < j` test is false, so control fell into the `else` branch and computed `asym2_index(i, i, Dim)` — which returns the `num_stored` sentinel, so the code wrote `data_[num_stored]`, one element past the end of the storage array.

## Root cause

`detail_sym::asym2_index(i, i, Dim)` deliberately returns `D*(D-1)/2 == num_stored` as a "zero diagonal" sentinel. `operator()` checks `i == j` *before* indexing and is safe, but `set()` relied on the (release-stripped) assert and indexed unconditionally.

## Fix

- `set(i, i, val)` is now an explicit no-op — the diagonal of an antisymmetric tensor is structurally zero and has no storage slot.
- The `assert` now checks index bounds (`i < Dim && j < Dim`) rather than the diagonal, so it no longer depends on being compiled in for correctness.

## Changes

- `include/mtl/tensor/symmetric.hpp` — explicit `i == j` early return + bounds assert in `antisymmetric_tensor::set`.
- `tests/unit/tensor/test_tensor.cpp` — regression test: setting any diagonal element is a no-op and leaves stored off-diagonal components intact.

## Test Results

| Target | gcc build | gcc test | clang compile | NDEBUG + ASan/UBSan |
|--------|-----------|----------|---------------|---------------------|
| `tensor_test_tensor` | OK | PASS | OK | clean (gcc + clang) |

Before the fix, the same NDEBUG + ASan harness reports a `stack-buffer-overflow` in `antisymmetric_tensor::set`; after the fix it exits cleanly.

> Note: the full clang Catch2 build was deferred locally (a heavy unrelated build was running on the host); clang was validated via a single-process `-DNDEBUG -fsanitize=address,undefined` compile + run. Fast CI exercises the full clang matrix.

## Test plan
- [ ] Fast CI passes (gcc + clang)
- [ ] Promote to ready: `gh pr ready <N>`

Resolves #61

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of antisymmetric tensor diagonal element assignments; they now safely complete as no-ops instead of triggering assertions.

* **Tests**
  * Added comprehensive unit test coverage verifying that diagonal element assignments preserve tensor structure and antisymmetry properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->