### PR TITLE
chore(ci): pin GitHub Actions to commit SHAs and disable credential persistence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # Keep GitHub Actions pinned to commit SHAs up to date. Dependabot bumps the
+  # SHA and the trailing "# vX.Y.Z" comment together when a new release ships.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+      include: scope
+    labels:
+      - dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,9 @@ jobs:
   ascii-check:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Check for non-ASCII characters in source
         run: |
           # grep -l exits 0 (matches), 1 (no matches), >1 (execution error).
@@ -97,10 +99,12 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Set up sccache
-        uses: mozilla-actions/sccache-action@v0.0.6
+        uses: mozilla-actions/sccache-action@9e326ebed976843c9932b3aa0e021c6f50310eb4 # v0.0.6
 
       - name: Configure (Unix, GCC/Clang)
         if: runner.os != 'Windows'
@@ -159,10 +163,12 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Set up sccache
-        uses: mozilla-actions/sccache-action@v0.0.6
+        uses: mozilla-actions/sccache-action@9e326ebed976843c9932b3aa0e021c6f50310eb4 # v0.0.6
 
       - name: Configure
         run: >

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,9 +24,11 @@ jobs:
       run:
         working-directory: docs-site
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -40,7 +42,7 @@ jobs:
 
       - name: Upload artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: docs-site/dist
 
@@ -54,4 +56,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,10 @@ jobs:
   release:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0  # full history for changelog generation
+          persist-credentials: false
 
       - name: Extract version from tag
         id: version
@@ -103,7 +104,7 @@ jobs:
           cat release_notes.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: "MTL5 ${{ steps.version.outputs.tag }}"


### PR DESCRIPTION
## Summary

Hardens the GitHub Actions workflows against supply-chain / token-persistence risks flagged by zizmor (`unpinned-uses`, `artipacked`) — the deferred follow-up from #60's review.

- **Pin every action to a full commit SHA** (with a `# vX.Y.Z` comment so the human-readable version is still visible and Dependabot can bump both together).
- **Add `persist-credentials: false`** to all checkout steps — none of them push back via git.
- **Add `.github/dependabot.yml`** with a `github-actions` ecosystem entry to keep the pinned SHAs current.

## Pinned actions

| Action | SHA | Version |
|--------|-----|---------|
| `actions/checkout` (×5) | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4.3.1 |
| `mozilla-actions/sccache-action` (×2) | `9e326ebed976843c9932b3aa0e021c6f50310eb4` | v0.0.6 |
| `actions/setup-node` | `49933ea5288caeca8642d1e84afbd3f7d6820020` | v4.4.0 |
| `actions/upload-pages-artifact` | `7b1f4a764d45c48632c6b24a0339c27f5614fb0b` | v4.0.0 |
| `actions/deploy-pages` | `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e` | v4.0.5 |
| `softprops/action-gh-release` | `3bb12739c298aeb8a4eeaf626c5b8d85266b0e65` | v2.6.2 |

## Why `persist-credentials: false` is safe on every checkout

- **ci.yml** (3 checkouts) — build/test only, no git writes.
- **docs.yml** (1) — builds the site and deploys via `actions/deploy-pages` (OIDC token), not `git push`.
- **release.yml** (1) — runs `git describe`/`git log` (read-only, keeps `fetch-depth: 0`); the release is created through `action-gh-release`'s API token, not a git push.

## Changes

- `.github/workflows/ci.yml` — pin 3× checkout + 2× sccache; `persist-credentials: false`.
- `.github/workflows/docs.yml` — pin checkout/setup-node/upload-pages-artifact/deploy-pages; `persist-credentials: false`.
- `.github/workflows/release.yml` — pin checkout + action-gh-release; `persist-credentials: false`.
- `.github/dependabot.yml` — new; weekly `github-actions` updates.

## Verification

- All four YAML files parse (`yaml.safe_load_all`).
- No `@vN` moving-tag references remain (`grep 'uses: .*@v[0-9]'` → none).
- SHAs resolved live from each action's tag via the GitHub API.

## Test plan
- [ ] Fast CI passes with the pinned actions (proves the SHAs resolve and run)
- [ ] CodeRabbit/zizmor no longer reports `unpinned-uses` / `artipacked`
- [ ] Promote to ready: `gh pr ready <N>`

Resolves #62

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automated dependency update checks via Dependabot with weekly scheduling and automated pull requests.
  * Enhanced CI/CD workflow security by pinning GitHub Actions to specific commit versions for improved reliability and reproducibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->