### PR TITLE
chore(ci): gate sccache to trusted runs to prevent GHA cache poisoning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,12 +98,21 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
 
+    # Use sccache (and its GitHub Actions cache) only on trusted runs: pushes
+    # and same-repo PRs. Forked PRs leave it empty so they never write to the
+    # shared GHA cache (zizmor cache-poisoning). An empty launcher == no launcher.
+    env:
+      SCCACHE_LAUNCHER: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'sccache' || '' }}
+
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Set up sccache
+        if: >-
+          github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       - name: Configure (Unix, GCC/Clang)
@@ -113,8 +122,8 @@ jobs:
           -DCMAKE_CXX_STANDARD=20
           -DCMAKE_C_COMPILER=${{ matrix.cc }}
           -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
-          -DCMAKE_C_COMPILER_LAUNCHER=sccache
-          -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+          -DCMAKE_C_COMPILER_LAUNCHER=${{ env.SCCACHE_LAUNCHER }}
+          -DCMAKE_CXX_COMPILER_LAUNCHER=${{ env.SCCACHE_LAUNCHER }}
           -DCMAKE_BUILD_TYPE=Release
 
       - name: Configure (Windows, MSVC)
@@ -123,8 +132,8 @@ jobs:
           cmake -B build
           -G "Visual Studio 17 2022" -A x64
           -DCMAKE_CXX_STANDARD=20
-          -DCMAKE_C_COMPILER_LAUNCHER=sccache
-          -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+          -DCMAKE_C_COMPILER_LAUNCHER=${{ env.SCCACHE_LAUNCHER }}
+          -DCMAKE_CXX_COMPILER_LAUNCHER=${{ env.SCCACHE_LAUNCHER }}
 
       - name: Configure (Windows, Clang-CL)
         if: matrix.compiler == 'clang-cl'
@@ -133,8 +142,8 @@ jobs:
           -G "Visual Studio 17 2022" -A x64
           -T ClangCL
           -DCMAKE_CXX_STANDARD=20
-          -DCMAKE_C_COMPILER_LAUNCHER=sccache
-          -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+          -DCMAKE_C_COMPILER_LAUNCHER=${{ env.SCCACHE_LAUNCHER }}
+          -DCMAKE_CXX_COMPILER_LAUNCHER=${{ env.SCCACHE_LAUNCHER }}
 
       - name: Build (Unix)
         if: runner.os != 'Windows'
@@ -162,12 +171,20 @@ jobs:
     needs: build
     runs-on: ubuntu-24.04
 
+    # Same trusted-run gate as the build job (see note there): forked PRs skip
+    # sccache so they cannot poison the shared GHA cache.
+    env:
+      SCCACHE_LAUNCHER: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'sccache' || '' }}
+
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Set up sccache
+        if: >-
+          github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       - name: Configure
@@ -175,8 +192,8 @@ jobs:
           cmake --preset ci-regression
           -DCMAKE_C_COMPILER=gcc-13
           -DCMAKE_CXX_COMPILER=g++-13
-          -DCMAKE_C_COMPILER_LAUNCHER=sccache
-          -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+          -DCMAKE_C_COMPILER_LAUNCHER=${{ env.SCCACHE_LAUNCHER }}
+          -DCMAKE_CXX_COMPILER_LAUNCHER=${{ env.SCCACHE_LAUNCHER }}
 
       - name: Build
         run: cmake --build build-ci-regression --parallel


### PR DESCRIPTION
## Summary

Resolves the zizmor `cache-poisoning` finding (#65). `mozilla-actions/sccache-action` restores from and writes to the shared GitHub Actions cache and runs on `pull_request`, so a **forked** PR could in principle seed poisoned compiler artifacts that a later trusted run restores.

Implements **option (B)** from the issue — keep caching for trusted runs, skip it for forks — so normal same-repo development keeps full sccache speedup while untrusted forks can no longer touch the shared cache.

## How

The sccache-action both installs the `sccache` binary *and* enables the GHA cache, and CMake uses `-DCMAKE_*_COMPILER_LAUNCHER=sccache`. So the gate has to keep builds working when sccache is absent:

- **Job-level `env.SCCACHE_LAUNCHER`** (build + regression): `'sccache'` on pushes and same-repo PRs, `''` (no launcher) for forked PRs — computed from the `github` context.
- **`if:` gate on "Set up sccache"** with the same trusted-run condition, so the cache action doesn't run for forked PRs.
- **Launcher flags** reference `${{ env.SCCACHE_LAUNCHER }}` — trusted runs use sccache; forked PRs build with the compiler directly (empty launcher = none).

Trusted = `github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository`.

## Changes

- `.github/workflows/ci.yml` — `env` block + sccache `if:` gate on both the `build` and `regression` jobs; 8 launcher flags switched to the gated env var.

## Verification

- `ci.yml` parses as valid YAML.
- Expression matrix: push → `sccache` + action runs; same-repo PR → `sccache` + action runs; forked PR → empty launcher + action skipped.
- This PR itself is a same-repo PR, so CI will exercise the trusted path (sccache active) end-to-end.
- zizmor isn't run in this repo's CI; CodeRabbit's zizmor will re-check the `cache-poisoning` rule on this PR.

## Test plan
- [ ] Fast CI passes with sccache active on the trusted path
- [ ] CodeRabbit/zizmor no longer reports `cache-poisoning` (or it's an accepted, gated residual)
- [ ] Promote to ready: `gh pr ready <N>`

Resolves #65

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI pipeline with enhanced build cache handling and improved security controls for pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->