### PR TITLE
docs(benchmarks): fix BLAS/LAPACK option names and add MKL instructions

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -109,11 +109,25 @@ for_each_backend(dense_backends{}, [&]<typename Backend>() {
 cmake -B build -DMTL5_BUILD_BENCHMARKS=ON
 cmake --build build --target bench_all
 
-# With BLAS + LAPACK comparison
+# With BLAS + LAPACK comparison (uses the system default BLAS, e.g. OpenBLAS)
 cmake -B build -DMTL5_BUILD_BENCHMARKS=ON \
-      -DMTL5_ENABLE_BLAS=ON -DMTL5_ENABLE_LAPACK=ON
+      -DMTL5_WITH_BLAS=ON -DMTL5_WITH_LAPACK=ON
 cmake --build build --target bench_all
+
+# Against Intel MKL: select it through CMake's FindBLAS vendor, with the
+# oneAPI environment sourced so the libraries are found at configure and run time.
+source /opt/intel/oneapi/setvars.sh
+cmake -B build-mkl -DMTL5_BUILD_BENCHMARKS=ON \
+      -DMTL5_WITH_BLAS=ON -DMTL5_WITH_LAPACK=ON \
+      -DBLA_VENDOR=Intel10_64lp
+cmake --build build-mkl --target bench_all
 ```
+
+> The CMake options are `MTL5_WITH_BLAS` / `MTL5_WITH_LAPACK`. The benchmark
+> output labels the accelerated backend `blas` / `lapack` regardless of which
+> library is linked, so "native vs MKL" is the `blas` / `lapack` rows of a
+> binary built against MKL. Use separate build directories to keep OpenBLAS and
+> MKL results apart.
 
 ## Running
 


### PR DESCRIPTION
## Summary

The benchmark README documented `-DMTL5_ENABLE_BLAS` / `-DMTL5_ENABLE_LAPACK`, but the real CMake options are **`MTL5_WITH_BLAS`** / **`MTL5_WITH_LAPACK`** — so following the README's "with BLAS + LAPACK" build silently produced a native-only binary.

## Changes

- `benchmarks/README.md`:
  - Fix the option names (`MTL5_ENABLE_*` → `MTL5_WITH_*`).
  - Add an Intel MKL recipe: `source /opt/intel/oneapi/setvars.sh` + select MKL through CMake's `FindBLAS` vendor (`-DBLA_VENDOR=Intel10_64lp`) in a separate build dir.
  - Note that the harness labels the accelerated backend `blas`/`lapack` regardless of the linked library, so MKL numbers are the `blas`/`lapack` rows of an MKL-linked binary.

## Verification

Both recipes were run end-to-end on Linux (Ubuntu noble):
- `MTL5_WITH_BLAS/LAPACK=ON` → links OpenBLAS, full suite runs.
- `+ -DBLA_VENDOR=Intel10_64lp` (oneAPI MKL 2026.0) → links `libmkl_intel_lp64`/`libmkl_core`, full suite runs.

Docs-only change; no code touched.

## Test plan
- [ ] Docs build / CI passes
- [ ] Promote to ready: `gh pr ready <N>`

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark build instructions with revised CMake configuration options.
  * Added guidance for Intel MKL benchmark comparisons, including setup procedures.
  * Clarified benchmark output labeling for accelerated library backends.
  * Recommended separate build directories to distinguish library comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->