### PR TITLE
chore(build): gitignore Claude Code per-user and runtime files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,8 @@ _deps/
 # OS
 .DS_Store
 Thumbs.db
+
+# Claude Code: ignore per-user and runtime files.
+# Shared config (.claude/agents, hooks, skills, settings.json) IS committed.
+.claude/settings.local.json
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## Summary

`.claude/` was neither tracked nor ignored, so it surfaced as `?? .claude/` untracked noise in every `git status`. This ignores the **per-user and runtime** files while keeping **shared** Claude Code config trackable — matching the sister repo (`universal`)'s convention.

## Changes

- `.gitignore` — add:
  - `.claude/settings.local.json` — per-user permission allowlist (machine-specific)
  - `.claude/scheduled_tasks.lock` — runtime lock file

Shared config (`.claude/agents/`, `hooks/`, `skills/`, a project `settings.json`) is intentionally **not** ignored, so it can be committed if/when added.

## Verification

- `git status` no longer lists `.claude/`.
- `git check-ignore` confirms the two local files are ignored.
- `git check-ignore` confirms `settings.json` / `skills/**` are **not** ignored (stay trackable).

Docs/tooling only; no source code touched.

## Test plan
- [ ] CI passes

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated development configuration to better manage local settings and prevent accidental commits of runtime-specific files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->