### PR TITLE
perf(simd): portable SIMD abstraction layer backed by Google Highway

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ endif()
 # fallback, so MTL5 stays MIT and dependency-free by default. Found if already
 # installed, otherwise fetched at a pinned version (reproducible).
 if(MTL5_WITH_HIGHWAY)
-    find_package(hwy 1.0 QUIET)
+    find_package(hwy 1.4 QUIET)   # match the pinned FetchContent tag below
     if(NOT hwy_FOUND)
         include(FetchContent)
         set(HWY_ENABLE_TESTS    OFF CACHE BOOL "" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ option(MTL5_BUILD_EXAMPLES "Build the examples"         ON)
 option(MTL5_ENABLE_OPENMP  "Enable OpenMP parallelism"  OFF)
 option(MTL5_WITH_BLAS               "Link BLAS library for dense acceleration" OFF)
 option(MTL5_WITH_LAPACK             "Link LAPACK library for factorizations"  OFF)
+option(MTL5_WITH_HIGHWAY            "Use Google Highway for SIMD-accelerated native kernels" OFF)
 option(MTL5_WITH_UMFPACK            "Link UMFPACK library (SuiteSparse)"      OFF)
 option(MTL5_WITH_SUPERLU            "Link SuperLU library"                    OFF)
 option(MTL5_WITH_SUITESPARSE_KLU    "Link KLU sparse solver (SuiteSparse)"    OFF)
@@ -96,6 +97,32 @@ if(MTL5_WITH_LAPACK)
     find_package(LAPACK REQUIRED)
     target_compile_definitions(mtl5 INTERFACE MTL5_HAS_LAPACK)
     target_link_libraries(mtl5 INTERFACE ${LAPACK_LIBRARIES})
+endif()
+
+# Google Highway (Apache-2.0 / BSD-3-Clause): SIMD backend for mtl::simd.
+# Optional, like BLAS/LAPACK — without it mtl::simd uses a portable scalar
+# fallback, so MTL5 stays MIT and dependency-free by default. Found if already
+# installed, otherwise fetched at a pinned version (reproducible).
+if(MTL5_WITH_HIGHWAY)
+    find_package(hwy 1.0 QUIET)
+    if(NOT hwy_FOUND)
+        include(FetchContent)
+        set(HWY_ENABLE_TESTS    OFF CACHE BOOL "" FORCE)
+        set(HWY_ENABLE_EXAMPLES OFF CACHE BOOL "" FORCE)
+        set(HWY_ENABLE_CONTRIB  OFF CACHE BOOL "" FORCE)
+        set(HWY_ENABLE_INSTALL  OFF CACHE BOOL "" FORCE)
+        FetchContent_Declare(highway
+            GIT_REPOSITORY https://github.com/google/highway.git
+            GIT_TAG        1.4.0
+            GIT_SHALLOW    TRUE)
+        FetchContent_MakeAvailable(highway)
+    endif()
+    # BUILD_INTERFACE only: a fetched `hwy` target can't be part of MTL5's
+    # install export set. Highway is active for in-tree consumers (tests,
+    # benchmarks, the native kernels); an installed MTL5 re-enables it against
+    # its own Highway, like the BLAS/LAPACK backends.
+    target_compile_definitions(mtl5 INTERFACE $<BUILD_INTERFACE:MTL5_HAS_HIGHWAY>)
+    target_link_libraries(mtl5 INTERFACE $<BUILD_INTERFACE:hwy>)
 endif()
 
 if(MTL5_WITH_UMFPACK)

--- a/include/mtl/mtl.hpp
+++ b/include/mtl/mtl.hpp
@@ -9,6 +9,9 @@
 // Forward declarations
 #include <mtl/mtl_fwd.hpp>
 
+// SIMD abstraction (Highway-backed when MTL5_HAS_HIGHWAY, scalar fallback otherwise)
+#include <mtl/simd/batch.hpp>
+
 // Concepts
 #include <mtl/concepts/scalar.hpp>
 #include <mtl/concepts/magnitude.hpp>

--- a/include/mtl/simd/batch.hpp
+++ b/include/mtl/simd/batch.hpp
@@ -1,0 +1,127 @@
+#pragma once
+// MTL5 -- portable SIMD abstraction (Phase 0 of the native-BLAS performance epic, #82/#83)
+//
+// `mtl::simd::batch<T>` is a value-type wrapper over one SIMD register with a
+// COMPILE-TIME lane count (`batch<T>::size`). A kernel is written ONCE against
+// this type and the lane width becomes the unroll factor -- the algorithm is
+// decoupled from the SIMD width (the xtensor/xsimd idea; cf. std::simd, Eigen
+// PacketMath). It exposes: aligned/unaligned load & store, broadcast, + - * /,
+// a single fma() primitive (one FMA decision point), and horizontal
+// reduce_add / reduce_min / reduce_max.
+//
+// Backends, selected at compile time:
+//   * Google Highway (Apache-2.0 / BSD-3-Clause), when MTL5_HAS_HIGHWAY is
+//     defined AND the target is not vector-length-agnostic (x86 SSE..AVX-512,
+//     NEON, ...). One ISA per build, chosen by the compiler -m flags (static
+//     dispatch). Enable with CMake -DMTL5_WITH_HIGHWAY=ON.
+//   * Portable scalar fallback (size == 1) otherwise -- correct everywhere and
+//     autovectorizable, so MTL5 stays MIT and dependency-free by default.
+//
+// The API surface is identical across backends, so the dense kernels (#86-#90)
+// never need to know which one is active.
+
+#include <cmath>
+#include <cstddef>
+#include <type_traits>
+
+#if defined(MTL5_HAS_HIGHWAY)
+#  include <hwy/highway.h>
+#  if HWY_HAVE_SCALABLE
+#    define MTL5_SIMD_USE_HIGHWAY 0   // scalable (SVE/RVV): no constexpr lane count yet -> scalar
+#  else
+#    define MTL5_SIMD_USE_HIGHWAY 1
+#  endif
+#else
+#  define MTL5_SIMD_USE_HIGHWAY 0
+#endif
+
+namespace mtl::simd {
+
+#if MTL5_SIMD_USE_HIGHWAY
+
+namespace hn = hwy::HWY_NAMESPACE;
+
+/// SIMD register of `T`, backed by Google Highway (static dispatch).
+template <typename T>
+class batch {
+    using D = hn::ScalableTag<T>;
+    using V = hn::VFromD<D>;
+    static constexpr D d_{};
+    V v_;
+    explicit batch(V v) : v_(v) {}
+
+public:
+    using value_type = T;
+    /// Lane count for the compiled target (compile-time constant).
+    static constexpr std::size_t size = HWY_MAX_LANES_D(D);
+
+    batch() : v_(hn::Zero(d_)) {}
+    explicit batch(T x) : v_(hn::Set(d_, x)) {}
+
+    static batch load_aligned(const T* p)   { return batch(hn::Load(d_, p)); }
+    static batch load_unaligned(const T* p) { return batch(hn::LoadU(d_, p)); }
+    void store_aligned(T* p)   const { hn::Store(v_, d_, p); }
+    void store_unaligned(T* p) const { hn::StoreU(v_, d_, p); }
+
+    friend batch operator+(batch a, batch b) { return batch(hn::Add(a.v_, b.v_)); }
+    friend batch operator-(batch a, batch b) { return batch(hn::Sub(a.v_, b.v_)); }
+    friend batch operator*(batch a, batch b) { return batch(hn::Mul(a.v_, b.v_)); }
+    friend batch operator/(batch a, batch b) { return batch(hn::Div(a.v_, b.v_)); }
+
+    /// Fused multiply-add: a*b + c (the single FMA decision point).
+    friend batch fma(batch a, batch b, batch c) { return batch(hn::MulAdd(a.v_, b.v_, c.v_)); }
+
+    friend T reduce_add(batch a) { return hn::ReduceSum(d_, a.v_); }
+    friend T reduce_min(batch a) { return hn::ReduceMin(d_, a.v_); }
+    friend T reduce_max(batch a) { return hn::ReduceMax(d_, a.v_); }
+};
+
+#else  // ---- portable scalar fallback (size == 1) ----
+
+template <typename T>
+class batch {
+    T v_{};
+
+public:
+    using value_type = T;
+    static constexpr std::size_t size = 1;
+
+    batch() = default;
+    explicit batch(T x) : v_(x) {}
+
+    static batch load_aligned(const T* p)   { return batch(p[0]); }
+    static batch load_unaligned(const T* p) { return batch(p[0]); }
+    void store_aligned(T* p)   const { p[0] = v_; }
+    void store_unaligned(T* p) const { p[0] = v_; }
+
+    friend batch operator+(batch a, batch b) { return batch(a.v_ + b.v_); }
+    friend batch operator-(batch a, batch b) { return batch(a.v_ - b.v_); }
+    friend batch operator*(batch a, batch b) { return batch(a.v_ * b.v_); }
+    friend batch operator/(batch a, batch b) { return batch(a.v_ / b.v_); }
+
+    /// Fused multiply-add: a*b + c (the single FMA decision point).
+    friend batch fma(batch a, batch b, batch c) {
+        using std::fma;
+        return batch(fma(a.v_, b.v_, c.v_));
+    }
+
+    friend T reduce_add(batch a) { return a.v_; }
+    friend T reduce_min(batch a) { return a.v_; }
+    friend T reduce_max(batch a) { return a.v_; }
+};
+
+#endif
+
+/// Largest multiple of W not exceeding n -- the SIMD body length; iterate the
+/// remainder [vectorizable_length(n) .. n) scalar:
+///   for (i = 0; i < vectorizable_length(n, W); i += W) { ... }   // SIMD
+///   for (; i < n; ++i) { ... }                                   // tail
+constexpr std::size_t vectorizable_length(std::size_t n, std::size_t w) noexcept {
+    return w == 0 ? 0 : n - (n % w);
+}
+
+/// Lane count of batch<T> for the current build (1 on the scalar fallback).
+template <typename T>
+inline constexpr std::size_t width = batch<T>::size;
+
+} // namespace mtl::simd

--- a/include/mtl/simd/batch.hpp
+++ b/include/mtl/simd/batch.hpp
@@ -44,6 +44,11 @@ namespace hn = hwy::HWY_NAMESPACE;
 /// SIMD register of `T`, backed by Google Highway (static dispatch).
 template <typename T>
 class batch {
+    static_assert(std::is_floating_point_v<T>,
+                  "mtl::simd::batch currently supports floating-point lanes "
+                  "(float/double) -- the dense-BLAS use case. The ops (/, fma, "
+                  "reductions) assume floating semantics; integer lanes are a "
+                  "future extension.");
     using D = hn::ScalableTag<T>;
     using V = hn::VFromD<D>;
     static constexpr D d_{};
@@ -80,6 +85,11 @@ public:
 
 template <typename T>
 class batch {
+    static_assert(std::is_floating_point_v<T>,
+                  "mtl::simd::batch currently supports floating-point lanes "
+                  "(float/double) -- the dense-BLAS use case. The ops (/, fma, "
+                  "reductions) assume floating semantics; integer lanes are a "
+                  "future extension.");
     T v_{};
 
 public:

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -4,6 +4,9 @@
 file(GLOB CONCEPT_SRC "concepts/*.cpp")
 compile_all("true" "concept" "Tests/concepts" "MTL5::mtl5;Catch2::Catch2WithMain" ${CONCEPT_SRC})
 
+file(GLOB SIMD_SRC "simd/*.cpp")
+compile_all("true" "simd" "Tests/simd" "MTL5::mtl5;Catch2::Catch2WithMain" ${SIMD_SRC})
+
 file(GLOB MATH_SRC "math/*.cpp")
 compile_all("true" "math" "Tests/math" "MTL5::mtl5;Catch2::Catch2WithMain" ${MATH_SRC})
 

--- a/tests/unit/simd/test_batch.cpp
+++ b/tests/unit/simd/test_batch.cpp
@@ -1,0 +1,125 @@
+// Tests for the mtl::simd::batch<T> abstraction (#83).
+// These exercise the public API against a scalar reference and pass in both
+// backends (Highway when MTL5_HAS_HIGHWAY, scalar fallback otherwise).
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <mtl/simd/batch.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <vector>
+
+using Catch::Approx;
+
+TEST_CASE("vectorizable_length tail helper", "[simd]") {
+    using mtl::simd::vectorizable_length;
+    CHECK(vectorizable_length(10, 4) == 8);
+    CHECK(vectorizable_length(8, 4) == 8);
+    CHECK(vectorizable_length(3, 4) == 0);
+    CHECK(vectorizable_length(0, 4) == 0);
+    CHECK(vectorizable_length(7, 1) == 7);   // scalar fallback: no tail
+    CHECK(vectorizable_length(7, 0) == 0);   // guard against div-by-zero
+}
+
+TEMPLATE_TEST_CASE("batch size is a positive compile-time constant", "[simd]", float, double) {
+    using B = mtl::simd::batch<TestType>;
+    STATIC_REQUIRE(B::size >= 1);
+    STATIC_REQUIRE(mtl::simd::width<TestType> == B::size);
+}
+
+TEMPLATE_TEST_CASE("batch load/store round-trip (aligned + unaligned)", "[simd]", float, double) {
+    using B = mtl::simd::batch<TestType>;
+    constexpr std::size_t N = B::size;
+
+    alignas(64) TestType in[64];
+    alignas(64) TestType out[64];
+    for (std::size_t i = 0; i < N; ++i) in[i] = static_cast<TestType>(i) + TestType(1);
+
+    SECTION("unaligned") {
+        auto v = B::load_unaligned(in);
+        v.store_unaligned(out);
+        for (std::size_t i = 0; i < N; ++i) CHECK(out[i] == in[i]);
+    }
+    SECTION("aligned") {
+        auto v = B::load_aligned(in);
+        v.store_aligned(out);
+        for (std::size_t i = 0; i < N; ++i) CHECK(out[i] == in[i]);
+    }
+    SECTION("broadcast") {
+        B v(TestType(3.5));
+        v.store_unaligned(out);
+        for (std::size_t i = 0; i < N; ++i) CHECK(out[i] == Approx(TestType(3.5)));
+    }
+}
+
+TEMPLATE_TEST_CASE("batch elementwise arithmetic vs scalar", "[simd]", float, double) {
+    using B = mtl::simd::batch<TestType>;
+    constexpr std::size_t N = B::size;
+    alignas(64) TestType a[64], b[64], r[64];
+    for (std::size_t i = 0; i < N; ++i) { a[i] = TestType(i) + 2; b[i] = TestType(i) * TestType(0.5) + 1; }
+
+    auto va = B::load_aligned(a);
+    auto vb = B::load_aligned(b);
+
+    (va + vb).store_aligned(r); for (std::size_t i=0;i<N;++i) CHECK(r[i] == Approx(a[i] + b[i]));
+    (va - vb).store_aligned(r); for (std::size_t i=0;i<N;++i) CHECK(r[i] == Approx(a[i] - b[i]));
+    (va * vb).store_aligned(r); for (std::size_t i=0;i<N;++i) CHECK(r[i] == Approx(a[i] * b[i]));
+    (va / vb).store_aligned(r); for (std::size_t i=0;i<N;++i) CHECK(r[i] == Approx(a[i] / b[i]));
+}
+
+TEMPLATE_TEST_CASE("batch fma matches a*b+c", "[simd]", float, double) {
+    using B = mtl::simd::batch<TestType>;
+    constexpr std::size_t N = B::size;
+    alignas(64) TestType a[64], b[64], c[64], r[64];
+    for (std::size_t i = 0; i < N; ++i) { a[i]=TestType(i)+1; b[i]=TestType(2); c[i]=TestType(0.25)*TestType(i); }
+
+    fma(B::load_aligned(a), B::load_aligned(b), B::load_aligned(c)).store_aligned(r);
+    for (std::size_t i = 0; i < N; ++i) CHECK(r[i] == Approx(a[i]*b[i] + c[i]));
+}
+
+TEMPLATE_TEST_CASE("batch horizontal reductions", "[simd]", float, double) {
+    using B = mtl::simd::batch<TestType>;
+    constexpr std::size_t N = B::size;
+    alignas(64) TestType a[64];
+    TestType sum = 0, mn = std::numeric_limits<TestType>::max(), mx = std::numeric_limits<TestType>::lowest();
+    for (std::size_t i = 0; i < N; ++i) {
+        a[i] = TestType(i) - TestType(N) / 2 + TestType(1);   // mix of signs
+        sum += a[i]; mn = std::min(mn, a[i]); mx = std::max(mx, a[i]);
+    }
+    auto v = B::load_aligned(a);
+    CHECK(reduce_add(v) == Approx(sum));
+    CHECK(reduce_min(v) == Approx(mn));
+    CHECK(reduce_max(v) == Approx(mx));
+}
+
+// "Written once" SIMD kernel: y = alpha*x + y, body + scalar tail. Compiles to
+// the widest enabled ISA by build flags only; correct for any length.
+namespace {
+template <typename T>
+void simd_axpy(T alpha, const T* x, T* y, std::size_t n) {
+    using B = mtl::simd::batch<T>;
+    const B va(alpha);
+    const std::size_t vl = mtl::simd::vectorizable_length(n, B::size);
+    std::size_t i = 0;
+    for (; i < vl; i += B::size) {
+        auto r = fma(va, B::load_unaligned(x + i), B::load_unaligned(y + i));
+        r.store_unaligned(y + i);
+    }
+    for (; i < n; ++i) y[i] = alpha * x[i] + y[i];
+}
+}
+
+TEMPLATE_TEST_CASE("written-once axpy over arbitrary (incl. non-multiple) lengths", "[simd]", float, double) {
+    const std::size_t lengths[] = {0, 1, 3, 7, 16, 31, 33, 100, 257};
+    for (std::size_t n : lengths) {
+        std::vector<TestType> x(n), y(n), ref(n);
+        for (std::size_t i = 0; i < n; ++i) { x[i] = TestType(i) * TestType(0.5) + 1; y[i] = TestType(2) - TestType(i); ref[i] = y[i]; }
+        const TestType alpha = TestType(1.5);
+        simd_axpy(alpha, x.data(), y.data(), n);
+        for (std::size_t i = 0; i < n; ++i) CHECK(y[i] == Approx(alpha * x[i] + ref[i]));
+    }
+}


### PR DESCRIPTION
First foundation of the native dense-BLAS performance epic (#82). Resolves #83.

## What
`mtl::simd::batch<T>` — a value-type wrapper over one SIMD register with a **compile-time lane count** (`batch<T>::size`). Kernels are written once against `batch`; the lane width is the unroll factor, decoupling the algorithm from the SIMD width (the xtensor/xsimd idea; cf. `std::simd`, Eigen `PacketMath`). API: aligned/unaligned `load`/`store`, broadcast, `+ - * /`, a single `fma()` primitive (one FMA decision point), horizontal `reduce_add/min/max`, and a `vectorizable_length` tail helper.

## Backend choice
- **Google Highway** (Apache-2.0 / BSD-3-Clause), static dispatch, when `MTL5_HAS_HIGHWAY` is set and the target isn't vector-length-agnostic. Enable via `-DMTL5_WITH_HIGHWAY=ON` (found if installed, else fetched at pinned **1.4.0**). Linked `$<BUILD_INTERFACE:hwy>` so the fetched target stays out of MTL5's install export set.
- **Portable scalar fallback** (`size == 1`) otherwise → MTL5 stays **MIT and dependency-free by default**, and all 8 CI platforms compile.

Highway was chosen over xsimd/vir-simd for project longevity + a permissive license. **vir-simd is LGPL-3.0**, incompatible with MTL5's MIT license, so it was rejected (flagged mid-review).

## Changes
- `include/mtl/simd/batch.hpp` (new) — the abstraction + both backends.
- `include/mtl/mtl.hpp` — expose it via the umbrella.
- `CMakeLists.txt` — `MTL5_WITH_HIGHWAY` option + optional fetch/find of Highway.
- `tests/unit/simd/test_batch.cpp` (new) + `tests/unit/CMakeLists.txt` glob.

## Test results
| Config | Build | Tests |
|--------|-------|-------|
| scalar fallback, gcc | OK | **100/100** (full suite) |
| scalar fallback, clang | OK (compiles) | — |
| Highway `-march=native`, gcc | OK | simd PASS |
| Highway `-march=native`, clang | OK | simd PASS (probe) |

Lane count scales by build flags only: SSE→2, AVX2→4 doubles. Tests cover load/store (aligned+unaligned), broadcast, arithmetic, `fma` vs `a*b+c`, reductions, the tail helper, and a written-once axpy over non-multiple lengths — all vs a scalar reference, for `float` and `double`.

## Notes / follow-ups
- Default CI (Highway OFF) exercises the scalar path on all platforms; the Highway path is verified locally on gcc+clang. A CI job with `-DMTL5_WITH_HIGHWAY=ON` to exercise the SIMD path in CI is a small follow-up (tie into #85/#93).
- Over-aligned storage so kernels can use `load_aligned` on heap data is **#84** (next).

## Test plan
- [ ] Fast CI passes (scalar fallback on all platforms)
- [ ] Promote to ready: `gh pr ready 95`

Resolves #83

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional SIMD backend for vectorized computations with automatic scalar fallback.
  * New SIMD batch API for elementwise arithmetic, fused multiply-add, and horizontal reductions; exposes vectorizable length and lane-width helpers.

* **Tests**
  * Added comprehensive unit tests validating SIMD batch behavior, reductions, loads/stores, fma, and a SIMD-enabled kernel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->