### PR TITLE
perf(mat): over-aligned storage + aligned allocator for dense2D/dense_vector

### DIFF
--- a/include/mtl/detail/aligned_allocator.hpp
+++ b/include/mtl/detail/aligned_allocator.hpp
@@ -1,0 +1,81 @@
+#pragma once
+// MTL5 -- over-aligned heap allocation for SIMD-friendly storage (#84, epic #82).
+//
+// Dense storage and packing buffers are over-aligned to a cache-line / widest-
+// SIMD boundary so the SIMD layer (mtl::simd, #83) can use aligned loads/stores
+// and packed panels start on aligned addresses. Uses C++17 over-aligned
+// operator new/delete, which is portable across GCC/Clang/MSVC (unlike
+// posix_memalign / std::aligned_alloc).
+
+#include <cstddef>
+#include <memory>        // uninitialized_value_construct_n, destroy_n
+#include <new>           // ::operator new(std::align_val_t), std::align_val_t
+#include <type_traits>   // remove_cv_t
+
+namespace mtl::detail {
+
+/// Default over-alignment: 64 bytes covers a typical cache line and the widest
+/// common SIMD register (AVX-512). Types with a larger natural alignment keep it.
+inline constexpr std::size_t default_alignment = 64;
+
+/// Alignment used for a block of `T`: at least `default_alignment`, but never
+/// less than T's natural alignment.
+template <typename T>
+inline constexpr std::size_t block_alignment =
+    alignof(T) > default_alignment ? alignof(T) : default_alignment;
+
+/// Allocate and value-initialize `n` elements of `T` on an over-aligned heap
+/// block (`block_alignment<T>`). Returns nullptr for n == 0. Works for cv-
+/// qualified `T` (e.g. ndarray's `const double` views) by constructing/freeing
+/// through the unqualified type.
+template <typename T>
+[[nodiscard]] T* allocate_aligned(std::size_t n) {
+    using U = std::remove_cv_t<T>;
+    if (n == 0) return nullptr;
+    void* raw = ::operator new(n * sizeof(U), std::align_val_t(block_alignment<U>));
+    U* p = static_cast<U*>(raw);
+    std::uninitialized_value_construct_n(p, n);
+    return p;   // implicit U* -> T* (adds const/volatile back if any)
+}
+
+/// Destroy `n` elements and free a block from allocate_aligned. No-op on nullptr.
+template <typename T>
+void deallocate_aligned(T* p, std::size_t n) noexcept {
+    using U = std::remove_cv_t<T>;
+    if (p == nullptr) return;
+    U* up = const_cast<U*>(p);
+    std::destroy_n(up, n);
+    ::operator delete(static_cast<void*>(up), std::align_val_t(block_alignment<U>));
+}
+
+/// C++ Allocator that hands out `Align`-byte-aligned storage. Usable as
+/// `std::vector<T, aligned_allocator<T>>` for SIMD-friendly scratch/packing
+/// buffers. Stateless: all instances compare equal.
+template <typename T, std::size_t Align = block_alignment<T>>
+class aligned_allocator {
+public:
+    using value_type = T;
+    static constexpr std::size_t alignment = Align;
+
+    aligned_allocator() noexcept = default;
+    template <typename U>
+    aligned_allocator(const aligned_allocator<U, Align>&) noexcept {}
+
+    template <typename U>
+    struct rebind { using other = aligned_allocator<U, Align>; };
+
+    [[nodiscard]] T* allocate(std::size_t n) {
+        if (n == 0) return nullptr;
+        return static_cast<T*>(::operator new(n * sizeof(T), std::align_val_t(Align)));
+    }
+    void deallocate(T* p, std::size_t /*n*/) noexcept {
+        ::operator delete(static_cast<void*>(p), std::align_val_t(Align));
+    }
+
+    template <typename U>
+    bool operator==(const aligned_allocator<U, Align>&) const noexcept { return true; }
+    template <typename U>
+    bool operator!=(const aligned_allocator<U, Align>&) const noexcept { return false; }
+};
+
+} // namespace mtl::detail

--- a/include/mtl/detail/aligned_allocator.hpp
+++ b/include/mtl/detail/aligned_allocator.hpp
@@ -34,7 +34,12 @@ template <typename T>
     if (n == 0) return nullptr;
     void* raw = ::operator new(n * sizeof(U), std::align_val_t(block_alignment<U>));
     U* p = static_cast<U*>(raw);
-    std::uninitialized_value_construct_n(p, n);
+    try {
+        std::uninitialized_value_construct_n(p, n);
+    } catch (...) {
+        ::operator delete(raw, std::align_val_t(block_alignment<U>));   // no leak if a ctor throws
+        throw;
+    }
     return p;   // implicit U* -> T* (adds const/volatile back if any)
 }
 

--- a/include/mtl/detail/contiguous_memory_block.hpp
+++ b/include/mtl/detail/contiguous_memory_block.hpp
@@ -8,6 +8,7 @@
 #include <type_traits>
 #include <utility>
 
+#include <mtl/detail/aligned_allocator.hpp>
 #include <mtl/tag/storage.hpp>
 
 namespace mtl::detail {
@@ -22,9 +23,10 @@ template <typename Value, typename Storage, std::size_t StaticSize = 0>
 class contiguous_memory_block {
     static constexpr bool on_stack = std::is_same_v<Storage, tag::on_stack>;
 
-    // Stack storage: fixed-size aligned array
+    // Stack storage: fixed-size array, over-aligned to the SIMD/cache-line
+    // boundary so fixed-size operands also support aligned SIMD loads.
     struct stack_data {
-        alignas(alignof(Value)) Value data_[StaticSize > 0 ? StaticSize : 1];
+        alignas(block_alignment<Value>) Value data_[StaticSize > 0 ? StaticSize : 1];
     };
 
     // Heap storage: pointer + size + ownership
@@ -36,11 +38,12 @@ class contiguous_memory_block {
 
     std::conditional_t<on_stack, stack_data, heap_data> store_;
 
-    // Heap helpers
+    // Heap helpers. Owned blocks are over-aligned (block_alignment<Value>, i.e.
+    // >= 64B) so .data() is suitable for aligned SIMD loads/stores.
     void allocate(std::size_t n) {
         assert(!on_stack);
         if constexpr (!on_stack) {
-            store_.data_ = (n > 0) ? new Value[n]{} : nullptr;
+            store_.data_ = allocate_aligned<Value>(n);   // value-initialized, nullptr if n==0
             store_.size_ = n;
             store_.category_ = memory_category::own;
         }
@@ -49,7 +52,7 @@ class contiguous_memory_block {
     void deallocate() {
         if constexpr (!on_stack) {
             if (store_.category_ == memory_category::own) {
-                delete[] store_.data_;
+                deallocate_aligned<Value>(store_.data_, store_.size_);
             }
             store_.data_ = nullptr;
             store_.size_ = 0;

--- a/tests/unit/detail/test_aligned_storage.cpp
+++ b/tests/unit/detail/test_aligned_storage.cpp
@@ -1,0 +1,78 @@
+// Tests for over-aligned storage + aligned allocator (#84, epic #82).
+#include <catch2/catch_test_macros.hpp>
+
+#include <mtl/detail/aligned_allocator.hpp>
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/vec/dense_vector.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace {
+bool is_aligned(const void* p, std::size_t a) {
+    return (reinterpret_cast<std::uintptr_t>(p) % a) == 0;
+}
+}
+
+TEST_CASE("block_alignment is >= 64 and respects natural alignment", "[detail][simd]") {
+    using mtl::detail::block_alignment;
+    STATIC_REQUIRE(block_alignment<float>  >= 64);
+    STATIC_REQUIRE(block_alignment<double> >= 64);
+    struct alignas(128) Over { double x; };
+    STATIC_REQUIRE(block_alignment<Over> == 128);   // larger natural alignment wins
+}
+
+TEST_CASE("allocate_aligned: aligned, value-initialized, round-trips", "[detail][simd]") {
+    using mtl::detail::allocate_aligned;
+    using mtl::detail::deallocate_aligned;
+
+    CHECK(allocate_aligned<double>(0) == nullptr);
+
+    for (std::size_t n : std::vector<std::size_t>{1, 3, 7, 64, 1000}) {
+        double* p = allocate_aligned<double>(n);
+        REQUIRE(p != nullptr);
+        CHECK(is_aligned(p, 64));
+        for (std::size_t i = 0; i < n; ++i) CHECK(p[i] == 0.0);   // value-initialized
+        for (std::size_t i = 0; i < n; ++i) p[i] = double(i);
+        for (std::size_t i = 0; i < n; ++i) CHECK(p[i] == double(i));
+        deallocate_aligned(p, n);
+    }
+}
+
+TEST_CASE("aligned_allocator backs an over-aligned std::vector", "[detail][simd]") {
+    std::vector<double, mtl::detail::aligned_allocator<double>> v(257, 1.5);
+    REQUIRE(v.size() == 257);
+    CHECK(is_aligned(v.data(), 64));
+    CHECK(v[0] == 1.5);
+    CHECK(v[256] == 1.5);
+}
+
+TEST_CASE("dense2D<double> heap buffer is 64B-aligned", "[mat][detail][simd]") {
+    for (std::size_t n : std::vector<std::size_t>{4, 5, 13, 64, 257}) {
+        mtl::mat::dense2D<double> A(n, n);
+        REQUIRE(A.data() != nullptr);
+        CHECK(is_aligned(A.data(), 64));
+    }
+    mtl::mat::dense2D<float> Af(100, 100);
+    CHECK(is_aligned(Af.data(), 64));
+}
+
+TEST_CASE("dense_vector<double> heap buffer is 64B-aligned", "[vec][detail][simd]") {
+    for (std::size_t n : std::vector<std::size_t>{1, 7, 64, 1025}) {
+        mtl::vec::dense_vector<double> v(n);
+        REQUIRE(v.data() != nullptr);
+        CHECK(is_aligned(v.data(), 64));
+    }
+}
+
+TEST_CASE("alignment survives copy/move/realloc (still owns aligned storage)", "[mat][detail][simd]") {
+    mtl::mat::dense2D<double> A(33, 17);
+    A(0, 0) = 3.0;
+    auto B = A;                       // copy
+    CHECK(is_aligned(B.data(), 64));
+    CHECK(B(0, 0) == 3.0);
+    auto C = std::move(A);            // move (steals pointer; already aligned)
+    CHECK(is_aligned(C.data(), 64));
+    CHECK(C(0, 0) == 3.0);
+}

--- a/tests/unit/detail/test_aligned_storage.cpp
+++ b/tests/unit/detail/test_aligned_storage.cpp
@@ -7,6 +7,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <utility>   // std::move
 #include <vector>
 
 namespace {


### PR DESCRIPTION
Phase 0 of the native dense-BLAS performance epic (#82). Resolves #84.

## Why
`dense2D` / `dense_vector` heap storage used plain `new[]/delete[]` (only naturally aligned), so the SIMD layer (#83) couldn't safely use **aligned** loads/stores on `.data()`, and packed panels (#89) wouldn't start on cache-line boundaries.

## Changes
- **`include/mtl/detail/aligned_allocator.hpp`** (new):
  - `block_alignment<T>` = `max(alignof(T), 64)` — 64B covers a cache line and AVX-512.
  - `allocate_aligned` / `deallocate_aligned` — value-initialized, over-aligned heap via portable C++17 `::operator new(std::align_val_t)` (works on MSVC, unlike `posix_memalign`/`std::aligned_alloc`); **cv-correct** so `ndarray`'s `const`-Value blocks still compile.
  - `aligned_allocator<T>` — a stateless C++ Allocator for SIMD-friendly `std::vector` scratch/packing buffers (used later in #89).
- **`contiguous_memory_block`**: owned heap blocks allocate via `allocate_aligned`; the fixed-size stack array is over-aligned to `block_alignment<Value>`. External/view memory untouched; copy/move/realloc keep the guarantee.

## Test results
| | gcc | clang |
|--|-----|-------|
| full unit suite | **101/101** | **101/101** |
| build | OK | OK (portable aligned `operator new`) |

New `tests/unit/detail/test_aligned_storage.cpp`: `dense2D<double>`/`dense_vector<double>` heap buffers 64B-aligned across sizes; `allocate_aligned` aligned + value-initialized + round-trip; `aligned_allocator`-backed `std::vector`; alignment survives copy/move/realloc; `block_alignment` respects larger natural alignment. No regressions (incl. the `ndarray` const-double path that initially broke and drove the cv-correct fix).

## Notes
- Alignment is unconditional (independent of `MTL5_WITH_HIGHWAY`): it benefits the scalar fallback (autovectorization on aligned data) and the Highway `load_aligned` path equally.
- Next on the critical path: **#85** (`hw_traits` + constexpr blocking params), then **#88** (GEMM micro-kernel).

## Test plan
- [ ] Fast CI passes (gcc + clang)
- [ ] Promote to ready: `gh pr ready 96`

Resolves #84

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added aligned memory allocation infrastructure (64-byte minimum) and updated contiguous storage to use over-aligned heap/stack allocation for SIMD/cache-friendly access.

* **Tests**
  * Added unit tests validating alignment guarantees for allocators, storage buffers, and that alignment persists across copy/move operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->