### PR TITLE
perf(build): hw_traits + constexpr GEMM blocking-parameter derivation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ option(MTL5_ENABLE_OPENMP  "Enable OpenMP parallelism"  OFF)
 option(MTL5_WITH_BLAS               "Link BLAS library for dense acceleration" OFF)
 option(MTL5_WITH_LAPACK             "Link LAPACK library for factorizations"  OFF)
 option(MTL5_WITH_HIGHWAY            "Use Google Highway for SIMD-accelerated native kernels" OFF)
+option(MTL5_NATIVE_ARCH            "Tune in-tree builds for the host CPU (-march=native; non-portable binaries)" OFF)
 option(MTL5_WITH_UMFPACK            "Link UMFPACK library (SuiteSparse)"      OFF)
 option(MTL5_WITH_SUPERLU            "Link SuperLU library"                    OFF)
 option(MTL5_WITH_SUITESPARSE_KLU    "Link KLU sparse solver (SuiteSparse)"    OFF)
@@ -81,6 +82,14 @@ target_include_directories(mtl5 INTERFACE
 )
 
 target_compile_features(mtl5 INTERFACE cxx_std_20)
+
+# Host-CPU tuning for in-tree builds (tests, benchmarks, native kernels). Off by
+# default to keep binaries portable; -march=native lets the SIMD layer pick the
+# widest ISA (the blocking params in mtl/simd/blocking.hpp adapt accordingly).
+# BUILD_INTERFACE only, so it never leaks into the installed/exported flags.
+if(MTL5_NATIVE_ARCH AND NOT MSVC)
+    target_compile_options(mtl5 INTERFACE $<BUILD_INTERFACE:-march=native>)
+endif()
 
 if(MTL5_ENABLE_OPENMP)
     find_package(OpenMP REQUIRED)

--- a/include/mtl/mtl.hpp
+++ b/include/mtl/mtl.hpp
@@ -11,6 +11,7 @@
 
 // SIMD abstraction (Highway-backed when MTL5_HAS_HIGHWAY, scalar fallback otherwise)
 #include <mtl/simd/batch.hpp>
+#include <mtl/simd/blocking.hpp>
 
 // Concepts
 #include <mtl/concepts/scalar.hpp>

--- a/include/mtl/simd/blocking.hpp
+++ b/include/mtl/simd/blocking.hpp
@@ -1,0 +1,104 @@
+#pragma once
+// MTL5 -- hardware traits + compile-time GEMM blocking-parameter derivation
+// (#85, epic #82, Phase 0).
+//
+// The GEMM micro-kernel (#88) and the cache-blocking loop nest (#90) need a
+// register tile (mr x nr) and cache block sizes (kc, mc, nc). Rather than
+// search for them empirically, derive them at compile time from a hardware
+// description using the BLIS analytical model:
+//
+//   Low, Igual, Smith, Quintana-Orti, "Analytical Modeling Is Enough for
+//   High-Performance BLIS", ACM TOMS. https://www.cs.utexas.edu/~flame/pubs/TOMS-BLIS-Analytical.pdf
+//
+// Register block (Eqs. 1-3): the mr x nr C microtile must hold enough
+// independent FMA accumulators to cover the FMA pipeline:
+//     mr * nr  >=  Nvec * Lvfma * Nvfma
+// with one dimension (here nr, the vector dimension) a multiple of the SIMD
+// width Nvec. Cache blocks (Eq. 4 and analogues): kc sizes the B micro-panel
+// to ~half of L1; mc sizes the packed A block to ~half of L2; nc sizes the
+// packed B panel to ~L3.
+
+#include <cstddef>
+
+#include <mtl/simd/batch.hpp>   // simd::width<T>
+
+namespace mtl::simd {
+
+// -- small constexpr integer helpers ---------------------------------------
+namespace detail {
+constexpr std::size_t ceil_div(std::size_t a, std::size_t b) { return b == 0 ? 0 : (a + b - 1) / b; }
+constexpr std::size_t round_up(std::size_t n, std::size_t m)   { return m == 0 ? n : ceil_div(n, m) * m; }
+constexpr std::size_t round_down(std::size_t n, std::size_t m) { return m == 0 ? n : (n / m) * m; }
+constexpr std::size_t isqrt_ceil(std::size_t n) {            // smallest r with r*r >= n
+    std::size_t r = 0;
+    while (r * r < n) ++r;
+    return r;
+}
+} // namespace detail
+
+/// Hardware description for blocking-parameter derivation. All sizes in bytes.
+struct hw_traits {
+    std::size_t fma_latency;   // Lvfma: dependent-FMA latency (cycles)
+    std::size_t fma_units;     // Nvfma: FMA issue width
+    std::size_t l1_bytes;      // per-core L1 data cache
+    std::size_t l1_assoc;      // L1 associativity (reserved for refinement)
+    std::size_t line_bytes;    // cache line
+    std::size_t l2_bytes;      // per-core L2
+    std::size_t l3_bytes;      // shared L3 (per core group)
+    std::size_t page_bytes;    // page size (TLB reasoning)
+};
+
+/// Generic modern-x86 (AVX2-class) default; override per architecture.
+/// Matches a Haswell-class core: 32 KB/8-way L1, 256 KB L2, 8 MB L3,
+/// FMA latency 4, 2 FMA units.
+inline constexpr hw_traits default_hw_traits{
+    /*fma_latency*/ 4, /*fma_units*/ 2,
+    /*l1_bytes*/ 32u * 1024, /*l1_assoc*/ 8, /*line_bytes*/ 64,
+    /*l2_bytes*/ 256u * 1024,
+    /*l3_bytes*/ 8u * 1024 * 1024,
+    /*page_bytes*/ 4096,
+};
+
+/// GEMM blocking parameters: mr x nr register microtile, kc/mc/nc cache blocks.
+struct blocking_params {
+    std::size_t mr, nr, kc, mc, nc;
+};
+
+/// Derive GEMM blocking parameters for element type `T` with `nvec` SIMD lanes
+/// (e.g. simd::width<T>) on hardware `hw`. constexpr / pure integer.
+template <typename T>
+constexpr blocking_params derive_blocking(std::size_t nvec,
+                                          const hw_traits& hw = default_hw_traits) {
+    using detail::ceil_div; using detail::round_up; using detail::round_down; using detail::isqrt_ceil;
+    const std::size_t sdata = sizeof(T);
+    if (nvec == 0) nvec = 1;
+
+    // Register block (Eqs. 1-3): area >= Nvec*Lvfma*Nvfma, near-square, nr a
+    // multiple of the SIMD width (nr is the vectorized dimension).
+    const std::size_t area = nvec * hw.fma_latency * hw.fma_units;
+    std::size_t nr = round_up(isqrt_ceil(area), nvec);
+    if (nr == 0) nr = nvec;
+    std::size_t mr = ceil_div(area, nr);
+    if (mr == 0) mr = 1;
+
+    // kc: B micro-panel (kc x nr) occupies ~half of L1.
+    std::size_t kc = (hw.l1_bytes / 2) / (nr * sdata);
+    if (kc == 0) kc = 1;
+
+    // mc: packed A block (mc x kc) occupies ~half of L2; multiple of mr.
+    std::size_t mc = round_down((hw.l2_bytes / 2) / (kc * sdata), mr);
+    if (mc == 0) mc = mr;
+
+    // nc: packed B panel (kc x nc) occupies ~L3; multiple of nr.
+    std::size_t nc = round_down(hw.l3_bytes / (kc * sdata), nr);
+    if (nc == 0) nc = nr;
+
+    return {mr, nr, kc, mc, nc};
+}
+
+/// Blocking parameters for `T` using the compiled SIMD width and the default
+/// hardware traits. (#90 will let the hw_traits be overridden per build.)
+template <typename T>
+inline constexpr blocking_params default_blocking = derive_blocking<T>(width<T>);
+
+} // namespace mtl::simd

--- a/tests/unit/simd/test_blocking.cpp
+++ b/tests/unit/simd/test_blocking.cpp
@@ -1,0 +1,80 @@
+// Tests for hw_traits + constexpr GEMM blocking-parameter derivation (#85).
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+
+#include <mtl/simd/blocking.hpp>
+
+#include <cstddef>
+
+using mtl::simd::hw_traits;
+using mtl::simd::blocking_params;
+using mtl::simd::derive_blocking;
+using mtl::simd::default_hw_traits;
+
+TEST_CASE("constexpr integer helpers", "[simd][blocking]") {
+    using namespace mtl::simd::detail;
+    STATIC_REQUIRE(ceil_div(10, 4) == 3);
+    STATIC_REQUIRE(round_up(5, 4) == 8);
+    STATIC_REQUIRE(round_down(10, 4) == 8);
+    STATIC_REQUIRE(isqrt_ceil(32) == 6);   // 6*6=36 >= 32, 5*5=25 < 32
+    STATIC_REQUIRE(isqrt_ceil(64) == 8);
+    STATIC_REQUIRE(isqrt_ceil(0) == 0);
+}
+
+TEST_CASE("AVX2 double derivation matches published Haswell-class values", "[simd][blocking]") {
+    // Nvec=4 (AVX2 double), default Haswell-class traits.
+    constexpr blocking_params bp = derive_blocking<double>(4);
+    STATIC_REQUIRE(bp.mr == 4);
+    STATIC_REQUIRE(bp.nr == 8);     // multiple of Nvec=4; matches OpenBLAS Haswell 4x8
+    STATIC_REQUIRE(bp.kc == 256);   // (32KB/2)/(8*8)
+    STATIC_REQUIRE(bp.mc == 64);    // (256KB/2)/(256*8), multiple of mr
+    STATIC_REQUIRE(bp.nc == 4096);  // 8MB/(256*8), multiple of nr
+}
+
+namespace {
+// Structural + cache-residency invariants the model must always satisfy.
+void check_valid(const blocking_params& bp, std::size_t nvec, std::size_t sdata,
+                 const hw_traits& hw) {
+    INFO("nvec=" << nvec << " sdata=" << sdata
+         << " mr=" << bp.mr << " nr=" << bp.nr << " kc=" << bp.kc
+         << " mc=" << bp.mc << " nc=" << bp.nc);
+    CHECK(bp.mr >= 1);
+    CHECK(bp.nr >= 1);
+    CHECK(bp.mr * bp.nr >= nvec * hw.fma_latency * hw.fma_units);  // enough accumulators (Eq.1)
+    CHECK(bp.nr % nvec == 0);                                      // vector dimension
+    CHECK(bp.kc >= 1);
+    CHECK(bp.mc % bp.mr == 0);
+    CHECK(bp.nc % bp.nr == 0);
+    CHECK(bp.kc * bp.nr * sdata <= hw.l1_bytes);   // B micro-panel resident in L1
+    CHECK(bp.mc * bp.kc * sdata <= hw.l2_bytes);   // packed A block resident in L2
+    CHECK(bp.kc * bp.nc * sdata <= hw.l3_bytes);   // packed B panel resident in L3
+}
+}
+
+TEMPLATE_TEST_CASE("derivation satisfies the blocking invariants across SIMD widths", "[simd][blocking]", float, double) {
+    const std::size_t sdata = sizeof(TestType);
+    const std::size_t nvecs[] = {1, 2, 4, 8, 16};
+    for (std::size_t nvec : nvecs) {
+        check_valid(derive_blocking<TestType>(nvec), nvec, sdata, default_hw_traits);
+    }
+}
+
+TEST_CASE("derivation adapts to a different hardware profile (AVX-512 / bigger caches)", "[simd][blocking]") {
+    constexpr hw_traits avx512{
+        /*fma_latency*/ 4, /*fma_units*/ 2,
+        /*l1_bytes*/ 32u * 1024, /*l1_assoc*/ 8, /*line_bytes*/ 64,
+        /*l2_bytes*/ 1024u * 1024,           // 1 MB L2 (Skylake-X)
+        /*l3_bytes*/ 16u * 1024 * 1024,
+        /*page_bytes*/ 4096,
+    };
+    constexpr blocking_params bp = derive_blocking<double>(8, avx512);   // 8 doubles = AVX-512
+    STATIC_REQUIRE(bp.nr % 8 == 0);
+    check_valid(bp, 8, sizeof(double), avx512);
+    // bigger L2/L3 than the default => larger mc/nc than the AVX2 default run
+    CHECK(bp.nc >= 4096);
+}
+
+TEMPLATE_TEST_CASE("default_blocking compiles and is valid for the build's SIMD width", "[simd][blocking]", float, double) {
+    constexpr blocking_params bp = mtl::simd::default_blocking<TestType>;
+    check_valid(bp, mtl::simd::width<TestType>, sizeof(TestType), default_hw_traits);
+}


### PR DESCRIPTION
Completes **Phase 0** of the native dense-BLAS performance epic (#82). Resolves #85.

## What
The compile-time blocking-parameter model the GEMM micro-kernel (#88) and cache-blocking nest (#90) will consume, plus a host-tuning build knob.

- **`include/mtl/simd/blocking.hpp`**:
  - `hw_traits` — SIMD/FMA (`fma_latency`, `fma_units`) + L1/L2/L3 sizes/assoc/line + page; default is a Haswell-class AVX2 core, overridable per arch.
  - `derive_blocking<T>(nvec, hw)` — **constexpr** derivation of the `mr × nr` register tile and `kc/mc/nc` cache blocks via the BLIS analytical model (Low et al.): `mr·nr ≥ Nvec·Lvfma·Nvfma` with `nr` a multiple of the SIMD width; `kc` fills ~½ L1, `mc` ~½ L2, `nc` ~L3.
  - `default_blocking<T>` — uses the compiled `simd::width<T>`.
- **CMake `MTL5_NATIVE_ARCH`** — adds `-march=native` to in-tree builds (`BUILD_INTERFACE` only; off by default for portable binaries) so the SIMD layer picks the widest ISA.
- `mtl.hpp` exposes the header.

## Matches published values
AVX2 double (Nvec=4, default traits) → **mr=4, nr=8, kc=256, mc=64, nc=4096** — the OpenBLAS/BLIS Haswell-class ballpark (OpenBLAS uses 4×8; kc=256; mc≈64–96; nc≈4080).

## Test results
| | gcc | clang |
|--|-----|-------|
| full unit suite | **102/102** | **102/102** |

`tests/unit/simd/test_blocking.cpp` pins the AVX2-double values and asserts the **invariants** always hold (enough FMA accumulators, `nr % Nvec == 0`, `mc % mr == 0`, `nc % nr == 0`, and B-panel/A-block/B-panel residency in L1/L2/L3) across SIMD widths 1–16 and an AVX-512 hardware profile. The `MTL5_NATIVE_ARCH` knob was confirmed to apply `-march=native`.

## Epic status
Phase 0 is now complete: ✅ #83 SIMD layer · ✅ #84 aligned storage · ✅ #85 (this). **Unblocks #88** (GEMM micro-kernel), the next critical-path item.

## Test plan
- [ ] Fast CI passes (gcc + clang)
- [ ] Promote to ready: `gh pr ready 97`

Resolves #85

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional build-time configuration option for host-CPU-specific performance tuning in development builds to optimize local development workflows.
  * Introduced compile-time SIMD blocking parameter derivation capabilities to enhance optimization of matrix multiplication kernel operations.

* **Tests**
  * Added comprehensive unit test coverage validating SIMD blocking parameter derivation behavior across multiple processor architectures and SIMD vector widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->