### PR TITLE
perf(operation): vectorize native L1 kernels (dot, nrm2, axpy, scal)

### DIFF
--- a/include/mtl/mtl.hpp
+++ b/include/mtl/mtl.hpp
@@ -142,6 +142,7 @@
 #include <mtl/operation/num_rows.hpp>
 #include <mtl/operation/num_cols.hpp>
 #include <mtl/operation/dot.hpp>
+#include <mtl/operation/axpy.hpp>
 #include <mtl/operation/sum.hpp>
 #include <mtl/operation/product.hpp>
 #include <mtl/operation/norms.hpp>

--- a/include/mtl/operation/axpy.hpp
+++ b/include/mtl/operation/axpy.hpp
@@ -1,0 +1,44 @@
+#pragma once
+// MTL5 -- axpy: y <- alpha*x + y  (BLAS level-1)
+// Native SIMD path for contiguous, same-type real float/double vectors
+// (mtl::simd::axpy, #86); BLAS dispatch when available; generic scalar
+// fallback otherwise.
+#include <cassert>
+#include <cstddef>
+#include <limits>
+#include <type_traits>
+
+#include <mtl/concepts/scalar.hpp>
+#include <mtl/concepts/vector.hpp>
+#include <mtl/interface/dispatch_traits.hpp>
+#include <mtl/simd/algorithm.hpp>
+#ifdef MTL5_HAS_BLAS
+#include <mtl/interface/blas.hpp>
+#endif
+
+namespace mtl {
+
+/// y[i] += alpha * x[i]
+template <Scalar S, Vector VX, Vector VY>
+void axpy(const S& alpha, const VX& x, VY& y) {
+    assert(x.size() == y.size());
+    if constexpr (interface::BlasDenseVector<VX> && interface::BlasDenseVector<VY> &&
+                  std::is_same_v<typename VX::value_type, typename VY::value_type>) {
+        using T = typename VY::value_type;
+        const std::size_t n = y.size();
+#ifdef MTL5_HAS_BLAS
+        if (n <= static_cast<std::size_t>(std::numeric_limits<int>::max())) {
+            interface::blas::axpy(static_cast<int>(n), static_cast<T>(alpha),
+                                  x.data(), 1, y.data(), 1);
+            return;
+        }
+#endif
+        simd::axpy<T>(static_cast<T>(alpha), x.data(), y.data(), n);
+    } else {
+        for (typename VY::size_type i = 0; i < y.size(); ++i) {
+            y(i) += alpha * x(i);
+        }
+    }
+}
+
+} // namespace mtl

--- a/include/mtl/operation/dot.hpp
+++ b/include/mtl/operation/dot.hpp
@@ -12,6 +12,7 @@
 #include <mtl/math/identity.hpp>
 #include <mtl/functor/scalar/conj.hpp>
 #include <mtl/interface/dispatch_traits.hpp>
+#include <mtl/simd/algorithm.hpp>
 #ifdef MTL5_HAS_BLAS
 #include <mtl/interface/blas.hpp>
 #endif
@@ -33,12 +34,19 @@ auto dot(const V1& v1, const V2& v2) {
         }
     }
 #endif
-    using result_type = std::common_type_t<typename V1::value_type, typename V2::value_type>;
-    auto acc = math::zero<result_type>();
-    for (typename V1::size_type i = 0; i < v1.size(); ++i) {
-        acc += functor::scalar::conj<typename V1::value_type>::apply(v1(i)) * v2(i);
+    // Native SIMD path for contiguous, same-type real float/double vectors
+    // (conj is the identity there, so reduce_dot matches the Hermitian product).
+    if constexpr (interface::BlasDenseVector<V1> && interface::BlasDenseVector<V2> &&
+                  std::is_same_v<typename V1::value_type, typename V2::value_type>) {
+        return simd::reduce_dot<typename V1::value_type>(v1.data(), v2.data(), v1.size());
+    } else {
+        using result_type = std::common_type_t<typename V1::value_type, typename V2::value_type>;
+        auto acc = math::zero<result_type>();
+        for (typename V1::size_type i = 0; i < v1.size(); ++i) {
+            acc += functor::scalar::conj<typename V1::value_type>::apply(v1(i)) * v2(i);
+        }
+        return acc;
     }
-    return acc;
 }
 
 /// Real dot product: sum(v1[i] * v2[i]) -- no conjugation
@@ -53,12 +61,17 @@ auto dot_real(const V1& v1, const V2& v2) {
         }
     }
 #endif
-    using result_type = std::common_type_t<typename V1::value_type, typename V2::value_type>;
-    auto acc = math::zero<result_type>();
-    for (typename V1::size_type i = 0; i < v1.size(); ++i) {
-        acc += v1(i) * v2(i);
+    if constexpr (interface::BlasDenseVector<V1> && interface::BlasDenseVector<V2> &&
+                  std::is_same_v<typename V1::value_type, typename V2::value_type>) {
+        return simd::reduce_dot<typename V1::value_type>(v1.data(), v2.data(), v1.size());
+    } else {
+        using result_type = std::common_type_t<typename V1::value_type, typename V2::value_type>;
+        auto acc = math::zero<result_type>();
+        for (typename V1::size_type i = 0; i < v1.size(); ++i) {
+            acc += v1(i) * v2(i);
+        }
+        return acc;
     }
-    return acc;
 }
 
 } // namespace mtl

--- a/include/mtl/operation/norms.hpp
+++ b/include/mtl/operation/norms.hpp
@@ -11,6 +11,7 @@
 #include <mtl/concepts/magnitude.hpp>
 #include <mtl/math/identity.hpp>
 #include <mtl/interface/dispatch_traits.hpp>
+#include <mtl/simd/algorithm.hpp>
 #ifdef MTL5_HAS_BLAS
 #include <mtl/interface/blas.hpp>
 #endif
@@ -42,15 +43,21 @@ auto two_norm(const V& v) {
         }
     }
 #endif
-    using mag_t = magnitude_t<typename V::value_type>;
-    auto acc = math::zero<mag_t>();
-    for (typename V::size_type i = 0; i < v.size(); ++i) {
-        using std::abs;
-        auto a = abs(v(i));
-        acc += a * a;
+    // Native SIMD path for contiguous real float/double (abs is the identity).
+    if constexpr (interface::BlasDenseVector<V>) {
+        using std::sqrt;
+        return sqrt(simd::reduce_sum_squares<typename V::value_type>(v.data(), v.size()));
+    } else {
+        using mag_t = magnitude_t<typename V::value_type>;
+        auto acc = math::zero<mag_t>();
+        for (typename V::size_type i = 0; i < v.size(); ++i) {
+            using std::abs;
+            auto a = abs(v(i));
+            acc += a * a;
+        }
+        using std::sqrt;
+        return sqrt(acc);
     }
-    using std::sqrt;
-    return sqrt(acc);
 }
 
 /// infinity_norm(v) = max(|v[i]|)

--- a/include/mtl/operation/scale.hpp
+++ b/include/mtl/operation/scale.hpp
@@ -1,15 +1,38 @@
 #pragma once
 // MTL5 -- Scale collection by a scalar factor
+#include <cstddef>
+#include <limits>
+#include <type_traits>
+
 #include <mtl/concepts/scalar.hpp>
 #include <mtl/concepts/collection.hpp>
+#include <mtl/interface/dispatch_traits.hpp>
+#include <mtl/simd/algorithm.hpp>
+#ifdef MTL5_HAS_BLAS
+#include <mtl/interface/blas.hpp>
+#endif
 
 namespace mtl {
 
 /// In-place scale: c[i] *= alpha
 template <Scalar S, MutableCollection C>
 void scale(const S& alpha, C& c) {
-    for (auto it = c.begin(); it != c.end(); ++it) {
-        *it *= alpha;
+    // Native SIMD / BLAS path for contiguous real float/double vectors;
+    // generic iterator loop for everything else (matrices, strided, complex).
+    if constexpr (interface::BlasDenseVector<C>) {
+        using T = typename C::value_type;
+        const std::size_t n = c.size();
+#ifdef MTL5_HAS_BLAS
+        if (n <= static_cast<std::size_t>(std::numeric_limits<int>::max())) {
+            interface::blas::scal(static_cast<int>(n), static_cast<T>(alpha), c.data(), 1);
+            return;
+        }
+#endif
+        simd::scal<T>(static_cast<T>(alpha), c.data(), n);
+    } else {
+        for (auto it = c.begin(); it != c.end(); ++it) {
+            *it *= alpha;
+        }
     }
 }
 

--- a/include/mtl/simd/algorithm.hpp
+++ b/include/mtl/simd/algorithm.hpp
@@ -1,0 +1,96 @@
+#pragma once
+// MTL5 -- vectorized level-1 kernels over raw contiguous storage (#86, epic #82).
+//
+// These are the native (no external BLAS) L1 building blocks: dot, sum-of-
+// squares (for two_norm), axpy, and scal. Each is written ONCE against the SIMD
+// abstraction (mtl::simd::batch<T>, #83) so it targets SSE/AVX/AVX-512/NEON by
+// build flags. Reductions use several independent accumulators to hide the FP
+// add/FMA latency (the dependent-accumulator stall that limits a single-acc
+// loop), then a horizontal reduce and a scalar tail. L1 is bandwidth-bound, so
+// the goal is to reach the memory ceiling, not peak FLOPs.
+//
+// Unaligned loads/stores are used so these work on any contiguous span
+// (sub-vectors, views); on modern cores aligned vs unaligned cost is
+// negligible. The packed-panel GEMM path (#89) uses aligned loads instead.
+
+#include <cstddef>
+#include <type_traits>
+
+#include <mtl/simd/batch.hpp>
+
+namespace mtl::simd {
+
+/// dot product: sum_i a[i]*b[i]  (real float/double).
+template <typename T>
+T reduce_dot(const T* a, const T* b, std::size_t n) {
+    static_assert(std::is_floating_point_v<T>);
+    using B = batch<T>;
+    constexpr std::size_t W = B::size;
+    constexpr std::size_t U = 4;             // independent accumulators
+    constexpr std::size_t step = W * U;
+    B a0{}, a1{}, a2{}, a3{};                // default ctor zero-initializes
+    std::size_t i = 0;
+    for (; i + step <= n; i += step) {
+        a0 = fma(B::load_unaligned(a + i),           B::load_unaligned(b + i),           a0);
+        a1 = fma(B::load_unaligned(a + i + W),       B::load_unaligned(b + i + W),       a1);
+        a2 = fma(B::load_unaligned(a + i + 2 * W),   B::load_unaligned(b + i + 2 * W),   a2);
+        a3 = fma(B::load_unaligned(a + i + 3 * W),   B::load_unaligned(b + i + 3 * W),   a3);
+    }
+    for (; i + W <= n; i += W)
+        a0 = fma(B::load_unaligned(a + i), B::load_unaligned(b + i), a0);
+    T s = reduce_add((a0 + a1) + (a2 + a3));
+    for (; i < n; ++i) s += a[i] * b[i];     // scalar tail
+    return s;
+}
+
+/// sum of squares: sum_i a[i]*a[i]  (two_norm computes sqrt of this).
+template <typename T>
+T reduce_sum_squares(const T* a, std::size_t n) {
+    static_assert(std::is_floating_point_v<T>);
+    using B = batch<T>;
+    constexpr std::size_t W = B::size;
+    constexpr std::size_t U = 4;
+    constexpr std::size_t step = W * U;
+    B a0{}, a1{}, a2{}, a3{};
+    std::size_t i = 0;
+    for (; i + step <= n; i += step) {
+        B v0 = B::load_unaligned(a + i);          a0 = fma(v0, v0, a0);
+        B v1 = B::load_unaligned(a + i + W);      a1 = fma(v1, v1, a1);
+        B v2 = B::load_unaligned(a + i + 2 * W);  a2 = fma(v2, v2, a2);
+        B v3 = B::load_unaligned(a + i + 3 * W);  a3 = fma(v3, v3, a3);
+    }
+    for (; i + W <= n; i += W) { B v = B::load_unaligned(a + i); a0 = fma(v, v, a0); }
+    T s = reduce_add((a0 + a1) + (a2 + a3));
+    for (; i < n; ++i) s += a[i] * a[i];
+    return s;
+}
+
+/// axpy: y[i] += alpha*x[i].
+template <typename T>
+void axpy(T alpha, const T* x, T* y, std::size_t n) {
+    static_assert(std::is_floating_point_v<T>);
+    using B = batch<T>;
+    constexpr std::size_t W = B::size;
+    const B va(alpha);
+    std::size_t i = 0;
+    for (; i + W <= n; i += W) {
+        B r = fma(va, B::load_unaligned(x + i), B::load_unaligned(y + i));
+        r.store_unaligned(y + i);
+    }
+    for (; i < n; ++i) y[i] += alpha * x[i];
+}
+
+/// scal: x[i] *= alpha.
+template <typename T>
+void scal(T alpha, T* x, std::size_t n) {
+    static_assert(std::is_floating_point_v<T>);
+    using B = batch<T>;
+    constexpr std::size_t W = B::size;
+    const B va(alpha);
+    std::size_t i = 0;
+    for (; i + W <= n; i += W)
+        (va * B::load_unaligned(x + i)).store_unaligned(x + i);
+    for (; i < n; ++i) x[i] *= alpha;
+}
+
+} // namespace mtl::simd

--- a/tests/unit/operation/test_axpy.cpp
+++ b/tests/unit/operation/test_axpy.cpp
@@ -1,0 +1,54 @@
+// Tests for mtl::axpy and the vectorized mtl::scale path (#86), exercised
+// through dense_vector (which routes to the SIMD/BLAS L1 kernels).
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <mtl/operation/axpy.hpp>
+#include <mtl/operation/scale.hpp>
+#include <mtl/operation/dot.hpp>
+#include <mtl/operation/norms.hpp>
+#include <mtl/vec/dense_vector.hpp>
+
+#include <cmath>
+#include <cstddef>
+
+using Catch::Approx;
+
+TEMPLATE_TEST_CASE("axpy: y += alpha*x on dense_vector", "[operation][l1]", float, double) {
+    const std::size_t sizes[] = {0, 1, 7, 16, 31, 100, 257};
+    const TestType alpha = TestType(3);
+    for (std::size_t n : sizes) {
+        mtl::vec::dense_vector<TestType> x(n), y(n);
+        for (std::size_t i = 0; i < n; ++i) { x(i) = TestType(i % 7) - 3; y(i) = TestType(i % 4); }
+        mtl::axpy(alpha, x, y);
+        for (std::size_t i = 0; i < n; ++i)
+            CHECK(y(i) == Approx(alpha * (TestType(i % 7) - 3) + TestType(i % 4)));
+    }
+}
+
+TEMPLATE_TEST_CASE("scale: x *= alpha on dense_vector", "[operation][l1]", float, double) {
+    const std::size_t sizes[] = {0, 1, 7, 16, 33, 100, 257};
+    const TestType alpha = TestType(-2);
+    for (std::size_t n : sizes) {
+        mtl::vec::dense_vector<TestType> x(n);
+        for (std::size_t i = 0; i < n; ++i) x(i) = TestType(i % 9) - 4;
+        mtl::scale(alpha, x);
+        for (std::size_t i = 0; i < n; ++i) CHECK(x(i) == Approx(alpha * (TestType(i % 9) - 4)));
+    }
+}
+
+// dot / two_norm now route through the SIMD L1 path for dense_vector; confirm
+// they are still numerically correct end-to-end.
+TEMPLATE_TEST_CASE("dot and two_norm via dense_vector are correct", "[operation][l1]", float, double) {
+    const std::size_t n = 257;
+    mtl::vec::dense_vector<TestType> a(n), b(n);
+    TestType dotref = 0, ssq = 0;
+    for (std::size_t i = 0; i < n; ++i) {
+        a(i) = TestType(i % 5) - 2; b(i) = TestType(i % 3) - 1;
+        dotref += a(i) * b(i); ssq += a(i) * a(i);
+    }
+    CHECK(mtl::dot(a, b) == Approx(dotref));
+    CHECK(mtl::dot_real(a, b) == Approx(dotref));
+    CHECK(mtl::two_norm(a) == Approx(std::sqrt(ssq)));
+}

--- a/tests/unit/simd/test_algorithm.cpp
+++ b/tests/unit/simd/test_algorithm.cpp
@@ -1,0 +1,63 @@
+// Tests for vectorized L1 kernels (#86): reduce_dot, reduce_sum_squares, axpy, scal.
+// Integer-valued data keeps reductions exact regardless of accumulation order
+// (SIMD multi-accumulator vs scalar), so we can compare exactly; sqrt uses Approx.
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <mtl/simd/algorithm.hpp>
+
+#include <cstddef>
+#include <vector>
+
+using Catch::Approx;
+
+namespace {
+const std::size_t kLengths[] = {0, 1, 2, 3, 7, 8, 9, 15, 16, 17, 31, 33, 64, 100, 257};
+}
+
+TEMPLATE_TEST_CASE("reduce_dot matches scalar reference", "[simd][l1]", float, double) {
+    for (std::size_t n : kLengths) {
+        std::vector<TestType> a(n), b(n);
+        TestType ref = 0;
+        for (std::size_t i = 0; i < n; ++i) {
+            a[i] = TestType((i % 7) - 3);     // small integers
+            b[i] = TestType((i % 5) - 2);
+            ref += a[i] * b[i];
+        }
+        CHECK(mtl::simd::reduce_dot<TestType>(a.data(), b.data(), n) == ref);
+    }
+}
+
+TEMPLATE_TEST_CASE("reduce_sum_squares matches scalar reference", "[simd][l1]", float, double) {
+    for (std::size_t n : kLengths) {
+        std::vector<TestType> a(n);
+        TestType ref = 0;
+        for (std::size_t i = 0; i < n; ++i) { a[i] = TestType((i % 9) - 4); ref += a[i] * a[i]; }
+        CHECK(mtl::simd::reduce_sum_squares<TestType>(a.data(), n) == ref);
+    }
+}
+
+TEMPLATE_TEST_CASE("axpy matches scalar reference over all lengths", "[simd][l1]", float, double) {
+    const TestType alpha = TestType(2.5);
+    for (std::size_t n : kLengths) {
+        std::vector<TestType> x(n), y(n), ref(n);
+        for (std::size_t i = 0; i < n; ++i) {
+            x[i] = TestType(i % 11) - 5;
+            y[i] = TestType(i % 6) - 3;
+            ref[i] = alpha * x[i] + y[i];
+        }
+        mtl::simd::axpy<TestType>(alpha, x.data(), y.data(), n);
+        for (std::size_t i = 0; i < n; ++i) CHECK(y[i] == Approx(ref[i]));
+    }
+}
+
+TEMPLATE_TEST_CASE("scal matches scalar reference over all lengths", "[simd][l1]", float, double) {
+    const TestType alpha = TestType(-1.5);
+    for (std::size_t n : kLengths) {
+        std::vector<TestType> x(n), ref(n);
+        for (std::size_t i = 0; i < n; ++i) { x[i] = TestType(i % 13) - 6; ref[i] = alpha * x[i]; }
+        mtl::simd::scal<TestType>(alpha, x.data(), n);
+        for (std::size_t i = 0; i < n; ++i) CHECK(x[i] == Approx(ref[i]));
+    }
+}


### PR DESCRIPTION
Phase 1 of the native dense-BLAS performance epic (#82) — the first kernels on the Phase-0 foundations (#83 `batch`, #84 aligned storage). Resolves #86.

## What
- **`include/mtl/simd/algorithm.hpp`** (new) — raw-pointer L1 kernels written once over `mtl::simd::batch<T>`: `reduce_dot`, `reduce_sum_squares` (nrm2), `axpy`, `scal`. Reductions use **4 independent accumulators + FMA** to hide FP-add latency, then a horizontal reduce + scalar tail. Unaligned loads (works on any contiguous span).
- **`dot`/`dot_real`** (dot.hpp) and **`two_norm`** (norms.hpp) — the generic fallback now routes contiguous, same-type real float/double vectors through these kernels (conj/abs are the identity there). BLAS dispatch + int-overflow guards unchanged; only the generic branch changes.
- **`scale`** (scal) — vectorized fast path for contiguous float/double vectors (BLAS `scal` + `simd::scal`); generic iterator loop otherwise.
- **`mtl::axpy(alpha, x, y)`** (new op) — BLAS `axpy` dispatch + `simd::axpy` + scalar fallback.

The win lands in the no-external-BLAS build with Highway on; the scalar-fallback build is unchanged.

## Measured speedup
i7-12700K P-core, single thread, `-march=native`, no BLAS, Highway:

| op | scalar native (pre) | native-fast (this) |
|----|---------------------|--------------------|
| dot @1024 | 4.6 GFLOP/s | **22.8** (~5×) |
| nrm2 @1024 | 4.6 GFLOP/s | **23.6** (~5×) |
| nrm2 @4096 | — | 36.3 |

Native L1 now reaches the OpenBLAS ballpark (~20 GFLOP/s) — the acceptance criterion.

## Test results
| | gcc | clang | Highway (real SIMD) |
|--|-----|-------|---------------------|
| full unit suite | **104/104** | **104/104** | L1 tests pass |

New tests: raw kernels vs scalar reference (exact, integer-valued data) and the public ops (`axpy`, `scale`, `dot`, `two_norm`) across non-multiple lengths, float/double.

## Epic status
Phase 1 underway: 🔄 #86 (this) · #87 GEMV next-parallel. Critical path remains #88 (GEMM micro-kernel). This is the first **end-to-end measurable** speedup from the epic.

## Test plan
- [ ] Fast CI (gcc + clang)
- [ ] Promote: `gh pr ready 98`

Resolves #86

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced AXPY operation for efficient vector scaling and addition.
  * Added SIMD-accelerated implementations for core linear algebra operations (dot products, two-norm, scaling) on dense vectors, improving computational performance.

* **Tests**
  * Added comprehensive unit tests for new operations and SIMD algorithms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->