### PR TITLE
perf(operation): GEMM packing routines (A/B panels, orientation strides, edge padding)

### DIFF
--- a/include/mtl/detail/gemm_pack.hpp
+++ b/include/mtl/detail/gemm_pack.hpp
@@ -1,0 +1,96 @@
+#pragma once
+// MTL5 -- GEMM packing routines (#89, epic #82, Phase 2).
+//
+// Copy A and B blocks into contiguous, aligned, SIMD-friendly buffers laid out
+// in the exact order the register micro-kernel (#88) streams them. This is the
+// single biggest non-register performance lever in a GotoBLAS/BLIS-style GEMM:
+// the hot inner loop then reads unit-stride, cache-line- and page-friendly
+// bytes, which slashes TLB misses and lets the hardware prefetcher run.
+//
+// Two micro-panel layouts, matching the micro-kernel's contract exactly:
+//
+//   pack_A  -- MR-row column-major panels.   Ap[panel*MR*k + p*MR + i] == A(i,p)
+//   pack_B  -- NR-col row-major panels.       Bp[panel*NR*k + p*NR + j] == B(p,j)
+//
+// where i/j are panel-local indices and p in [0,k). The micro-kernel consumes a
+// single mr x kc A-panel as Ap[p*MR+i] and a kc x nr B-panel as Bp[p*NR+j].
+//
+// Generic strides (BLIS-style): the source is given by a base pointer plus a row
+// stride `rs` and column stride `cs`, so row-major (rs=ld, cs=1), column-major
+// (rs=1, cs=ld), and transposed views all pack with NO special-casing -- just
+// pass the strides of the view. A(i,j) is read from `A[i*rs + j*cs]`.
+//
+// Edge padding: a trailing partial block (rows < MR, or cols < NR) is zero-padded
+// up to the full tile, so the micro-kernel only ever sees full MR x NR tiles and
+// needs no inner-loop size checks. Padded multiplies contribute 0 to C.
+//
+// Buffers are written sequentially front-to-back; the caller allocates them once
+// (via the aligned allocator) and reuses them across the blocking loops. Use
+// packed_A_size / packed_B_size to size them.
+
+#include <cstddef>
+#include <type_traits>
+
+namespace mtl::detail {
+
+/// Elements needed to pack an m x k A block into MR-row panels (rows padded to MR).
+constexpr std::size_t packed_A_size(std::size_t m, std::size_t k, std::size_t MR) {
+    return ((m + MR - 1) / MR) * MR * k;
+}
+
+/// Elements needed to pack a k x n B block into NR-col panels (cols padded to NR).
+constexpr std::size_t packed_B_size(std::size_t k, std::size_t n, std::size_t NR) {
+    return ((n + NR - 1) / NR) * NR * k;
+}
+
+/// Pack an m x k block of A into MR-row, column-major micro-panels.
+///
+/// Layout: panels are laid out contiguously by row-block; within panel q (rows
+/// [q*MR, q*MR+MR)), storage is column-major over the kc dimension --
+///     Ap[q*MR*k + p*MR + i] = (q*MR+i < m) ? A(q*MR+i, p) : 0
+/// for p in [0,k), i in [0,MR). This is exactly what gemm_microkernel reads as
+/// Ap[p*MR + i]. `Ap` must hold packed_A_size(m,k,MR) elements.
+template <typename T, std::size_t MR>
+void pack_A(const T* A, std::ptrdiff_t rs, std::ptrdiff_t cs,
+            std::size_t m, std::size_t k, T* Ap) {
+    static_assert(MR > 0, "MR must be positive");
+    std::size_t dst = 0;
+    for (std::size_t i0 = 0; i0 < m; i0 += MR) {
+        const std::size_t mr = (m - i0 < MR) ? (m - i0) : MR;  // rows in this panel
+        for (std::size_t p = 0; p < k; ++p) {
+            const T* col = A + static_cast<std::ptrdiff_t>(i0) * rs
+                             + static_cast<std::ptrdiff_t>(p) * cs;
+            for (std::size_t i = 0; i < mr; ++i)
+                Ap[dst++] = col[static_cast<std::ptrdiff_t>(i) * rs];
+            for (std::size_t i = mr; i < MR; ++i)
+                Ap[dst++] = T(0);  // zero-pad trailing rows up to MR
+        }
+    }
+}
+
+/// Pack a k x n block of B into NR-col, row-major micro-panels.
+///
+/// Layout: panels are laid out contiguously by column-block; within panel q
+/// (cols [q*NR, q*NR+NR)), storage is row-major over the kc dimension --
+///     Bp[q*NR*k + p*NR + j] = (q*NR+j < n) ? B(p, q*NR+j) : 0
+/// for p in [0,k), j in [0,NR). This is exactly what gemm_microkernel reads as
+/// Bp[p*NR + j]. `Bp` must hold packed_B_size(k,n,NR) elements.
+template <typename T, std::size_t NR>
+void pack_B(const T* B, std::ptrdiff_t rs, std::ptrdiff_t cs,
+            std::size_t k, std::size_t n, T* Bp) {
+    static_assert(NR > 0, "NR must be positive");
+    std::size_t dst = 0;
+    for (std::size_t j0 = 0; j0 < n; j0 += NR) {
+        const std::size_t nr = (n - j0 < NR) ? (n - j0) : NR;  // cols in this panel
+        for (std::size_t p = 0; p < k; ++p) {
+            const T* row = B + static_cast<std::ptrdiff_t>(p) * rs
+                             + static_cast<std::ptrdiff_t>(j0) * cs;
+            for (std::size_t j = 0; j < nr; ++j)
+                Bp[dst++] = row[static_cast<std::ptrdiff_t>(j) * cs];
+            for (std::size_t j = nr; j < NR; ++j)
+                Bp[dst++] = T(0);  // zero-pad trailing cols up to NR
+        }
+    }
+}
+
+} // namespace mtl::detail

--- a/include/mtl/detail/gemm_pack.hpp
+++ b/include/mtl/detail/gemm_pack.hpp
@@ -31,6 +31,8 @@
 #include <cstddef>
 #include <type_traits>
 
+#include <mtl/concepts/scalar.hpp>
+
 namespace mtl::detail {
 
 /// Elements needed to pack an m x k A block into MR-row panels (rows padded to MR).
@@ -51,6 +53,7 @@ constexpr std::size_t packed_B_size(std::size_t k, std::size_t n, std::size_t NR
 /// for p in [0,k), i in [0,MR). This is exactly what gemm_microkernel reads as
 /// Ap[p*MR + i]. `Ap` must hold packed_A_size(m,k,MR) elements.
 template <typename T, std::size_t MR>
+    requires mtl::Scalar<T>
 void pack_A(const T* A, std::ptrdiff_t rs, std::ptrdiff_t cs,
             std::size_t m, std::size_t k, T* Ap) {
     static_assert(MR > 0, "MR must be positive");
@@ -76,6 +79,7 @@ void pack_A(const T* A, std::ptrdiff_t rs, std::ptrdiff_t cs,
 /// for p in [0,k), j in [0,NR). This is exactly what gemm_microkernel reads as
 /// Bp[p*NR + j]. `Bp` must hold packed_B_size(k,n,NR) elements.
 template <typename T, std::size_t NR>
+    requires mtl::Scalar<T>
 void pack_B(const T* B, std::ptrdiff_t rs, std::ptrdiff_t cs,
             std::size_t k, std::size_t n, T* Bp) {
     static_assert(NR > 0, "NR must be positive");

--- a/include/mtl/mtl.hpp
+++ b/include/mtl/mtl.hpp
@@ -13,6 +13,9 @@
 #include <mtl/simd/batch.hpp>
 #include <mtl/simd/blocking.hpp>
 
+// Dense GEMM building blocks (native-BLAS epic #82)
+#include <mtl/detail/gemm_pack.hpp>
+
 // Concepts
 #include <mtl/concepts/scalar.hpp>
 #include <mtl/concepts/magnitude.hpp>

--- a/tests/unit/detail/test_gemm_pack.cpp
+++ b/tests/unit/detail/test_gemm_pack.cpp
@@ -1,0 +1,122 @@
+// Tests for GEMM packing routines (#89): pack_A (MR-row col-major panels) and
+// pack_B (NR-col row-major panels), with generic strides and edge padding.
+//
+// We verify the packed buffer layout DIRECTLY against the micro-kernel contract
+//   Ap[panel*MR*k + p*MR + i] == A(panel*MR+i, p)   (0 when row is padded)
+//   Bp[panel*NR*k + p*NR + j] == B(p, panel*NR+j)   (0 when col is padded)
+// rather than through the micro-kernel, so the test is independent of #88.
+// Integer-valued, distinct entries make every (i,j) mismatch (stride/transpose
+// bug) detectable by exact comparison.
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+
+#include <mtl/detail/gemm_pack.hpp>
+
+#include <cstddef>
+#include <vector>
+
+namespace {
+
+// Distinct nonzero value for logical entry (i,j): never collides with the 0 pad.
+template <typename T>
+T entry(std::size_t i, std::size_t j) { return T(1 + i * 31 + j); }
+
+// Pack an m x k logical A in BOTH row-major and col-major storage and check the
+// packed buffer slot-by-slot (real entries and zero padding).
+template <typename T, std::size_t MR>
+void check_pack_A(std::size_t m, std::size_t k) {
+    std::vector<T> rowmaj(m * k), colmaj(m * k);
+    for (std::size_t i = 0; i < m; ++i)
+        for (std::size_t j = 0; j < k; ++j) {
+            rowmaj[i * k + j] = entry<T>(i, j);  // rs=k, cs=1
+            colmaj[j * m + i] = entry<T>(i, j);  // rs=1, cs=m
+        }
+
+    const std::size_t panels = (m + MR - 1) / MR;
+    const std::size_t sz = mtl::detail::packed_A_size(m, k, MR);
+    CHECK(sz == panels * MR * k);
+
+    const T sentinel = T(-99999);
+    for (int orient = 0; orient < 2; ++orient) {
+        std::vector<T> Ap(sz, sentinel);
+        if (orient == 0)
+            mtl::detail::pack_A<T, MR>(rowmaj.data(), static_cast<std::ptrdiff_t>(k), 1, m, k, Ap.data());
+        else
+            mtl::detail::pack_A<T, MR>(colmaj.data(), 1, static_cast<std::ptrdiff_t>(m), m, k, Ap.data());
+
+        for (std::size_t q = 0; q < panels; ++q)
+            for (std::size_t p = 0; p < k; ++p)
+                for (std::size_t i = 0; i < MR; ++i) {
+                    const std::size_t row = q * MR + i;
+                    const T expected = (row < m) ? entry<T>(row, p) : T(0);
+                    CHECK(Ap[q * MR * k + p * MR + i] == expected);
+                }
+    }
+}
+
+// Pack a k x n logical B in BOTH row-major and col-major storage and check.
+template <typename T, std::size_t NR>
+void check_pack_B(std::size_t k, std::size_t n) {
+    std::vector<T> rowmaj(k * n), colmaj(k * n);
+    for (std::size_t p = 0; p < k; ++p)
+        for (std::size_t j = 0; j < n; ++j) {
+            rowmaj[p * n + j] = entry<T>(p, j);  // rs=n, cs=1
+            colmaj[j * k + p] = entry<T>(p, j);  // rs=1, cs=k
+        }
+
+    const std::size_t panels = (n + NR - 1) / NR;
+    const std::size_t sz = mtl::detail::packed_B_size(k, n, NR);
+    CHECK(sz == panels * NR * k);
+
+    const T sentinel = T(-99999);
+    for (int orient = 0; orient < 2; ++orient) {
+        std::vector<T> Bp(sz, sentinel);
+        if (orient == 0)
+            mtl::detail::pack_B<T, NR>(rowmaj.data(), static_cast<std::ptrdiff_t>(n), 1, k, n, Bp.data());
+        else
+            mtl::detail::pack_B<T, NR>(colmaj.data(), 1, static_cast<std::ptrdiff_t>(k), k, n, Bp.data());
+
+        for (std::size_t q = 0; q < panels; ++q)
+            for (std::size_t p = 0; p < k; ++p)
+                for (std::size_t j = 0; j < NR; ++j) {
+                    const std::size_t col = q * NR + j;
+                    const T expected = (col < n) ? entry<T>(p, col) : T(0);
+                    CHECK(Bp[q * NR * k + p * NR + j] == expected);
+                }
+    }
+}
+
+const std::size_t kDims[] = {1, 2, 3, 4, 5, 7, 8, 9, 16};
+
+} // namespace
+
+TEMPLATE_TEST_CASE("pack_A: MR-row col-major panels, both orientations + padding", "[detail][gemm][pack]", float, double) {
+    for (std::size_t m : kDims)
+        for (std::size_t k : kDims) {
+            check_pack_A<TestType, 1>(m, k);
+            check_pack_A<TestType, 3>(m, k);  // odd MR -> exercises padding for most m
+            check_pack_A<TestType, 4>(m, k);  // AVX2 fp64 MR
+        }
+}
+
+TEMPLATE_TEST_CASE("pack_B: NR-col row-major panels, both orientations + padding", "[detail][gemm][pack]", float, double) {
+    for (std::size_t k : kDims)
+        for (std::size_t n : kDims) {
+            check_pack_B<TestType, 1>(k, n);
+            check_pack_B<TestType, 3>(k, n);  // odd NR
+            check_pack_B<TestType, 8>(k, n);  // AVX2 fp64 NR
+        }
+}
+
+// Spot-check the exact contract values for a known 3x2 A with MR=2 (one full
+// panel + one padded panel), so a layout regression is caught concretely.
+TEST_CASE("pack_A: explicit 3x2, MR=2 layout", "[detail][gemm][pack]") {
+    // A = [[10,11],[20,21],[30,31]] row-major, rs=2, cs=1
+    const double A[] = {10, 11, 20, 21, 30, 31};
+    std::vector<double> Ap(mtl::detail::packed_A_size(3, 2, 2));  // 2 panels * 2 * 2 = 8
+    mtl::detail::pack_A<double, 2>(A, 2, 1, 3, 2, Ap.data());
+    // panel0 (rows 0..1), col-major: p0->{10,20}, p1->{11,21}
+    // panel1 (row 2 + pad),         : p0->{30, 0}, p1->{31, 0}
+    const double expected[] = {10, 20, 11, 21, 30, 0, 31, 0};
+    for (std::size_t t = 0; t < 8; ++t) CHECK(Ap[t] == expected[t]);
+}


### PR DESCRIPTION
## Summary
- Adds the GotoBLAS/BLIS-style **packing** layer for the native GEMM (epic #82, Phase 2): copy A and B blocks into contiguous, aligned, SIMD-friendly buffers in the exact order the register micro-kernel (#88) streams them.
- `pack_A` — **MR-row, column-major** micro-panels: `Ap[panel*MR*k + p*MR + i] == A(panel*MR+i, p)`.
- `pack_B` — **NR-col, row-major** micro-panels: `Bp[panel*NR*k + p*NR + j] == B(p, panel*NR+j)`.
- Layout matches the micro-kernel contract byte-for-byte (`Ap[p*MR+i]`, `Bp[p*NR+j]`), so packed panels feed straight into `gemm_microkernel`.

## Design
- **Generic strides (BLIS-style):** source is a base pointer + row stride `rs` + col stride `cs`, so row-major (`rs=ld,cs=1`), col-major (`rs=1,cs=ld`) and transposed views all pack with **no special-casing** — `A(i,j)` is read from `A[i*rs + j*cs]`.
- **Edge padding:** trailing partial blocks (rows `< MR`, cols `< NR`) are zero-padded up to the full tile, so the micro-kernel only ever sees full `MR x NR` tiles and needs no inner-loop size checks (padded multiplies contribute 0).
- Buffers written front-to-back; caller sizes them with `packed_A_size` / `packed_B_size` and reuses across the blocking loops (allocated via the aligned allocator, #84).

## Changes
- `include/mtl/detail/gemm_pack.hpp` — `pack_A`, `pack_B`, `packed_A_size`, `packed_B_size`.
- `include/mtl/mtl.hpp` — include the new header.
- `tests/unit/detail/test_gemm_pack.cpp` — verifies packed-buffer layout **slot-by-slot** (real entries + zero padding) for both orientations, `MR in {1,3,4}`, `NR in {1,3,8}`, sizes including non-multiples of MR/NR, plus an explicit 3x2/MR=2 case.

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| detail_test_gemm_pack | OK | PASS (88540 assertions) | OK | PASS |

## Test plan
- [ ] Fast CI passes (gcc + clang)
- [ ] Promote to ready when satisfied: `gh pr ready <n>`

Resolves #89

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GEMM packing utilities that prepare matrix panels with edge padding so micro-kernels can operate on full tiles without per-element bounds checks.

* **Tests**
  * Added unit tests validating packed outputs (including padding behavior) across multiple panel sizes and source layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->