### PR TITLE
perf(operation): GEMM macro-kernel + cache-blocking loop nest + dispatch wiring

### DIFF
--- a/include/mtl/detail/gemm_blocked.hpp
+++ b/include/mtl/detail/gemm_blocked.hpp
@@ -1,0 +1,125 @@
+#pragma once
+// MTL5 -- blocked GEMM macro-kernel: the GotoBLAS/BLIS 5-loop cache-blocking
+// nest around the register micro-kernel (#88) and the packing step (#89).
+// (#90, epic #82, Phase 2.)
+//
+// gemm_blocked computes  C := beta*C + alpha * A * B  with C row-major. A and B
+// are given by a base pointer plus (row stride, col stride), so every operand
+// orientation -- row-major, col-major, transposed view -- packs with NO special
+// casing: A(i,p) == A[i*a_rs + p*a_cs], B(p,j) == B[p*b_rs + j*b_cs]. The packing
+// normalizes layout; the micro-kernel always sees its canonical packed panels.
+//
+// The five loops (outer..inner), per Goto/BLIS:
+//   jc (step nc)  -- partition C/B columns                       -> L3 (B panel)
+//     pc (step kc)  -- partition the k dimension; pack B(pc,jc)   -> L1 (B micro-panel)
+//       ic (step mc)  -- partition C/A rows; pack A(ic,pc)        -> L2 (A block)
+//         jr (step nr) -- macro-kernel over packed panels
+//           ir (step mr) -> MICRO-KERNEL: mr x nr C tile in registers, kc deep
+//
+// kc/mc/nc and the mr x nr register tile come from simd::default_blocking<T>.
+// Edge tiles (trailing rows < mr or cols < nr) are accumulated through a zeroed
+// mr x nr temporary so the micro-kernel only ever writes full tiles.
+
+#include <algorithm>
+#include <cstddef>
+#include <vector>
+
+#include <mtl/concepts/scalar.hpp>
+#include <mtl/detail/aligned_allocator.hpp>
+#include <mtl/detail/gemm_microkernel.hpp>
+#include <mtl/detail/gemm_pack.hpp>
+#include <mtl/simd/blocking.hpp>
+
+namespace mtl::detail {
+
+/// SIMD-aligned scratch buffer for packed panels (reused across the nest).
+template <typename T>
+using packed_buffer = std::vector<T, aligned_allocator<T>>;
+
+/// C[m x n] (row-major, leading dim ldc) := beta*C + alpha * A[m x k] * B[k x n].
+/// A,B addressed by generic strides (see file header). ldc must be >= n.
+template <typename T>
+    requires mtl::Scalar<T>
+void gemm_blocked(std::size_t m, std::size_t n, std::size_t k,
+                  T alpha,
+                  const T* A, std::ptrdiff_t a_rs, std::ptrdiff_t a_cs,
+                  const T* B, std::ptrdiff_t b_rs, std::ptrdiff_t b_cs,
+                  T beta,
+                  T* C, std::size_t ldc) {
+    constexpr simd::blocking_params bp = simd::default_blocking<T>;
+    constexpr std::size_t MR = bp.mr;
+    constexpr std::size_t NR = bp.nr;
+    const std::size_t KC = bp.kc, MC = bp.mc, NC = bp.nc;
+
+    // beta: scale (or zero) C once up front; the nest then purely accumulates.
+    if (beta == T(0)) {
+        for (std::size_t i = 0; i < m; ++i)
+            for (std::size_t j = 0; j < n; ++j) C[i * ldc + j] = T(0);
+    } else if (!(beta == T(1))) {
+        for (std::size_t i = 0; i < m; ++i)
+            for (std::size_t j = 0; j < n; ++j) C[i * ldc + j] = beta * C[i * ldc + j];
+    }
+
+    if (m == 0 || n == 0 || k == 0) return;
+
+    // Scratch for one packed A block (mc x kc) and one packed B panel (kc x nc),
+    // sized to the largest block actually used (clamped to the problem) so small
+    // problems don't allocate full-MC/KC/NC buffers. Reused across the nest.
+    const std::size_t kc_max = std::min(KC, k);
+    const std::size_t mc_max = std::min(MC, m);
+    const std::size_t nc_max = std::min(NC, n);
+    packed_buffer<T> Ac(packed_A_size(mc_max, kc_max, MR));
+    packed_buffer<T> Bc(packed_B_size(kc_max, nc_max, NR));
+
+    for (std::size_t jc = 0; jc < n; jc += NC) {
+        const std::size_t nci = std::min(NC, n - jc);
+        const std::size_t npanels = (nci + NR - 1) / NR;
+        for (std::size_t pc = 0; pc < k; pc += KC) {
+            const std::size_t kci = std::min(KC, k - pc);
+            pack_B<T, NR>(B + static_cast<std::ptrdiff_t>(pc) * b_rs
+                            + static_cast<std::ptrdiff_t>(jc) * b_cs,
+                          b_rs, b_cs, kci, nci, Bc.data());
+
+            for (std::size_t ic = 0; ic < m; ic += MC) {
+                const std::size_t mci = std::min(MC, m - ic);
+                pack_A<T, MR>(A + static_cast<std::ptrdiff_t>(ic) * a_rs
+                                + static_cast<std::ptrdiff_t>(pc) * a_cs,
+                              a_rs, a_cs, mci, kci, Ac.data());
+                if (!(alpha == T(1))) {                       // fold alpha into A panel
+                    const std::size_t na = packed_A_size(mci, kci, MR);
+                    for (std::size_t t = 0; t < na; ++t) Ac[t] = alpha * Ac[t];
+                }
+
+                const std::size_t mpanels = (mci + MR - 1) / MR;
+                T* Cmacro = C + static_cast<std::ptrdiff_t>(ic) * static_cast<std::ptrdiff_t>(ldc)
+                              + static_cast<std::ptrdiff_t>(jc);
+                for (std::size_t jr = 0; jr < npanels; ++jr) {
+                    const std::size_t nr_eff = std::min(NR, nci - jr * NR);
+                    const T* Bpanel = Bc.data() + jr * (NR * kci);
+                    for (std::size_t ir = 0; ir < mpanels; ++ir) {
+                        const std::size_t mr_eff = std::min(MR, mci - ir * MR);
+                        const T* Apanel = Ac.data() + ir * (MR * kci);
+                        T* Cblock = Cmacro + (ir * MR) * ldc + jr * NR;
+                        if (mr_eff == MR && nr_eff == NR) {
+                            gemm_microkernel<T, MR, NR>(kci, Apanel, Bpanel, Cblock, ldc);
+                        } else {
+                            // Edge: accumulate through a zeroed full mr x nr tile so
+                            // the micro-kernel's full-tile load/store stays in bounds.
+                            T tile[MR * NR];
+                            for (std::size_t t = 0; t < MR * NR; ++t) tile[t] = T(0);
+                            for (std::size_t i = 0; i < mr_eff; ++i)
+                                for (std::size_t j = 0; j < nr_eff; ++j)
+                                    tile[i * NR + j] = Cblock[i * ldc + j];
+                            gemm_microkernel<T, MR, NR>(kci, Apanel, Bpanel, tile, NR);
+                            for (std::size_t i = 0; i < mr_eff; ++i)
+                                for (std::size_t j = 0; j < nr_eff; ++j)
+                                    Cblock[i * ldc + j] = tile[i * NR + j];
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+} // namespace mtl::detail

--- a/include/mtl/mtl.hpp
+++ b/include/mtl/mtl.hpp
@@ -15,6 +15,7 @@
 
 // Dense GEMM building blocks (native-BLAS epic #82)
 #include <mtl/detail/gemm_pack.hpp>
+#include <mtl/detail/gemm_blocked.hpp>
 
 // Concepts
 #include <mtl/concepts/scalar.hpp>

--- a/include/mtl/operation/mult.hpp
+++ b/include/mtl/operation/mult.hpp
@@ -9,6 +9,10 @@
 #ifdef MTL5_HAS_BLAS
 #include <mtl/interface/blas.hpp>
 #endif
+#ifdef MTL5_NATIVE_FAST_GEMM
+#include <cstddef>
+#include <mtl/detail/gemm_blocked.hpp>
+#endif
 
 namespace mtl {
 
@@ -106,6 +110,38 @@ void mult(const MA& A, const MB& B, MC& C) {
             interface::blas::gemm('N', 'N', m, n, k, alpha,
                                   A.data(), m, B.data(), k,
                                   beta, C.data(), m);
+        }
+        return;
+    }
+#endif
+#ifdef MTL5_NATIVE_FAST_GEMM
+    // Native blocked GEMM: preferred over the generic triple loop for dense
+    // contiguous float/double matrices when no external BLAS handled it above.
+    if constexpr (interface::BlasDenseMatrix<MA> &&
+                  interface::BlasDenseMatrix<MB> &&
+                  interface::BlasDenseMatrix<MC>) {
+        using T = typename MC::value_type;
+        const std::size_t M = A.num_rows();
+        const std::size_t N = B.num_cols();
+        const std::size_t K = A.num_cols();
+        // Tightly-packed dense layout: ld = ncols (row-major) or nrows (col-major).
+        const std::ptrdiff_t a_rs = interface::is_row_major_v<MA> ? static_cast<std::ptrdiff_t>(A.num_cols()) : 1;
+        const std::ptrdiff_t a_cs = interface::is_row_major_v<MA> ? 1 : static_cast<std::ptrdiff_t>(A.num_rows());
+        const std::ptrdiff_t b_rs = interface::is_row_major_v<MB> ? static_cast<std::ptrdiff_t>(B.num_cols()) : 1;
+        const std::ptrdiff_t b_cs = interface::is_row_major_v<MB> ? 1 : static_cast<std::ptrdiff_t>(B.num_rows());
+        if constexpr (interface::is_row_major_v<MC>) {
+            detail::gemm_blocked<T>(M, N, K, math::one<T>(),
+                                    A.data(), a_rs, a_cs,
+                                    B.data(), b_rs, b_cs,
+                                    math::zero<T>(), C.data(), N);
+        } else {
+            // Col-major C: compute C^T = B^T * A^T into the same buffer, viewed as
+            // a row-major N x M matrix (ld = M). Pack picks up B^T/A^T by swapping
+            // each operand's strides.
+            detail::gemm_blocked<T>(N, M, K, math::one<T>(),
+                                    B.data(), b_cs, b_rs,
+                                    A.data(), a_cs, a_rs,
+                                    math::zero<T>(), C.data(), M);
         }
         return;
     }

--- a/tests/unit/operation/test_gemm_blocked.cpp
+++ b/tests/unit/operation/test_gemm_blocked.cpp
@@ -1,0 +1,148 @@
+// Tests for the blocked GEMM macro-kernel (#90) and its mult() dispatch wiring.
+// Integer-valued data => exact products/sums in float/double regardless of
+// blocking/FMA order, so we compare bit-exactly to a naive triple-loop ref.
+//
+// One assertion per configuration (a bool "all elements matched"), not one per
+// element -- Catch2 CHECK is expensive, and the size sweep would otherwise fire
+// millions of them. Multi-block sizes are derived from default_blocking so the
+// cache-blocking nest is exercised (crossing mc/kc) regardless of SIMD width.
+//
+// Define the gate BEFORE including mult.hpp so the native-fast path compiles in
+// and is exercised through mtl::mult for this translation unit.
+#define MTL5_NATIVE_FAST_GEMM 1
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+
+#include <mtl/detail/gemm_blocked.hpp>
+#include <mtl/operation/mult.hpp>
+#include <mtl/simd/blocking.hpp>
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/mat/parameter.hpp>
+#include <mtl/tag/orientation.hpp>
+
+#include <cstddef>
+#include <vector>
+
+namespace {
+
+template <typename T>
+T av(std::size_t i, std::size_t j) { return T((i * 5 + j) % 7) - 3; }   // A entries
+template <typename T>
+T bv(std::size_t p, std::size_t j) { return T((p * 3 + 2 * j) % 5) - 2; } // B entries
+
+// gemm_blocked produces a row-major C. Feed A and B in either orientation (the
+// packing normalizes via strides) and return whether C == naive A*B everywhere.
+template <typename T>
+bool blocked_matches(std::size_t m, std::size_t n, std::size_t k, bool a_rowmaj, bool b_rowmaj) {
+    std::vector<T> A(m * k), B(k * n), C(m * n, T(-777));
+    for (std::size_t i = 0; i < m; ++i)
+        for (std::size_t p = 0; p < k; ++p)
+            A[a_rowmaj ? i * k + p : p * m + i] = av<T>(i, p);
+    for (std::size_t p = 0; p < k; ++p)
+        for (std::size_t j = 0; j < n; ++j)
+            B[b_rowmaj ? p * n + j : j * k + p] = bv<T>(p, j);
+
+    const std::ptrdiff_t a_rs = a_rowmaj ? (std::ptrdiff_t)k : 1, a_cs = a_rowmaj ? 1 : (std::ptrdiff_t)m;
+    const std::ptrdiff_t b_rs = b_rowmaj ? (std::ptrdiff_t)n : 1, b_cs = b_rowmaj ? 1 : (std::ptrdiff_t)k;
+    mtl::detail::gemm_blocked<T>(m, n, k, T(1), A.data(), a_rs, a_cs, B.data(), b_rs, b_cs,
+                                 T(0), C.data(), n);
+
+    for (std::size_t i = 0; i < m; ++i)
+        for (std::size_t j = 0; j < n; ++j) {
+            T s = 0;
+            for (std::size_t p = 0; p < k; ++p) s += av<T>(i, p) * bv<T>(p, j);
+            if (C[i * n + j] != s) return false;
+        }
+    return true;
+}
+
+// Sizes that straddle the mr/nr register tile and small kc edges.
+const std::size_t kEdge[] = {1, 2, 3, 4, 5, 7, 8, 9, 13, 16, 17};
+
+} // namespace
+
+TEMPLATE_TEST_CASE("gemm_blocked: C=A*B, all orientations, edge sizes", "[operation][gemm][blocked]", float, double) {
+    for (std::size_t m : kEdge)
+        for (std::size_t n : kEdge)
+            for (std::size_t k : kEdge) {
+                INFO("m=" << m << " n=" << n << " k=" << k);
+                CHECK(blocked_matches<TestType>(m, n, k, true,  true));
+                CHECK(blocked_matches<TestType>(m, n, k, false, true));   // A col-major
+                CHECK(blocked_matches<TestType>(m, n, k, true,  false));  // B col-major
+                CHECK(blocked_matches<TestType>(m, n, k, false, false));  // both col-major
+            }
+}
+
+TEMPLATE_TEST_CASE("gemm_blocked: crosses mc/kc cache blocks", "[operation][gemm][blocked]", float, double) {
+    // Derive sizes from the actual blocking so the ic/pc loops iterate >1 time
+    // regardless of SIMD width: m past one mc block, k past one kc block.
+    constexpr auto bp = mtl::simd::default_blocking<TestType>;
+    const std::size_t m = bp.mc + bp.mr + 1;   // > mc  -> multiple ic blocks + edge
+    const std::size_t k = bp.kc + 3;           // > kc  -> multiple pc blocks + edge
+    const std::size_t n = bp.nr * 3 + 1;       // a few nr panels + edge
+    INFO("m=" << m << " n=" << n << " k=" << k << "  (mc=" << bp.mc << " kc=" << bp.kc << ")");
+    CHECK(blocked_matches<TestType>(m, n, k, true,  true));
+    CHECK(blocked_matches<TestType>(m, n, k, false, false));   // both col-major
+}
+
+TEMPLATE_TEST_CASE("gemm_blocked: alpha/beta", "[operation][gemm][blocked]", float, double) {
+    const std::size_t m = 9, n = 7, k = 5;
+    std::vector<TestType> A(m * k), B(k * n);
+    for (std::size_t i = 0; i < m; ++i) for (std::size_t p = 0; p < k; ++p) A[i * k + p] = av<TestType>(i, p);
+    for (std::size_t p = 0; p < k; ++p) for (std::size_t j = 0; j < n; ++j) B[p * n + j] = bv<TestType>(p, j);
+
+    const TestType alpha = TestType(2), beta = TestType(3);
+    std::vector<TestType> C(m * n), ref(m * n);
+    for (std::size_t t = 0; t < m * n; ++t) C[t] = TestType(t % 4) - 1;
+    for (std::size_t i = 0; i < m; ++i)
+        for (std::size_t j = 0; j < n; ++j) {
+            TestType prod = 0;
+            for (std::size_t p = 0; p < k; ++p) prod += av<TestType>(i, p) * bv<TestType>(p, j);
+            ref[i * n + j] = beta * C[i * n + j] + alpha * prod;
+        }
+
+    mtl::detail::gemm_blocked<TestType>(m, n, k, alpha, A.data(), (std::ptrdiff_t)k, 1,
+                                        B.data(), (std::ptrdiff_t)n, 1, beta, C.data(), n);
+    bool ok = true;
+    for (std::size_t t = 0; t < m * n; ++t) ok = ok && (C[t] == ref[t]);
+    CHECK(ok);
+}
+
+// mult() dispatch: with MTL5_NATIVE_FAST_GEMM defined, dense2D float/double
+// routes through gemm_blocked. Verify both a row-major and a col-major C (the
+// latter exercises the C^T = B^T A^T branch).
+namespace {
+using rowmaj = mtl::mat::parameters<mtl::tag::row_major>;
+using colmaj = mtl::mat::parameters<mtl::tag::col_major>;
+
+template <typename Mat>
+void fill(Mat& M, bool isA) {
+    for (std::size_t i = 0; i < M.num_rows(); ++i)
+        for (std::size_t j = 0; j < M.num_cols(); ++j)
+            M(i, j) = isA ? av<typename Mat::value_type>(i, j) : bv<typename Mat::value_type>(i, j);
+}
+
+template <typename MC, typename MA, typename MB>
+bool mult_matches(const MA& A, const MB& B, std::size_t m, std::size_t n, std::size_t k) {
+    MC C(m, n);
+    mtl::mult(A, B, C);
+    using T = typename MC::value_type;
+    for (std::size_t i = 0; i < m; ++i)
+        for (std::size_t j = 0; j < n; ++j) {
+            T s = 0;
+            for (std::size_t p = 0; p < k; ++p) s += A(i, p) * B(p, j);
+            if (C(i, j) != s) return false;
+        }
+    return true;
+}
+} // namespace
+
+TEMPLATE_TEST_CASE("mult() native-fast dispatch matches naive (row- and col-major C)", "[operation][gemm][blocked][dispatch]", float, double) {
+    const std::size_t m = 13, n = 10, k = 6;
+    mtl::mat::dense2D<TestType, rowmaj> A(m, k), B(k, n);
+    fill(A, true); fill(B, false);
+
+    CHECK(mult_matches<mtl::mat::dense2D<TestType, rowmaj>>(A, B, m, n, k));  // row-major C
+    CHECK(mult_matches<mtl::mat::dense2D<TestType, colmaj>>(A, B, m, n, k));  // col-major C
+}


### PR DESCRIPTION
## Summary
The keystone of Phase 2 (epic #82): the GotoBLAS/BLIS **5-loop cache-blocking nest** that wires the packing routines (#89) and the register micro-kernel (#88) into a working native GEMM, plus the `mult()` dispatch wiring.

## What it does
- **`include/mtl/detail/gemm_blocked.hpp`** — `gemm_blocked` computes `C := beta*C + alpha * A * B` with `C` row-major. Loops: `jc(nc) → pc(kc)[pack B] → ic(mc)[pack A] → jr(nr) → ir(mr) → micro-kernel`. Blocking params from `simd::default_blocking<T>`.
  - **All orientations, no special-casing**: A and B are addressed by generic `(row stride, col stride)`, so row-major, col-major and transposed views all pack identically.
  - **Edge tiles**: trailing rows `< mr` / cols `< nr` accumulate through a zeroed `MR×NR` temp, so the micro-kernel only ever writes full tiles (and its full-tile load/store stays in bounds).
  - **alpha/beta**: `alpha` folds into the packed A panel; `beta` scales C once up front, then the nest purely accumulates.
  - **Right-sized scratch**: packed buffers are sized to `min(block, dim)`, so small problems don't allocate full `MC/KC/NC` buffers.
- **`include/mtl/operation/mult.hpp`** — native-fast branch inserted **between** the external-BLAS path and the generic triple loop, gated behind **`MTL5_NATIVE_FAST_GEMM`** (off by default → existing builds unchanged). Row-major C writes directly; col-major C is produced via the `Cᵀ = Bᵀ·Aᵀ` identity into the same buffer (operand strides swapped). Applies to dense contiguous `float`/`double` matrices.

## Changes
- `include/mtl/detail/gemm_blocked.hpp` — the macro-kernel (new).
- `include/mtl/operation/mult.hpp` — gated native-fast GEMM dispatch.
- `include/mtl/mtl.hpp` — include the new header.
- `tests/unit/operation/test_gemm_blocked.cpp` — correctness vs naive ref.

## Test plan / results
One assertion per configuration (bool "all matched"); multi-block sizes are derived from `default_blocking` so the nest crosses `mc`/`kc` regardless of SIMD width.

| Coverage | gcc | clang |
|---|---|---|
| `gemm_blocked` all 4 A/B orientations × edge sizes | PASS | PASS |
| crosses mc/kc cache blocks | PASS | PASS |
| alpha/beta | PASS | PASS |
| `mult()` dispatch, row- & col-major C | PASS | PASS |
| existing `matrix_ops` (ungated `mult`) regression | PASS | — |

- [ ] Fast CI passes (gcc + clang)
- [ ] Promote to ready when satisfied: `gh pr ready <n>`

> Note: this lands the *correctness* of the native GEMM path. The performance target (within 10–20% of OpenBLAS) and turning `MTL5_NATIVE_FAST_GEMM` on for the `native-fast` build are finalized in the #93 benchmark gate. General `alpha`/`beta` are supported in `gemm_blocked` but `mult()` only uses `alpha=1, beta=0`.

Relates to #90

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced optional native fast implementation for matrix multiplication operations on dense matrices, available as an alternative computation path when enabled.

* **Tests**
  * Added comprehensive unit tests for the new matrix multiplication implementation, validating correctness across various scenarios including multiple matrix dimensions, orientations, memory layouts, scaling parameters, and dispatch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->