### PR TITLE
perf(operation): optimize native GEMV (orientation-aware, SIMD, vector register-blocking)

### DIFF
--- a/include/mtl/detail/gemv.hpp
+++ b/include/mtl/detail/gemv.hpp
@@ -1,0 +1,102 @@
+#pragma once
+// MTL5 -- optimized native GEMV (#87, epic #82, Phase 1).
+//
+// y := A * x. GEMV is memory-bandwidth-bound (A is O(mn) bytes read once and is
+// the bottleneck), so there is no packing: the wins are an orientation-aware
+// loop order that reads A unit-stride, SIMD + FMA over the contiguous axis, and
+// register-blocking the *reused* vector to cut its traffic.
+//
+//   row-major A  -> dot-of-rows: block MR rows so each loaded x batch is reused
+//                   MR times (x traffic / MR); one horizontal reduce per row.
+//   col-major A  -> axpy-of-columns: hold a strip of y in registers across all
+//                   columns and accumulate (broadcast x[j]) * A[:,j]; y is then
+//                   written exactly once.
+//
+// A(i,j) is read from its orientation's contiguous layout:
+//   row-major  A(i,j) = A[i*lda + j]   (lda = n, rows contiguous)
+//   col-major  A(i,j) = A[j*lda + i]   (lda = m, columns contiguous)
+
+#include <cstddef>
+
+#include <mtl/concepts/scalar.hpp>
+#include <mtl/simd/algorithm.hpp>   // reduce_dot for the row remainder
+#include <mtl/simd/batch.hpp>
+
+namespace mtl::detail {
+
+/// y[m] := A[m x n] * x[n], A row-major (rows contiguous, lda = n).
+template <typename T>
+    requires mtl::Scalar<T>
+void gemv_rowmajor(std::size_t m, std::size_t n, const T* A, std::size_t lda,
+                   const T* x, T* y) {
+    using B = simd::batch<T>;
+    constexpr std::size_t W = B::size;
+    constexpr std::size_t MR = 4;                 // rows per register block
+
+    std::size_t i = 0;
+    for (; i + MR <= m; i += MR) {
+        const T* a0 = A + (i + 0) * lda;
+        const T* a1 = A + (i + 1) * lda;
+        const T* a2 = A + (i + 2) * lda;
+        const T* a3 = A + (i + 3) * lda;
+        B acc0, acc1, acc2, acc3;                 // batch() zero-initializes
+        std::size_t j = 0;
+        for (; j + W <= n; j += W) {
+            const B xb = B::load_unaligned(x + j);  // loaded once, reused MR times
+            acc0 = fma(B::load_unaligned(a0 + j), xb, acc0);
+            acc1 = fma(B::load_unaligned(a1 + j), xb, acc1);
+            acc2 = fma(B::load_unaligned(a2 + j), xb, acc2);
+            acc3 = fma(B::load_unaligned(a3 + j), xb, acc3);
+        }
+        T s0 = reduce_add(acc0), s1 = reduce_add(acc1),
+          s2 = reduce_add(acc2), s3 = reduce_add(acc3);
+        for (; j < n; ++j) {                      // scalar tail over columns
+            const T xj = x[j];
+            s0 += a0[j] * xj; s1 += a1[j] * xj; s2 += a2[j] * xj; s3 += a3[j] * xj;
+        }
+        y[i + 0] = s0; y[i + 1] = s1; y[i + 2] = s2; y[i + 3] = s3;
+    }
+    for (; i < m; ++i)                            // remaining rows (< MR)
+        y[i] = simd::reduce_dot<T>(A + i * lda, x, n);
+}
+
+/// y[m] := A[m x n] * x[n], A col-major (columns contiguous, lda = m).
+template <typename T>
+    requires mtl::Scalar<T>
+void gemv_colmajor(std::size_t m, std::size_t n, const T* A, std::size_t lda,
+                   const T* x, T* y) {
+    using B = simd::batch<T>;
+    constexpr std::size_t W = B::size;
+    constexpr std::size_t UB = 4;                 // y batches resident per strip
+    constexpr std::size_t SB = UB * W;            // rows per strip
+
+    std::size_t i = 0;
+    for (; i + SB <= m; i += SB) {                // wide resident y-strip
+        B acc0, acc1, acc2, acc3;                 // y-strip in registers, zeroed
+        for (std::size_t j = 0; j < n; ++j) {
+            const B xj(x[j]);
+            const T* col = A + j * lda + i;
+            acc0 = fma(xj, B::load_unaligned(col + 0 * W), acc0);
+            acc1 = fma(xj, B::load_unaligned(col + 1 * W), acc1);
+            acc2 = fma(xj, B::load_unaligned(col + 2 * W), acc2);
+            acc3 = fma(xj, B::load_unaligned(col + 3 * W), acc3);
+        }
+        acc0.store_unaligned(y + i + 0 * W);
+        acc1.store_unaligned(y + i + 1 * W);
+        acc2.store_unaligned(y + i + 2 * W);
+        acc3.store_unaligned(y + i + 3 * W);
+    }
+    for (; i + W <= m; i += W) {                  // single-batch strips
+        B acc;
+        for (std::size_t j = 0; j < n; ++j)
+            acc = fma(B(x[j]), B::load_unaligned(A + j * lda + i), acc);
+        acc.store_unaligned(y + i);
+    }
+    for (; i < m; ++i) {                          // remaining rows (< W), scalar
+        T s = T(0);
+        for (std::size_t j = 0; j < n; ++j) s += A[j * lda + i] * x[j];
+        y[i] = s;
+    }
+}
+
+} // namespace mtl::detail

--- a/include/mtl/mtl.hpp
+++ b/include/mtl/mtl.hpp
@@ -16,6 +16,7 @@
 // Dense GEMM building blocks (native-BLAS epic #82)
 #include <mtl/detail/gemm_pack.hpp>
 #include <mtl/detail/gemm_blocked.hpp>
+#include <mtl/detail/gemv.hpp>
 
 // Concepts
 #include <mtl/concepts/scalar.hpp>

--- a/include/mtl/operation/mult.hpp
+++ b/include/mtl/operation/mult.hpp
@@ -11,7 +11,9 @@
 #endif
 #ifdef MTL5_NATIVE_FAST_GEMM
 #include <cstddef>
+#include <type_traits>
 #include <mtl/detail/gemm_blocked.hpp>
+#include <mtl/detail/gemv.hpp>
 #endif
 
 namespace mtl {
@@ -73,6 +75,25 @@ void mult(const M& A, const VIn& x, VOut& y) {
             interface::blas::gemv('N', m, n, alpha,
                                   A.data(), m, x.data(), 1,
                                   beta, y.data(), 1);
+        }
+        return;
+    }
+#endif
+#ifdef MTL5_NATIVE_FAST_GEMM
+    // Native SIMD GEMV: preferred over the generic scalar loop for dense
+    // contiguous float/double when no external BLAS handled it above.
+    if constexpr (interface::BlasDenseMatrix<M> &&
+                  interface::BlasDenseVector<VIn> &&
+                  interface::BlasDenseVector<VOut> &&
+                  std::is_same_v<typename M::value_type, typename VIn::value_type> &&
+                  std::is_same_v<typename M::value_type, typename VOut::value_type>) {
+        using T = typename M::value_type;
+        const std::size_t mm = A.num_rows();
+        const std::size_t nn = A.num_cols();
+        if constexpr (interface::is_row_major_v<M>) {
+            detail::gemv_rowmajor<T>(mm, nn, A.data(), nn, x.data(), y.data());
+        } else {
+            detail::gemv_colmajor<T>(mm, nn, A.data(), mm, x.data(), y.data());
         }
         return;
     }

--- a/tests/unit/operation/test_gemv.cpp
+++ b/tests/unit/operation/test_gemv.cpp
@@ -1,0 +1,96 @@
+// Tests for the optimized native GEMV (#87) and its mult(A,x,y) dispatch wiring.
+// Integer-valued data => exact products/sums in float/double regardless of
+// SIMD/FMA order, so we compare bit-exactly to a naive reference. One assertion
+// per configuration (bool "all matched"), not one per element.
+//
+// Define the gate BEFORE including mult.hpp so the native path is exercised
+// through mtl::mult for this translation unit.
+#define MTL5_NATIVE_FAST_GEMM 1
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+
+#include <mtl/detail/gemv.hpp>
+#include <mtl/operation/mult.hpp>
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/mat/parameter.hpp>
+#include <mtl/tag/orientation.hpp>
+#include <mtl/vec/dense_vector.hpp>
+
+#include <cstddef>
+#include <vector>
+
+namespace {
+
+template <typename T> T av(std::size_t i, std::size_t j) { return T((i * 3 + j) % 7) - 3; }
+template <typename T> T xv(std::size_t j) { return T((j * 2) % 5) - 2; }
+
+// Build A in the requested orientation, run the matching kernel, and return
+// whether y == naive A*x everywhere.
+template <typename T>
+bool gemv_matches(std::size_t m, std::size_t n, bool rowmajor) {
+    std::vector<T> A(m * n), x(n), y(m, T(-777));
+    for (std::size_t i = 0; i < m; ++i)
+        for (std::size_t j = 0; j < n; ++j)
+            A[rowmajor ? i * n + j : j * m + i] = av<T>(i, j);
+    for (std::size_t j = 0; j < n; ++j) x[j] = xv<T>(j);
+
+    if (rowmajor) mtl::detail::gemv_rowmajor<T>(m, n, A.data(), n, x.data(), y.data());
+    else          mtl::detail::gemv_colmajor<T>(m, n, A.data(), m, x.data(), y.data());
+
+    for (std::size_t i = 0; i < m; ++i) {
+        T s = 0;
+        for (std::size_t j = 0; j < n; ++j) s += av<T>(i, j) * xv<T>(j);
+        if (y[i] != s) return false;
+    }
+    return true;
+}
+
+// Sizes straddling the SIMD width, the MR=4 row block, and the UB*W y-strip.
+const std::size_t kDims[] = {1, 2, 3, 4, 5, 7, 8, 9, 13, 16, 17, 31, 33, 64, 100};
+
+} // namespace
+
+TEMPLATE_TEST_CASE("gemv: row-major and col-major vs naive, all sizes", "[operation][gemv]", float, double) {
+    for (std::size_t m : kDims)
+        for (std::size_t n : kDims) {
+            INFO("m=" << m << " n=" << n);
+            CHECK(gemv_matches<TestType>(m, n, true));   // row-major (dot-of-rows)
+            CHECK(gemv_matches<TestType>(m, n, false));  // col-major (axpy-of-columns)
+        }
+}
+
+// mult(A,x,y) dispatch: with MTL5_NATIVE_FAST_GEMM defined, dense2D float/double
+// x dense_vector routes through the native GEMV for both A orientations.
+namespace {
+using rowmaj = mtl::mat::parameters<mtl::tag::row_major>;
+using colmaj = mtl::mat::parameters<mtl::tag::col_major>;
+
+template <typename MatA>
+bool mult_matches(std::size_t m, std::size_t n) {
+    using T = typename MatA::value_type;
+    MatA A(m, n);
+    mtl::vec::dense_vector<T> x(n), y(m);
+    for (std::size_t i = 0; i < m; ++i)
+        for (std::size_t j = 0; j < n; ++j) A(i, j) = av<T>(i, j);
+    for (std::size_t j = 0; j < n; ++j) x(j) = xv<T>(j);
+
+    mtl::mult(A, x, y);
+
+    for (std::size_t i = 0; i < m; ++i) {
+        T s = 0;
+        for (std::size_t j = 0; j < n; ++j) s += av<T>(i, j) * xv<T>(j);
+        if (y(i) != s) return false;
+    }
+    return true;
+}
+} // namespace
+
+TEMPLATE_TEST_CASE("mult() native GEMV dispatch matches naive (row- and col-major A)", "[operation][gemv][dispatch]", float, double) {
+    const std::size_t cases[][2] = {{1, 1}, {7, 5}, {16, 16}, {33, 20}, {100, 64}};
+    for (auto& c : cases) {
+        INFO("m=" << c[0] << " n=" << c[1]);
+        CHECK(mult_matches<mtl::mat::dense2D<TestType, rowmaj>>(c[0], c[1]));
+        CHECK(mult_matches<mtl::mat::dense2D<TestType, colmaj>>(c[0], c[1]));
+    }
+}

--- a/tests/unit/operation/test_gemv.cpp
+++ b/tests/unit/operation/test_gemv.cpp
@@ -46,8 +46,9 @@ bool gemv_matches(std::size_t m, std::size_t n, bool rowmajor) {
     return true;
 }
 
-// Sizes straddling the SIMD width, the MR=4 row block, and the UB*W y-strip.
-const std::size_t kDims[] = {1, 2, 3, 4, 5, 7, 8, 9, 13, 16, 17, 31, 33, 64, 100};
+// Sizes straddling the SIMD width, the MR=4 row block, and the UB*W y-strip;
+// 0 exercises the empty-shape / zero-iteration paths (incl. m==n==0).
+const std::size_t kDims[] = {0, 1, 2, 3, 4, 5, 7, 8, 9, 13, 16, 17, 31, 33, 64, 100};
 
 } // namespace
 
@@ -87,7 +88,7 @@ bool mult_matches(std::size_t m, std::size_t n) {
 } // namespace
 
 TEMPLATE_TEST_CASE("mult() native GEMV dispatch matches naive (row- and col-major A)", "[operation][gemv][dispatch]", float, double) {
-    const std::size_t cases[][2] = {{1, 1}, {7, 5}, {16, 16}, {33, 20}, {100, 64}};
+    const std::size_t cases[][2] = {{0, 0}, {0, 5}, {7, 0}, {1, 1}, {7, 5}, {16, 16}, {33, 20}, {100, 64}};
     for (auto& c : cases) {
         INFO("m=" << c[0] << " n=" << c[1]);
         CHECK(mult_matches<mtl::mat::dense2D<TestType, rowmaj>>(c[0], c[1]));


### PR DESCRIPTION
## Summary
Optimizes the native GEMV path (`mtl::mult(A, x, y)`). GEMV is memory-bandwidth-bound — `A` is O(mn) bytes read once and is the bottleneck — so there is **no packing**; the wins are an orientation-aware loop order that reads `A` unit-stride, SIMD+FMA over the contiguous axis, and register-blocking the *reused* vector to cut its traffic.

## Kernels (`include/mtl/detail/gemv.hpp`)
- **`gemv_rowmajor` — dot-of-rows.** Block `MR=4` rows; each loaded `x` batch is reused across all `MR` rows (cuts `x` traffic ~4×). One horizontal reduce per row, scalar column tail, row remainder via `simd::reduce_dot` (#86).
- **`gemv_colmajor` — axpy-of-columns.** Hold a strip of `y` (`UB*W` rows) resident in registers across **all** columns, accumulating `(broadcast x[j]) * A[:,j]`, so `y` is written exactly once. Single-batch strips + a scalar loop handle the row remainder.

These are the two L2 forms from the [BLAS kernel architecture](https://github.com/stillwater-sc/mtl5/blob/main/docs/design/blas-kernel-architecture.md) doc.

## Dispatch (`include/mtl/operation/mult.hpp`)
Native GEMV branch inserted **between** the external-BLAS path and the generic scalar loop, gated behind **`MTL5_NATIVE_FAST_GEMM`** (off by default → existing builds unchanged; same umbrella flag as the native GEMM). Kernel chosen from `is_row_major_v`; guarded on matching `float`/`double` `value_type`s across A/x/y.

## Changes
- `include/mtl/detail/gemv.hpp` — the two kernels (new).
- `include/mtl/operation/mult.hpp` — gated native GEMV dispatch.
- `include/mtl/mtl.hpp` — include the new header.
- `tests/unit/operation/test_gemv.cpp` — correctness vs naive ref.

## Test plan / results
One assertion per configuration; sizes straddle the SIMD width, the `MR` row block and the `UB*W` y-strip (incl. remainders).

| Coverage | gcc | clang |
|---|---|---|
| `gemv_rowmajor` / `gemv_colmajor` vs naive, size sweep | PASS | PASS |
| `mult()` dispatch, row- & col-major A × dense_vector | PASS | PASS |
| existing `matrix_ops` (ungated `mult`) regression | PASS | — |

- [ ] Fast CI passes (gcc + clang)
- [ ] Promote to ready when satisfied: `gh pr ready <n>`

> Lands GEMV *correctness/structure*; the bandwidth target vs OpenBLAS and flipping `MTL5_NATIVE_FAST_GEMM` on are finalized in the #93 benchmark gate.

Relates to #87

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optimized, SIMD-accelerated matrix‑vector multiplication path that runs automatically when available, supporting both row-major and column-major layouts.

* **Tests**
  * Added unit tests that validate the optimized GEMV and its dispatch across multiple matrix sizes and orientations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->