### PR TITLE
test(operation): correctness & edge-case coverage for native fast GEMM/GEMV

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,18 @@ if(MTL5_NATIVE_FAST_GEMM)
     target_compile_definitions(mtl5 INTERFACE $<BUILD_INTERFACE:MTL5_NATIVE_FAST_GEMM>)
 endif()
 
+# Sanitizers for in-tree builds (tests/benchmarks): pass a comma-separated list,
+# e.g. -DMTL5_SANITIZE=address,undefined. BUILD_INTERFACE only so it never leaks
+# into installed/exported flags. Used to validate the packing + micro-kernel
+# (#91). Not for MSVC (use its own /fsanitize separately).
+set(MTL5_SANITIZE "" CACHE STRING "Sanitizers for in-tree builds (e.g. address,undefined)")
+if(MTL5_SANITIZE AND NOT MSVC)
+    target_compile_options(mtl5 INTERFACE
+        $<BUILD_INTERFACE:-fsanitize=${MTL5_SANITIZE};-fno-omit-frame-pointer;-g>)
+    target_link_options(mtl5 INTERFACE
+        $<BUILD_INTERFACE:-fsanitize=${MTL5_SANITIZE}>)
+endif()
+
 if(MTL5_ENABLE_OPENMP)
     find_package(OpenMP REQUIRED)
     target_link_libraries(mtl5 INTERFACE OpenMP::OpenMP_CXX)

--- a/docs/getting-started/build-options.md
+++ b/docs/getting-started/build-options.md
@@ -24,6 +24,26 @@ These options link optional external libraries for hardware-accelerated or speci
 | `MTL5_WITH_SUITESPARSE_CHOLMOD` | OFF | Link CHOLMOD Cholesky (SuiteSparse) |
 | `MTL5_WITH_SUITESPARSE_SPQR` | OFF | Link SuiteSparseQR (SuiteSparse) |
 
+## Native Performance & Development
+
+These tune or instrument **in-tree** builds (tests, benchmarks). They are
+`BUILD_INTERFACE`-only and never leak into the installed/exported package.
+
+| Option | Default | Description |
+|---|---|---|
+| `MTL5_WITH_HIGHWAY` | OFF | Use Google Highway for SIMD-accelerated native kernels (found or fetched at a pinned tag); scalar fallback otherwise |
+| `MTL5_NATIVE_ARCH` | OFF | Tune for the host CPU (`-march=native`); lets the SIMD layer pick the widest ISA (non-portable binaries) |
+| `MTL5_NATIVE_FAST_GEMM` | OFF | Route `mtl::mult` through the native blocked GEMM / SIMD GEMV path instead of the generic loop |
+| `MTL5_SANITIZE` | *(empty)* | Comma-separated sanitizers for in-tree builds, e.g. `-DMTL5_SANITIZE=address,undefined` (GCC/Clang) |
+
+```bash
+# Native fast dense path, host-tuned (what benchmarks/run_sweeps.sh builds):
+cmake -B build -DMTL5_NATIVE_FAST_GEMM=ON -DMTL5_WITH_HIGHWAY=ON -DMTL5_NATIVE_ARCH=ON
+
+# ASan + UBSan over the kernels:
+cmake -B build-asan -DMTL5_SANITIZE=address,undefined -DMTL5_WITH_HIGHWAY=ON
+```
+
 ## Build Presets
 
 The project includes CMake presets for common configurations:

--- a/tests/unit/operation/test_fast_gemm_numeric.cpp
+++ b/tests/unit/operation/test_fast_gemm_numeric.cpp
@@ -1,0 +1,179 @@
+// Numerical correctness of the native fast GEMM/GEMV path (#91) on *random
+// floating-point* data -- the integer-exact tests (test_gemm_blocked.cpp,
+// test_gemv.cpp) prove the structure; this proves the arithmetic is right to
+// floating-point rounding across orientations, alpha/beta, rectangular and
+// multi-block sizes.
+//
+// Reference: the same T-rounded inputs accumulated in long double (the trusted
+// high-precision generic triple product). native-fast accumulates in T, so it
+// may differ by up to ~k * eps(T); we allow a generous multiple of that and
+// take the worst element per configuration (one assertion each). A real bug is
+// O(1) off and trips this immediately.
+//
+// MTL5_NATIVE_FAST_GEMM is defined before mult.hpp so mtl::mult routes through
+// gemm_blocked / gemv for this translation unit.
+#define MTL5_NATIVE_FAST_GEMM 1
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+
+#include <mtl/detail/gemm_blocked.hpp>
+#include <mtl/operation/mult.hpp>
+#include <mtl/simd/blocking.hpp>
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/mat/parameter.hpp>
+#include <mtl/tag/orientation.hpp>
+#include <mtl/vec/dense_vector.hpp>
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <random>
+#include <vector>
+
+namespace {
+
+using rowmaj = mtl::mat::parameters<mtl::tag::row_major>;
+using colmaj = mtl::mat::parameters<mtl::tag::col_major>;
+
+// Relative tolerance for a length-k contraction accumulated in T.
+template <typename T>
+long double tol_for(std::size_t k) {
+    return 64.0L * static_cast<long double>(k) *
+           static_cast<long double>(std::numeric_limits<T>::epsilon());
+}
+
+// C = A*B via mtl::mult (native-fast) vs a long-double reference over the same
+// T-rounded inputs. MatA/MatB/MatC fix the orientations. Returns true if every
+// element is within tolerance.
+template <typename MatA, typename MatB, typename MatC>
+bool gemm_ok(std::size_t m, std::size_t n, std::size_t k, std::uint64_t seed) {
+    using T = typename MatC::value_type;
+    MatA A(m, k); MatB B(k, n); MatC C(m, n);
+    std::mt19937_64 rng(seed);
+    std::uniform_real_distribution<double> dist(-1.0, 1.0);
+    for (std::size_t i = 0; i < m; ++i)
+        for (std::size_t p = 0; p < k; ++p) A(i, p) = static_cast<T>(dist(rng));
+    for (std::size_t p = 0; p < k; ++p)
+        for (std::size_t j = 0; j < n; ++j) B(p, j) = static_cast<T>(dist(rng));
+
+    mtl::mult(A, B, C);
+
+    const long double tol = tol_for<T>(k);
+    for (std::size_t i = 0; i < m; ++i)
+        for (std::size_t j = 0; j < n; ++j) {
+            long double ref = 0.0L;
+            for (std::size_t p = 0; p < k; ++p)
+                ref += static_cast<long double>(A(i, p)) * static_cast<long double>(B(p, j));
+            const long double err = std::fabs(static_cast<long double>(C(i, j)) - ref);
+            if (err > tol * (std::fabs(ref) + 1.0L)) return false;
+        }
+    return true;
+}
+
+// y = A*x via mtl::mult (native-fast) vs long-double reference.
+template <typename MatA>
+bool gemv_ok(std::size_t m, std::size_t n, std::uint64_t seed) {
+    using T = typename MatA::value_type;
+    MatA A(m, n);
+    mtl::vec::dense_vector<T> x(n), y(m);
+    std::mt19937_64 rng(seed);
+    std::uniform_real_distribution<double> dist(-1.0, 1.0);
+    for (std::size_t i = 0; i < m; ++i)
+        for (std::size_t j = 0; j < n; ++j) A(i, j) = static_cast<T>(dist(rng));
+    for (std::size_t j = 0; j < n; ++j) x(j) = static_cast<T>(dist(rng));
+
+    mtl::mult(A, x, y);
+
+    const long double tol = tol_for<T>(n);
+    for (std::size_t i = 0; i < m; ++i) {
+        long double ref = 0.0L;
+        for (std::size_t j = 0; j < n; ++j)
+            ref += static_cast<long double>(A(i, j)) * static_cast<long double>(x(j));
+        if (std::fabs(static_cast<long double>(y(i)) - ref) > tol * (std::fabs(ref) + 1.0L))
+            return false;
+    }
+    return true;
+}
+
+// Square + rectangular sizes straddling mr/nr; tiny through a few hundred.
+const std::size_t kSizes[] = {1, 2, 5, 7, 13, 16, 17, 31, 64, 100, 129};
+
+} // namespace
+
+TEMPLATE_TEST_CASE("fast GEMM: random data vs long-double ref (row-major)", "[operation][gemm][numeric]", float, double) {
+    using R = mtl::mat::dense2D<TestType, rowmaj>;
+    std::uint64_t seed = 1;
+    for (std::size_t m : kSizes)
+        for (std::size_t n : kSizes) {
+            // rectangular k mixes too: k = n-ish and an unrelated value
+            for (std::size_t k : {std::size_t(1), std::size_t(7), std::size_t(33)}) {
+                INFO("m=" << m << " n=" << n << " k=" << k);
+                CHECK(gemm_ok<R, R, R>(m, n, k, seed++));
+            }
+        }
+}
+
+TEMPLATE_TEST_CASE("fast GEMM: orientation combos (random)", "[operation][gemm][numeric]", float, double) {
+    using RM = mtl::mat::dense2D<TestType, rowmaj>;
+    using CM = mtl::mat::dense2D<TestType, colmaj>;
+    const std::size_t m = 37, n = 29, k = 23;   // all odd, rectangular, non-mr/nr
+    std::uint64_t s = 100;
+    CHECK(gemm_ok<RM, RM, RM>(m, n, k, s++));
+    CHECK(gemm_ok<CM, RM, RM>(m, n, k, s++));
+    CHECK(gemm_ok<RM, CM, RM>(m, n, k, s++));
+    CHECK(gemm_ok<CM, CM, RM>(m, n, k, s++));
+    CHECK(gemm_ok<RM, RM, CM>(m, n, k, s++));   // col-major C (C^T = B^T A^T branch)
+    CHECK(gemm_ok<CM, CM, CM>(m, n, k, s++));
+}
+
+TEMPLATE_TEST_CASE("fast GEMM: crosses mc/kc blocks (random)", "[operation][gemm][numeric]", float, double) {
+    using R = mtl::mat::dense2D<TestType, rowmaj>;
+    constexpr auto bp = mtl::simd::default_blocking<TestType>;
+    const std::size_t m = bp.mc + bp.mr + 3;   // > mc
+    const std::size_t k = bp.kc + 5;           // > kc
+    const std::size_t n = bp.nr * 2 + 1;
+    INFO("m=" << m << " n=" << n << " k=" << k << " (mc=" << bp.mc << " kc=" << bp.kc << ")");
+    CHECK(gemm_ok<R, R, R>(m, n, k, 7));
+}
+
+TEMPLATE_TEST_CASE("fast GEMM: alpha/beta numeric (gemm_blocked)", "[operation][gemm][numeric]", float, double) {
+    const std::size_t m = 31, n = 19, k = 23;
+    std::vector<TestType> A(m * k), B(k * n), C(m * n), C0(m * n);
+    std::mt19937_64 rng(55);
+    std::uniform_real_distribution<double> dist(-1.0, 1.0);
+    for (auto& a : A) a = static_cast<TestType>(dist(rng));
+    for (auto& b : B) b = static_cast<TestType>(dist(rng));
+    for (std::size_t t = 0; t < m * n; ++t) { C[t] = static_cast<TestType>(dist(rng)); C0[t] = C[t]; }
+
+    const TestType alpha = TestType(1.5), beta = TestType(-0.75);
+    mtl::detail::gemm_blocked<TestType>(m, n, k, alpha, A.data(), (std::ptrdiff_t)k, 1,
+                                        B.data(), (std::ptrdiff_t)n, 1, beta, C.data(), n);
+
+    const long double tol = tol_for<TestType>(k);
+    bool ok = true;
+    for (std::size_t i = 0; i < m && ok; ++i)
+        for (std::size_t j = 0; j < n && ok; ++j) {
+            long double prod = 0.0L;
+            for (std::size_t p = 0; p < k; ++p)
+                prod += static_cast<long double>(A[i * k + p]) * static_cast<long double>(B[p * n + j]);
+            const long double ref = static_cast<long double>(beta) * static_cast<long double>(C0[i * n + j])
+                                  + static_cast<long double>(alpha) * prod;
+            if (std::fabs(static_cast<long double>(C[i * n + j]) - ref) > tol * (std::fabs(ref) + 1.0L))
+                ok = false;
+        }
+    CHECK(ok);
+}
+
+TEMPLATE_TEST_CASE("fast GEMV: random data vs long-double ref (both orientations)", "[operation][gemv][numeric]", float, double) {
+    using RM = mtl::mat::dense2D<TestType, rowmaj>;
+    using CM = mtl::mat::dense2D<TestType, colmaj>;
+    std::uint64_t seed = 500;
+    for (std::size_t m : kSizes)
+        for (std::size_t n : kSizes) {
+            INFO("m=" << m << " n=" << n);
+            CHECK(gemv_ok<RM>(m, n, seed++));
+            CHECK(gemv_ok<CM>(m, n, seed++));
+        }
+}


### PR DESCRIPTION
## Summary
Correctness coverage for the native fast kernels (#91) — they now replace the trusted naive path under `MTL5_NATIVE_FAST_GEMM`, so this adds **numerical (random-float)** validation and a **sanitizer** sweep on top of the existing integer-exact structural tests.

## What it adds
- **`tests/unit/operation/test_fast_gemm_numeric.cpp`** — random `float`/`double` GEMM & GEMV through `mtl::mult` (native-fast) vs a **long-double reference** over the same T-rounded inputs, within `~64·k·eps(T)·(|ref|+1)`. Coverage:
  - all A/B orientation combos + **col-major C** (the `Cᵀ = Bᵀ·Aᵀ` branch)
  - `alpha`/`beta` (via `gemm_blocked`)
  - rectangular and tiny shapes; sizes **crossing `mc`/`kc`** (derived from `default_blocking`)
  - one assertion per configuration (cheap; deterministic `mt19937_64` seeds)
- **`MTL5_SANITIZE` CMake option** (`-DMTL5_SANITIZE=address,undefined`, BUILD_INTERFACE-only) to instrument the packing + micro-kernel.
- **docs**: a "Native Performance & Development" section documenting `MTL5_WITH_HIGHWAY` / `MTL5_NATIVE_ARCH` / `MTL5_NATIVE_FAST_GEMM` / `MTL5_SANITIZE`.

## Test results

| | gcc | clang | ASan+UBSan |
|---|---|---|---|
| `fast_gemm_numeric` (new) | PASS | PASS | PASS |
| `gemm_pack`, `gemm_microkernel`, `gemm_blocked`, `gemv` | (already) | (already) | **PASS** |

The ASan/UBSan run is built with Highway + `-march=native` (real SIMD paths), `UBSAN_OPTIONS=halt_on_error=1`, `ASAN_OPTIONS=detect_leaks=1` — **clean across packing, micro-kernel, macro-kernel, GEMV, and the numeric suite**.

```
100% tests passed, 0 tests failed out of 5   (build-asan)
```

## Notes
- "vs BLAS when available" from the issue is left out to keep the TU self-contained — the long-double reference is the gold standard and stricter than a same-precision BLAS compare. The benchmark gate (#93) already cross-checks native-fast vs OpenBLAS/MKL numerically by size.
- Sanitizers are an opt-in build flag, not wired into per-push CI.

## Test plan
- [x] gcc + clang pass (numeric); ASan+UBSan clean over the fast-path tests
- [ ] Fast CI passes

Relates to #91

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded build options documentation with native performance tuning and development configuration, including SIMD optimization, CPU tuning, native fast GEMM paths, and sanitizer support.

* **Tests**
  * Added numeric correctness validation for native fast GEMM and GEMV operations, covering various matrix sizes, orientations, and SIMD boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->