### PR TITLE
feat(sparse): native KLU solver (block-wise GP-LU + back-substitution)

### DIFF
--- a/examples/phase15_sparse_direct/sparse_direct_solvers.cpp
+++ b/examples/phase15_sparse_direct/sparse_direct_solvers.cpp
@@ -371,6 +371,7 @@ void demo_backend_summary() {
     std::cout << "     sparse::factorization::sparse_cholesky  (SPD, LL^T)\n";
     std::cout << "     sparse::factorization::sparse_lu        (general, PA=LU)\n";
     std::cout << "     sparse::factorization::sparse_qr        (least-squares, QR)\n";
+    std::cout << "     sparse::factorization::native_klu       (circuit, BTF + block LU)\n";
     std::cout << "\n   Fill-reducing orderings:\n";
     std::cout << "     sparse::ordering::rcm     (bandwidth reduction)\n";
     std::cout << "     sparse::ordering::amd     (symmetric fill, for Cholesky)\n";

--- a/include/mtl/sparse/factorization/native_klu.hpp
+++ b/include/mtl/sparse/factorization/native_klu.hpp
@@ -1,0 +1,201 @@
+#pragma once
+// MTL5 -- Native KLU: BTF + block-wise Gilbert-Peierls LU
+//
+// A header-only, value-type-generic KLU sparse direct solver (cf. the external
+// SuiteSparse binding in mtl/interface/klu.hpp, which is double-only). The
+// algorithm follows Davis & Palamadai Natarajan, "Algorithm 907: KLU", ACM
+// TOMS 2010:
+//
+//   1. Permute A to Block Triangular Form: B = P*A*Q is block upper triangular
+//      with a zero-free diagonal (mtl::sparse::ordering::block_triangular_form).
+//   2. Factor each diagonal block B_bb with the existing left-looking
+//      Gilbert-Peierls sparse LU (sparse_lu_numeric).
+//   3. Solve A*x = b by block back-substitution over the block structure.
+//
+// Solve derivation. With B = P*A*Q block upper triangular, A*x = b becomes
+//   B*y = c,   c[i] = b[p[i]],   x[q[j]] = y[j].
+// Because B is block UPPER triangular (nonzeros B[i,j] only when the block of i
+// is <= the block of j), we solve the last block first and work upward: for
+// block b,  B_bb * y_b = c_b - sum_{b' > b} B_{b,b'} * y_{b'}.
+//
+// Out of scope for v1: row/column scaling and iterative refinement. Per-block
+// fill-reducing ordering is natural (identity); COLAMD per block is a follow-up.
+//
+// Reference: Davis, "Direct Methods for Sparse Linear Systems", SIAM 2006.
+
+#include <cstddef>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include <mtl/concepts/scalar.hpp>
+#include <mtl/mat/compressed2D.hpp>
+#include <mtl/mat/inserter.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/sparse/factorization/sparse_lu.hpp>
+#include <mtl/sparse/ordering/dulmage_mendelsohn.hpp>
+#include <mtl/sparse/util/permutation.hpp>
+
+namespace mtl::sparse::factorization {
+
+/// Numeric KLU factorization: BTF permutation, the permuted matrix B = P*A*Q
+/// (block upper triangular), the per-new-index block id, and a left-looking LU
+/// factorization of each diagonal block.
+template <typename Value>
+struct klu_numeric {
+    ordering::btf_result          btf;            ///< row/col permutations + blocks
+    mat::compressed2D<Value>      B;              ///< P*A*Q, block upper triangular
+    std::vector<std::size_t>      block_of;       ///< new index -> block id
+    std::vector<lu_numeric<Value>> block_numeric; ///< LU of each diagonal block
+
+    std::size_t num_rows() const { return btf.row_perm.size(); }
+    std::size_t num_cols() const { return num_rows(); }
+    std::size_t nblocks()  const { return btf.nblocks(); }
+
+    /// Solve A*x = b via block back-substitution. x and b have the dimension of
+    /// the original matrix A.
+    template <typename VecX, typename VecB>
+    void solve(VecX& x, const VecB& b) const {
+        const std::size_t n = num_rows();
+        if (static_cast<std::size_t>(x.size()) != n ||
+            static_cast<std::size_t>(b.size()) != n) {
+            throw std::invalid_argument(
+                "klu_numeric::solve: vector size mismatch");
+        }
+
+        // c[i] = b[p[i]]; y is updated in place to the final solution per block.
+        std::vector<Value> y(n);
+        for (std::size_t i = 0; i < n; ++i)
+            y[i] = static_cast<Value>(b(btf.row_perm[i]));
+
+        const auto& rp  = B.ref_major();
+        const auto& ci  = B.ref_minor();
+        const auto& dat = B.ref_data();
+
+        // Back-substitution: last block first.
+        for (std::size_t blk = nblocks(); blk-- > 0; ) {
+            const std::size_t r0 = btf.blocks[blk];
+            const std::size_t r1 = btf.blocks[blk + 1];
+            const std::size_t m  = r1 - r0;
+
+            vec::dense_vector<Value> rhs(m), sol(m, Value{0});
+            for (std::size_t i = r0; i < r1; ++i) {
+                Value val = y[i];
+                for (std::size_t k = rp[i]; k < rp[i + 1]; ++k) {
+                    const std::size_t j = ci[k];
+                    if (block_of[j] > blk)          // coupling to a solved block
+                        val -= dat[k] * y[j];
+                    // block_of[j] == blk: part of the diagonal block (handled by
+                    //   the block LU below). block_of[j] < blk: impossible for
+                    //   block-upper-triangular B.
+                }
+                rhs(static_cast<int>(i - r0)) = val;
+            }
+
+            block_numeric[blk].solve(sol, rhs);
+
+            for (std::size_t i = r0; i < r1; ++i)
+                y[i] = sol(static_cast<int>(i - r0));
+        }
+
+        // x[q[j]] = y[j]
+        for (std::size_t j = 0; j < n; ++j)
+            x(btf.col_perm[j]) = static_cast<typename VecX::value_type>(y[j]);
+    }
+};
+
+/// Factor A using native KLU: BTF, then a left-looking LU of each diagonal
+/// block with threshold partial pivoting.
+///
+/// \throws std::invalid_argument if A is not square.
+/// \throws std::runtime_error    if A is structurally singular (no perfect
+///                               matching) or a diagonal block is numerically
+///                               singular.
+template <typename Value, typename Parameters>
+    requires OrderedField<Value>
+klu_numeric<Value> native_klu_factor(
+    const mat::compressed2D<Value, Parameters>& A,
+    Value threshold = Value{1})
+{
+    if (A.num_rows() != A.num_cols()) {
+        throw std::invalid_argument("native_klu_factor: matrix must be square");
+    }
+    const std::size_t n = A.num_rows();
+
+    klu_numeric<Value> result;
+    if (n == 0) {
+        result.btf.blocks = {0};
+        return result;
+    }
+
+    result.btf = ordering::block_triangular_form(A);
+    if (result.btf.structurally_singular) {
+        throw std::runtime_error(
+            "native_klu_factor: matrix is structurally singular");
+    }
+
+    // Build B = P*A*Q. New column of old column c is q_inv[c].
+    auto q_inv = util::invert_permutation(result.btf.col_perm);
+    mat::compressed2D<Value> B(n, n);
+    {
+        const auto& rp  = A.ref_major();
+        const auto& ci  = A.ref_minor();
+        const auto& dat = A.ref_data();
+        mat::inserter<mat::compressed2D<Value>> ins(B);
+        for (std::size_t i = 0; i < n; ++i) {
+            std::size_t orow = result.btf.row_perm[i];
+            for (std::size_t k = rp[orow]; k < rp[orow + 1]; ++k)
+                ins[i][q_inv[ci[k]]] << dat[k];
+        }
+    }
+    result.B = std::move(B);
+
+    // new index -> block id
+    result.block_of.assign(n, 0);
+    for (std::size_t blk = 0; blk < result.btf.nblocks(); ++blk)
+        for (std::size_t k = result.btf.blocks[blk];
+             k < result.btf.blocks[blk + 1]; ++k)
+            result.block_of[k] = blk;
+
+    // Factor each diagonal block.
+    const auto& Brp  = result.B.ref_major();
+    const auto& Bci  = result.B.ref_minor();
+    const auto& Bdat = result.B.ref_data();
+    result.block_numeric.reserve(result.btf.nblocks());
+    for (std::size_t blk = 0; blk < result.btf.nblocks(); ++blk) {
+        const std::size_t r0 = result.btf.blocks[blk];
+        const std::size_t r1 = result.btf.blocks[blk + 1];
+        const std::size_t m  = r1 - r0;
+
+        mat::compressed2D<Value> block(m, m);
+        {
+            mat::inserter<mat::compressed2D<Value>> ins(block);
+            for (std::size_t i = r0; i < r1; ++i)
+                for (std::size_t k = Brp[i]; k < Brp[i + 1]; ++k) {
+                    std::size_t j = Bci[k];
+                    if (j >= r0 && j < r1)
+                        ins[i - r0][j - r0] << Bdat[k];
+                }
+        }
+
+        auto sym = sparse_lu_symbolic(block);              // natural ordering
+        result.block_numeric.push_back(
+            sparse_lu_numeric(block, sym, threshold));
+    }
+
+    return result;
+}
+
+/// One-shot native KLU solve: factor and solve A*x = b.
+template <typename Value, typename Parameters, typename VecX, typename VecB>
+    requires OrderedField<Value>
+void native_klu_solve(
+    const mat::compressed2D<Value, Parameters>& A,
+    VecX& x, const VecB& b,
+    Value threshold = Value{1})
+{
+    auto fac = native_klu_factor(A, threshold);
+    fac.solve(x, b);
+}
+
+} // namespace mtl::sparse::factorization

--- a/include/mtl/sparse/sparse.hpp
+++ b/include/mtl/sparse/sparse.hpp
@@ -19,8 +19,10 @@
 #include <mtl/sparse/factorization/sparse_ldlt.hpp>
 #include <mtl/sparse/factorization/sparse_qr.hpp>
 #include <mtl/sparse/factorization/sparse_lu.hpp>
+#include <mtl/sparse/factorization/native_klu.hpp>
 
 // Orderings
 #include <mtl/sparse/ordering/rcm.hpp>
 #include <mtl/sparse/ordering/amd.hpp>
 #include <mtl/sparse/ordering/colamd.hpp>
+#include <mtl/sparse/ordering/dulmage_mendelsohn.hpp>

--- a/tests/unit/sparse/test_native_klu.cpp
+++ b/tests/unit/sparse/test_native_klu.cpp
@@ -1,0 +1,192 @@
+// MTL5 -- Tests for native KLU (BTF + block-wise Gilbert-Peierls LU).
+// Covers steps 4-6 of the native KLU plan (issue #114): per-block factorization,
+// block back-substitution, and the one-shot solve.
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <stdexcept>
+#include <vector>
+
+#include <mtl/mat/compressed2D.hpp>
+#include <mtl/mat/inserter.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/sparse/factorization/native_klu.hpp>
+#include <mtl/sparse/factorization/sparse_lu.hpp>
+
+#ifdef MTL5_HAS_KLU
+#include <mtl/interface/klu.hpp>
+#endif
+
+using namespace mtl;
+using Catch::Matchers::WithinAbs;
+using mtl::sparse::factorization::native_klu_factor;
+using mtl::sparse::factorization::native_klu_solve;
+
+namespace {
+
+template <typename Value>
+double residual_inf_norm(const mat::compressed2D<Value>& A,
+                         const vec::dense_vector<Value>& x,
+                         const vec::dense_vector<Value>& b) {
+    const auto& rp = A.ref_major();
+    const auto& ci = A.ref_minor();
+    const auto& dat = A.ref_data();
+    double max_r = 0.0;
+    for (std::size_t r = 0; r < A.num_rows(); ++r) {
+        Value ax = Value{0};
+        for (std::size_t k = rp[r]; k < rp[r + 1]; ++k)
+            ax += dat[k] * x(static_cast<int>(ci[k]));
+        max_r = std::max(max_r,
+            static_cast<double>(std::abs(ax - b(static_cast<int>(r)))));
+    }
+    return max_r;
+}
+
+// Unsymmetric tridiagonal: A(i,i)=4, A(i,i-1)=-1, A(i,i+1)=-2 (irreducible).
+mat::compressed2D<double> make_unsym_tridiag(std::size_t n) {
+    mat::compressed2D<double> A(n, n);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        for (std::size_t i = 0; i < n; ++i) {
+            if (i > 0)     ins[i][i - 1] << -1.0;
+            ins[i][i] << 4.0;
+            if (i + 1 < n) ins[i][i + 1] << -2.0;
+        }
+    }
+    return A;
+}
+
+} // namespace
+
+TEST_CASE("native KLU solves a block-triangular system", "[sparse][klu][native]") {
+    // Two 2x2 diagonal blocks {0,1}, {2,3} with upper coupling A(0,3) -> 2 blocks.
+    //   [ 2  1  0  5 ]
+    //   [ 1  3  0  0 ]
+    //   [ 0  0  4  1 ]
+    //   [ 0  0  2  5 ]
+    mat::compressed2D<double> A(4, 4);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        ins[0][0] << 2.0; ins[0][1] << 1.0; ins[0][3] << 5.0;
+        ins[1][0] << 1.0; ins[1][1] << 3.0;
+        ins[2][2] << 4.0; ins[2][3] << 1.0;
+        ins[3][2] << 2.0; ins[3][3] << 5.0;
+    }
+
+    auto fac = native_klu_factor(A);
+    REQUIRE(fac.nblocks() == 2);
+
+    vec::dense_vector<double> b = {1.0, 2.0, 3.0, 4.0};
+    vec::dense_vector<double> x(4, 0.0);
+    fac.solve(x, b);
+
+    REQUIRE(residual_inf_norm(A, x, b) < 1e-10);
+}
+
+TEST_CASE("native KLU one-shot agrees with native sparse LU",
+          "[sparse][klu][native]") {
+    for (std::size_t n : {5u, 16u, 41u}) {
+        auto A = make_unsym_tridiag(n);
+
+        vec::dense_vector<double> b(n);
+        for (std::size_t i = 0; i < n; ++i)
+            b(static_cast<int>(i)) = static_cast<double>((i % 7) + 1);
+
+        vec::dense_vector<double> x_klu(n, 0.0);
+        native_klu_solve(A, x_klu, b);
+
+        vec::dense_vector<double> x_lu(n, 0.0);
+        sparse::factorization::sparse_lu_solve(A, x_lu, b);
+
+        for (std::size_t i = 0; i < n; ++i)
+            REQUIRE_THAT(x_klu(static_cast<int>(i)),
+                         WithinAbs(x_lu(static_cast<int>(i)), 1e-9));
+        REQUIRE(residual_inf_norm(A, x_klu, b) < 1e-9);
+    }
+}
+
+TEST_CASE("native KLU handles a fully reducible (triangular) matrix",
+          "[sparse][klu][native]") {
+    // Lower-triangular with full diagonal: n singleton blocks.
+    std::size_t n = 6;
+    mat::compressed2D<double> A(n, n);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        for (std::size_t i = 0; i < n; ++i) {
+            for (std::size_t j = 0; j <= i; ++j)
+                ins[i][j] << (i == j ? 3.0 : 1.0);
+        }
+    }
+
+    auto fac = native_klu_factor(A);
+    REQUIRE(fac.nblocks() == n);
+
+    vec::dense_vector<double> b(n, 1.0), x(n, 0.0);
+    fac.solve(x, b);
+    REQUIRE(residual_inf_norm(A, x, b) < 1e-10);
+}
+
+TEST_CASE("native KLU is generic over the value type (float)",
+          "[sparse][klu][native]") {
+    std::size_t n = 8;
+    mat::compressed2D<float> A(n, n);
+    {
+        mat::inserter<mat::compressed2D<float>> ins(A);
+        for (std::size_t i = 0; i < n; ++i) {
+            if (i > 0)     ins[i][i - 1] << -1.0f;
+            ins[i][i] << 4.0f;
+            if (i + 1 < n) ins[i][i + 1] << -1.0f;
+        }
+    }
+    vec::dense_vector<float> b(n, 1.0f), x(n, 0.0f);
+    native_klu_solve(A, x, b);
+    REQUIRE(residual_inf_norm(A, x, b) < 1e-4);
+}
+
+TEST_CASE("native KLU rejects non-square and structurally singular matrices",
+          "[sparse][klu][native]") {
+    SECTION("non-square") {
+        mat::compressed2D<double> A(2, 3);
+        {
+            mat::inserter<mat::compressed2D<double>> ins(A);
+            ins[0][0] << 1.0;
+            ins[1][1] << 1.0;
+        }
+        REQUIRE_THROWS_AS(native_klu_factor(A), std::invalid_argument);
+    }
+    SECTION("structurally singular (empty column)") {
+        mat::compressed2D<double> A(3, 3);
+        {
+            mat::inserter<mat::compressed2D<double>> ins(A);
+            ins[0][0] << 1.0; ins[0][1] << 1.0;
+            ins[1][0] << 1.0; ins[1][1] << 1.0;
+            ins[2][0] << 1.0;            // column 2 empty
+        }
+        REQUIRE_THROWS_AS(native_klu_factor(A), std::runtime_error);
+    }
+}
+
+#ifdef MTL5_HAS_KLU
+TEST_CASE("native KLU agrees with the external SuiteSparse KLU binding",
+          "[sparse][klu][native][interface]") {
+    for (std::size_t n : {6u, 20u}) {
+        auto A = make_unsym_tridiag(n);
+        vec::dense_vector<double> b(n);
+        for (std::size_t i = 0; i < n; ++i)
+            b(static_cast<int>(i)) = static_cast<double>((i % 5) + 1);
+
+        vec::dense_vector<double> x_native(n, 0.0);
+        native_klu_solve(A, x_native, b);
+
+        vec::dense_vector<double> x_ext(n, 0.0);
+        interface::klu_solve(A, x_ext, b);
+
+        for (std::size_t i = 0; i < n; ++i)
+            REQUIRE_THAT(x_native(static_cast<int>(i)),
+                         WithinAbs(x_ext(static_cast<int>(i)), 1e-9));
+    }
+}
+#endif


### PR DESCRIPTION
Completes the native KLU epic (#114), steps 4–6, on top of the BTF infrastructure from #115. The result is a **header-only, value-type-generic KLU** sparse direct solver — in contrast to the `double`-only external SuiteSparse binding.

## What this adds

`include/mtl/sparse/factorization/native_klu.hpp`:

- **`native_klu_factor`** (step 4): BTF via `block_triangular_form` (`B = P·A·Q`, block upper triangular), then factor each diagonal block with the **existing** left-looking Gilbert–Peierls `sparse_lu_numeric` — no LU reimplementation. Rejects non-square (`invalid_argument`) and structurally singular (`runtime_error`) input.
- **`klu_numeric::solve`** (step 5): block back-substitution. `B·y=c` with `c[i]=b[p[i]]`, `x[q[j]]=y[j]`; solve the last block first, subtracting already-solved higher-block coupling, then each diagonal block via its stored LU.
- **`native_klu_solve`** (step 6): one-shot factor + solve.
- Wires both new headers into the `sparse` umbrella include; advertises `native_klu` in the phase15 example banner.

## Scope

Per-block ordering is **natural** for v1 (COLAMD per block is a noted follow-up). Row scaling and iterative refinement remain out of scope, as stated in the plan.

## Tests

`tests/unit/sparse/test_native_klu.cpp`:
- block-triangular solve with expected block count
- one-shot cross-validation vs `sparse_lu_solve` (n = 5/16/41)
- fully reducible (triangular) matrix; **generic `float`** value type
- non-square and structural-singularity rejection
- cross-validation vs the **external SuiteSparse KLU** binding under `MTL5_HAS_KLU`

**All pass — 98 assertions with KLU enabled; clean under ASan/UBSan.** Full sparse+interface suite (23 tests) green after the umbrella-include change.

## Epic status after this PR

- [x] 1–3 BTF (matching, SCC, `block_triangular_form`) — #115
- [x] 4 `native_klu_factor`
- [x] 5 `klu_numeric::solve`
- [x] 6 `native_klu_solve`

Closes #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a native KLU sparse direct solver supporting block-triangular form matrices with block-wise LU factorization capabilities for circuit and structural analysis problems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->