### PR TITLE
fix(sparse): ADL-friendly abs/sqrt so factorizations accept custom number types

### DIFF
--- a/include/mtl/sparse/factorization/sparse_cholesky.hpp
+++ b/include/mtl/sparse/factorization/sparse_cholesky.hpp
@@ -293,7 +293,8 @@ cholesky_numeric<Value> sparse_cholesky_numeric(
                 "sparse_cholesky_numeric: matrix is not positive definite "
                 "(non-positive diagonal at column " + std::to_string(j) + ")");
         }
-        Value ljj = std::sqrt(diag);
+        using std::sqrt;  // ADL: also find sqrt() for custom number types
+        Value ljj = sqrt(diag);
 
         // Guarded write into column j of L
         size_type col_capacity = sym.col_counts[j];

--- a/include/mtl/sparse/factorization/sparse_lu.hpp
+++ b/include/mtl/sparse/factorization/sparse_lu.hpp
@@ -175,6 +175,7 @@ lu_numeric<Value> sparse_lu_numeric(
     Value threshold = Value{1})
 {
     using size_type = std::size_t;
+    using std::abs;  // ADL: also find abs() for custom number types (e.g. posit/cfloat)
     size_type n = sym.n;
     if (A.num_rows() != n || A.num_cols() != n) {
         throw std::invalid_argument(
@@ -246,7 +247,7 @@ lu_numeric<Value> sparse_lu_numeric(
         for (size_type ti = 0; ti < touched.size(); ++ti) {
             size_type i = touched[ti];
             if (i < k) continue;
-            Value abs_val = std::abs(x[i]);
+            Value abs_val = abs(x[i]);
             if (abs_val > max_val) {
                 max_val = abs_val;
                 pivot_pos = i;
@@ -254,7 +255,7 @@ lu_numeric<Value> sparse_lu_numeric(
         }
         // Also check x[k] itself (may not be in touched if it was set to 0)
         {
-            Value abs_k = std::abs(x[k]);
+            Value abs_k = abs(x[k]);
             if (abs_k > max_val) {
                 max_val = abs_k;
                 pivot_pos = k;
@@ -270,7 +271,7 @@ lu_numeric<Value> sparse_lu_numeric(
 
         // Apply threshold: if x[k] is large enough relative to max, keep it
         // Otherwise swap with the row that has the maximum
-        if (std::abs(x[k]) < threshold * max_val && pivot_pos != k) {
+        if (abs(x[k]) < threshold * max_val && pivot_pos != k) {
             // Swap rows k and pivot_pos in workspace
             std::swap(x[k], x[pivot_pos]);
 

--- a/include/mtl/sparse/factorization/sparse_qr.hpp
+++ b/include/mtl/sparse/factorization/sparse_qr.hpp
@@ -59,6 +59,7 @@ struct qr_numeric {
     /// min ||Ax - b|| => R * Q^T * x = (Q_h^T * b)[0:n-1]
     template <typename VecX, typename VecB>
     void solve(VecX& x, const VecB& b) const {
+        using std::abs;  // ADL: also find abs() for custom number types
         std::size_t m = symbolic.nrows;
         std::size_t nc = symbolic.ncols;
         if (static_cast<std::size_t>(b.size()) != m) {
@@ -102,7 +103,7 @@ struct qr_numeric {
             if (R.col_ptr[col] > diag_pos) continue;
 
             Value diag = R.values[diag_pos];
-            if (std::abs(diag) < std::numeric_limits<Value>::min()) {
+            if (abs(diag) < std::numeric_limits<Value>::min()) {
                 throw std::runtime_error(
                     "qr_numeric::solve: zero diagonal in R at column "
                     + std::to_string(col) + " (rank deficient)");
@@ -187,6 +188,7 @@ qr_numeric<Value> sparse_qr_numeric(
     const qr_symbolic& sym)
 {
     using size_type = std::size_t;
+    using std::sqrt;  // ADL: also find sqrt() for custom number types
     size_type m = sym.nrows;
     size_type nc = sym.ncols;
     if (A.num_rows() != m || A.num_cols() != nc) {
@@ -262,7 +264,7 @@ qr_numeric<Value> sparse_qr_numeric(
             V_idx[k].push_back(k);
             V_vals[k].push_back(Value{1});
         } else {
-            Value norm_x = std::sqrt(x0 * x0 + sigma);
+            Value norm_x = sqrt(x0 * x0 + sigma);
 
             // alpha = -sign(x0) * ||x||
             Value alpha = (x0 >= Value{0}) ? -norm_x : norm_x;

--- a/tests/unit/sparse/test_custom_scalar_adl.cpp
+++ b/tests/unit/sparse/test_custom_scalar_adl.cpp
@@ -1,0 +1,141 @@
+// MTL5 -- Sparse factorizations must work with custom number types whose
+// abs()/sqrt() are found only via ADL (not std::). This guards against
+// regressions to unqualified std::abs / std::sqrt in the sparse factorizations,
+// which break custom field types (e.g. Universal's posit/cfloat) that are not
+// implicitly convertible to a built-in float.
+//
+// `adl::real` deliberately mimics that situation: it is only EXPLICITLY
+// convertible to double, and its abs()/sqrt() live in namespace `adl`, so the
+// factorization code must call them in an ADL-friendly way. No external
+// dependency is used (MTL5 must not depend on Universal).
+#include <catch2/catch_test_macros.hpp>
+
+#include <cmath>
+#include <compare>
+#include <cstddef>
+#include <limits>
+
+#include <mtl/mat/compressed2D.hpp>
+#include <mtl/mat/inserter.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/sparse/factorization/sparse_lu.hpp>
+#include <mtl/sparse/factorization/sparse_cholesky.hpp>
+#include <mtl/sparse/factorization/sparse_qr.hpp>
+
+namespace adl {
+
+// A minimal ordered field wrapping double, EXPLICITLY convertible to double so
+// that std::abs(real)/std::sqrt(real) do NOT compile -- abs()/sqrt() must be
+// found by ADL in this namespace.
+struct real {
+    double v{};
+    constexpr real() = default;
+    constexpr real(double x) : v(x) {}            // enables real{0}, real{1}
+    explicit constexpr operator double() const { return v; }
+
+    constexpr real operator+(real o) const { return real{v + o.v}; }
+    constexpr real operator-(real o) const { return real{v - o.v}; }
+    constexpr real operator*(real o) const { return real{v * o.v}; }
+    constexpr real operator/(real o) const { return real{v / o.v}; }
+    constexpr real operator-() const { return real{-v}; }
+    real& operator+=(real o) { v += o.v; return *this; }
+    real& operator-=(real o) { v -= o.v; return *this; }
+    real& operator*=(real o) { v *= o.v; return *this; }
+    real& operator/=(real o) { v /= o.v; return *this; }
+
+    constexpr auto operator<=>(const real&) const = default;
+    constexpr bool operator==(const real&) const = default;
+};
+
+// abs/sqrt visible ONLY via ADL (intentionally not in std).
+inline real abs(real x)  { return real{x.v < 0.0 ? -x.v : x.v}; }
+inline real sqrt(real x) { return real{std::sqrt(x.v)}; }
+
+} // namespace adl
+
+// numeric_limits specialization (sparse_qr uses ::min()).
+template <>
+class std::numeric_limits<adl::real> {
+public:
+    static constexpr bool is_specialized = true;
+    static constexpr adl::real min()     noexcept { return adl::real{std::numeric_limits<double>::min()}; }
+    static constexpr adl::real max()     noexcept { return adl::real{std::numeric_limits<double>::max()}; }
+    static constexpr adl::real lowest()  noexcept { return adl::real{std::numeric_limits<double>::lowest()}; }
+    static constexpr adl::real epsilon() noexcept { return adl::real{std::numeric_limits<double>::epsilon()}; }
+};
+
+using namespace mtl;
+using R = adl::real;
+
+namespace {
+
+double residual_inf(const mat::compressed2D<R>& A,
+                    const vec::dense_vector<R>& x,
+                    const vec::dense_vector<R>& b) {
+    const auto& rp = A.ref_major();
+    const auto& ci = A.ref_minor();
+    const auto& dat = A.ref_data();
+    double m = 0.0;
+    for (std::size_t r = 0; r < A.num_rows(); ++r) {
+        double ax = 0.0;
+        for (std::size_t k = rp[r]; k < rp[r + 1]; ++k)
+            ax += static_cast<double>(dat[k]) * static_cast<double>(x(static_cast<int>(ci[k])));
+        m = std::max(m, std::abs(ax - static_cast<double>(b(static_cast<int>(r)))));
+    }
+    return m;
+}
+
+} // namespace
+
+TEST_CASE("sparse_lu works with a custom ADL-abs scalar type", "[sparse][custom][adl]") {
+    // Unsymmetric tridiagonal.
+    std::size_t n = 6;
+    mat::compressed2D<R> A(n, n);
+    {
+        mat::inserter<mat::compressed2D<R>> ins(A);
+        for (std::size_t i = 0; i < n; ++i) {
+            if (i > 0)     ins[i][i - 1] << R{-1.0};
+            ins[i][i] << R{4.0};
+            if (i + 1 < n) ins[i][i + 1] << R{-2.0};
+        }
+    }
+    vec::dense_vector<R> b(n, R{1.0}), x(n, R{0.0});
+    sparse::factorization::sparse_lu_solve(A, x, b);
+    REQUIRE(residual_inf(A, x, b) < 1e-10);
+}
+
+TEST_CASE("sparse_cholesky works with a custom ADL-sqrt scalar type",
+          "[sparse][custom][adl]") {
+    // SPD tridiagonal: 4 on the diagonal, -1 off-diagonal.
+    std::size_t n = 6;
+    mat::compressed2D<R> A(n, n);
+    {
+        mat::inserter<mat::compressed2D<R>> ins(A);
+        for (std::size_t i = 0; i < n; ++i) {
+            if (i > 0)     ins[i][i - 1] << R{-1.0};
+            ins[i][i] << R{4.0};
+            if (i + 1 < n) ins[i][i + 1] << R{-1.0};
+        }
+    }
+    vec::dense_vector<R> b(n, R{1.0}), x(n, R{0.0});
+    sparse::factorization::sparse_cholesky_solve(A, x, b);
+    REQUIRE(residual_inf(A, x, b) < 1e-10);
+}
+
+TEST_CASE("sparse_qr works with a custom ADL-abs/sqrt scalar type",
+          "[sparse][custom][adl]") {
+    // Square nonsingular system (QR as a general solver).
+    std::size_t n = 5;
+    mat::compressed2D<R> A(n, n);
+    {
+        mat::inserter<mat::compressed2D<R>> ins(A);
+        for (std::size_t i = 0; i < n; ++i) {
+            ins[i][i] << R{4.0};
+            if (i > 0)     ins[i][i - 1] << R{-1.0};
+            if (i + 1 < n) ins[i][i + 1] << R{-1.0};
+        }
+    }
+    vec::dense_vector<R> b(n, R{1.0}), x(n, R{0.0});
+    sparse::factorization::sparse_qr_solve(A, x, b);
+    REQUIRE(residual_inf(A, x, b) < 1e-8);
+}


### PR DESCRIPTION
## Problem

`sparse_lu`, `sparse_cholesky`, and `sparse_qr` called **unqualified `std::abs()` / `std::sqrt()`**. For a custom field type that is not implicitly convertible to a built-in float — exactly the case for Universal's `posit`/`cfloat` (explicit `double` conversion) — `std::abs`/`std::sqrt` have no viable overload, and because the call is qualified with `std::`, **ADL never reaches the type's own `abs()`/`sqrt()`**. The factorizations therefore fail to compile for such types, which defeats MTL5's stated purpose:

> designed for mixed-precision algorithm design with custom number types (posits, LNS, etc.)

This was discovered while wiring MTL5's native KLU into the `mp-spice` sister repo (MTL5 + Universal). The fix belongs here in MTL5 and is **dependency-free** — MTL5 still does not depend on Universal.

## Fix

The standard two-step (a.k.a. `std::swap`) idiom: bring the `std` overload into scope, then call unqualified so the best match is chosen, with ADL also considered.

```cpp
using std::abs;     // built-in types still resolve to std::abs
...
abs(x);             // custom types found via ADL
```

Applied to the 6 call sites across `sparse_lu` (3× `abs`), `sparse_cholesky` (1× `sqrt`), and `sparse_qr` (1× `abs`, 1× `sqrt`). `sparse_ldlt` and `triangular_solve` had no qualified math calls. Behavior for `float`/`double` is unchanged.

## Regression test (no external dependency)

`tests/unit/sparse/test_custom_scalar_adl.cpp` defines `adl::real`: a minimal ordered field wrapping `double`, **explicitly** convertible to `double`, with `abs()`/`sqrt()` visible **only via ADL** in its own namespace. It exercises `sparse_lu`, `sparse_cholesky`, and `sparse_qr`. This reproduces the original failure mode (a regression to `std::abs` would fail to compile this test) and locks in the fix — without MTL5 ever depending on Universal.

## Verification

- All **114** unit tests pass; the 3 new ADL cases pass; no regression.
- Separately confirmed (outside MTL5's test suite, since MTL5 must not depend on Universal) that `posit<16,2>` and `cfloat<16,5>` now **compile and solve** through `native_klu`.

## Impact

Unblocks the `cfloat<16,5>` / `posit<16,2>` paths in the `mp-spice` mixed-precision KLU comparison (stillwater-sc/mp-spice#1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sparse factorization solvers (Cholesky, LU, QR) now fully support custom numeric types that provide their own implementations of mathematical functions, enabling greater flexibility in numeric computations.

* **Tests**
  * Added comprehensive unit tests validating sparse factorization solvers work correctly with custom scalar types across LU, Cholesky, and QR decompositions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->