### PR TITLE
chore(build): bump MTL5_FALLBACK_VERSION to 5.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.22)
 
 # ── Version from git tag ────────────────────────────────────────────────
-# If building from a git tag like v5.2.0, extract the version automatically.
+# If building from a git tag like v5.3.0, extract the version automatically.
 # Falls back to the hardcoded version below when git is unavailable or
 # the working directory is not a tagged commit.
-set(MTL5_FALLBACK_VERSION "5.2.0")
+set(MTL5_FALLBACK_VERSION "5.3.0")
 
 find_package(Git QUIET)
 if(GIT_FOUND)


### PR DESCRIPTION
## Summary

`v5.3.0` is tagged, but `MTL5_FALLBACK_VERSION` in `CMakeLists.txt` still read `5.2.0`. That fallback is used when building outside a git checkout / from an untagged tree (source tarballs, some FetchContent configurations), so a stale value would misreport the version. Bumped it to `5.3.0` (and updated the example version in the adjacent comment).

In a normal git build the version still comes from the tag (`-- MTL5 version from git tag: 5.3.0`); this only affects the no-git fallback path.

## Note (not in this PR)

`CHANGELOG.md` still has an `## [Unreleased]` section rather than a dated `## [5.3.0]` entry. Per the release checklist that should be rolled up for the release — happy to do that in a follow-up if you'd like, but I kept this PR scoped to the fallback version as requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chore**
  * Updated version number from 5.2.0 to 5.3.0 in build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->