### PR TITLE
docs(site): add "Linear Algebra Algorithms" section with KLU characterization

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -44,6 +44,10 @@ export default defineConfig({
           autogenerate: { directory: 'modernization' },
         },
         {
+          label: 'Linear Algebra Algorithms',
+          autogenerate: { directory: 'algorithms' },
+        },
+        {
           label: 'Design',
           autogenerate: { directory: 'design' },
         },

--- a/docs-site/sync-content.mjs
+++ b/docs-site/sync-content.mjs
@@ -48,6 +48,10 @@ const FILE_MAP = {
   'architecture/concepts.md':        'architecture/concepts.md',
   'architecture/aggregate-types.md': 'architecture/aggregate-types.md',
 
+  // ── Linear Algebra Algorithms ───────────────────────────────────
+  'algorithms/overview.md':                     'algorithms/overview.md',
+  'algorithms/klu.md':                          'algorithms/klu.md',
+
   // ── Design ──────────────────────────────────────────────────────
   'sparse-direct-solvers-design.md':            'design/sparse-direct-solvers.md',
   'position-mixed-precision-acceleration.md':   'design/mixed-precision-acceleration.md',

--- a/docs/algorithms/klu.md
+++ b/docs/algorithms/klu.md
@@ -27,7 +27,7 @@ to; matching KLU is an engineering problem, not an algorithmic one.
 
 ## The pipeline
 
-```
+```text
 A ─► [1] BTF ──────────► [2] order each ──► [3] factor each ───────► [4] solve
         permute to            diagonal block      diagonal block          block
         block triangular      (AMD on A+Aᵀ)       (left-looking GP-LU      back-

--- a/docs/algorithms/klu.md
+++ b/docs/algorithms/klu.md
@@ -1,0 +1,132 @@
+# KLU: Sparse LU for Circuit-Simulation Matrices
+
+KLU (Davis & Palamadai Natarajan, *Algorithm 907*, ACM TOMS 2010) is a sparse
+direct solver specialized for the matrices that arise in **circuit simulation**
+(Modified Nodal Analysis). It is the reference implementation against which any
+native sparse-LU solver for these problems should be measured.
+
+This page characterizes the algorithm and the engineering that makes it fast,
+and catalogs the performance weaknesses a naive implementation exhibits. It is
+implementation-independent; MTL5 ships its own native KLU
+(`mtl::sparse::factorization::native_klu`) and an external SuiteSparse binding
+(`mtl::interface::klu_solver`).
+
+## What kind of solver it is
+
+KLU is a **scalar, non-supernodal, left-looking Gilbert–Peierls LU** with
+threshold partial pivoting. The "scalar, non-supernodal" part is a deliberate
+design choice: circuit matrices are extremely sparse and have almost no dense
+sub-structure, so the supernodal/BLAS-3 approach that powers solvers like
+CHOLMOD and UMFPACK has nothing to amortize over. KLU therefore uses tight
+scalar integer kernels instead — and is faster than supernodal solvers *on this
+class of matrix* precisely because it does not pay for machinery it cannot use.
+
+A practical consequence: a from-scratch solver competes with KLU **in the same
+algorithm class**. There is no kernel-class advantage to attribute a slowdown
+to; matching KLU is an engineering problem, not an algorithmic one.
+
+## The pipeline
+
+```
+A ─► [1] BTF ──────────► [2] order each ──► [3] factor each ───────► [4] solve
+        permute to            diagonal block      diagonal block          block
+        block triangular      (AMD on A+Aᵀ)       (left-looking GP-LU      back-
+        form                                       + partial pivoting       substitution
+                                                   + symmetric pruning)
+```
+
+1. **Block Triangular Form (BTF).** A maximum transversal (bipartite matching
+   for a zero-free diagonal) followed by a strongly-connected-components
+   decomposition permutes `A` so that only the diagonal blocks require
+   factorization; the off-diagonal coupling is resolved during the solve. Many
+   circuit matrices are highly reducible, so BTF can shrink the work
+   dramatically. (Some are not — see "When BTF does not help" below.)
+2. **Ordering.** Each diagonal block gets a fill-reducing ordering. KLU's default
+   is **AMD on the symmetric structure `A + Aᵀ`** of the block. The ordering
+   choice dominates fill, and for unsymmetric blocks the *symmetrized* ordering
+   is markedly better than ordering `AᵀA` (COLAMD-style), because partial
+   pivoting otherwise deviates from the column order and fill explodes.
+3. **Numeric factorization.** Left-looking Gilbert–Peierls: each column `k` of
+   `L`/`U` is computed by a sparse triangular solve against the
+   already-computed columns, whose nonzero pattern (the *reach*) is found by a
+   depth-first traversal of the elimination structure. Threshold partial
+   pivoting provides stability; **Eisenstat–Liu symmetric pruning** keeps the
+   reach traversal cheap. Optional row **scaling** improves robustness on the
+   badly-scaled, indefinite blocks circuit matrices produce.
+4. **Solve.** Block back-substitution across the BTF structure, with a
+   triangular solve per diagonal block using its stored factors.
+
+## Why it is fast
+
+| Technique | What it buys |
+|-----------|--------------|
+| BTF | factor only the diagonal blocks |
+| AMD on A+Aᵀ per block | near-minimal fill on unsymmetric blocks |
+| Eisenstat–Liu **symmetric pruning** | the per-column reach DFS touches a *pruned* structure, not the full computed columns of L — the dominant constant-factor win in scalar left-looking LU |
+| Tight CSC integer kernels | gather/scatter on raw arrays, pre-sized and chunk-grown — no per-column heap traffic |
+| **analyze / factor / refactor** split | symbolic analysis and pivot search are done once; transient simulation refactors the same pattern thousands of times via `klu_refactor` (numeric only) |
+
+That last point is central to the circuit-simulation workload: a transient
+analysis performs one `klu_analyze` and then a `klu_factor`/`klu_refactor` per
+Newton step, reusing the symbolic structure and (for refactor) the pivot
+sequence. Amortizing the symbolic work is much of KLU's real-world speed.
+
+## Complexity
+
+- **Time:** O(flops), i.e. proportional to the arithmetic operations of the
+  factorization — *not* a function of `n` independent of sparsity. The
+  Gilbert–Peierls reach formulation is what guarantees this; an implementation
+  that scans all previous columns per step is accidentally O(n²) regardless of
+  sparsity.
+- **Fill / memory:** determined by the ordering. For 2D-grid-like structure,
+  optimal orderings give O(n log n) fill and O(n^1.5) flops — so even a perfect
+  implementation is super-linear on such matrices; the goal is to match the
+  *constant*, not to be linear.
+
+## Implementation pitfalls (where naive versions lose)
+
+These are the recurring ways a from-scratch KLU underperforms the reference.
+Each is a concrete, measurable target.
+
+1. **Accidental O(n²) factorization.** Computing each column's structure by
+   scanning all previously-factored columns (instead of via the Gilbert–Peierls
+   *reach*) is quadratic in `n` even for a tridiagonal matrix. Symptom: time
+   quadruples when `n` doubles, independent of nonzeros.
+2. **Wrong block ordering → fill explosion.** Ordering unsymmetric blocks by
+   `AᵀA` (COLAMD) rather than `A+Aᵀ` (AMD) lets partial pivoting diverge from the
+   predicted order; actual fill — and thus flops and memory — blows up on
+   indefinite circuit blocks while staying fine on symmetric/SPD ones.
+3. **No symmetric pruning.** Without Eisenstat–Liu pruning, the per-column reach
+   DFS re-traverses full L columns; the factorization is still O(flops) but with
+   a large constant. This is usually the biggest single constant-factor gap.
+4. **Heavyweight data structures in the hot path.** Building and slicing the
+   matrix through general containers (hashed/sorted inserters, per-block
+   reallocation) instead of raw CSC integer arrays adds allocation and indirection
+   to the innermost loops.
+5. **No analyze/factor/refactor split.** Re-running symbolic analysis and pivot
+   search on every solve is wasteful for the dominant workload (repeated
+   factorization of the same pattern with changing values).
+6. **No scaling / weak pivot strategy.** Badly-scaled, indefinite circuit blocks
+   provoke excessive off-diagonal pivoting (which feeds pitfall 2). Row/column
+   scaling and a tuned threshold reduce both instability and fill.
+7. **Quadratic BTF.** The matching and SCC passes must be near-linear; a per-row
+   full-array reset in the matching, or recursive SCC that overflows the stack,
+   reintroduces quadratic time or crashes on large graphs.
+
+### When BTF does not help
+
+BTF only reduces work when the matrix is reducible. Some circuit matrices are
+essentially irreducible — e.g. `Rajat/rajat30` (≈644k unknowns) decomposes into
+one block of ≈632k plus ~11.7k singletons. There, performance rests entirely on
+the per-block ordering (pitfall 2) and factorization quality (pitfalls 1, 3),
+not on BTF.
+
+## References
+
+- Davis, T. A. & Palamadai Natarajan, E. "Algorithm 907: KLU, A Direct Sparse
+  Solver for Circuit Simulation Problems." *ACM TOMS* 37(3), 2010.
+- Gilbert, J. R. & Peierls, T. "Sparse Partial Pivoting in Time Proportional to
+  Arithmetic Operations." *SIAM J. Sci. Stat. Comput.* 9(5), 1988.
+- Eisenstat, S. C. & Liu, J. W. H. "Exploiting Structural Symmetry in Unsymmetric
+  Sparse Symbolic Factorization." *SIAM J. Matrix Anal. Appl.* 13(1), 1992.
+- Davis, T. A. *Direct Methods for Sparse Linear Systems.* SIAM, 2006.

--- a/docs/algorithms/overview.md
+++ b/docs/algorithms/overview.md
@@ -1,0 +1,36 @@
+# Linear Algebra Algorithms
+
+A reference series on the **core algorithms** behind MTL5's solvers — what they
+do, why they perform the way they do, and the implementation pitfalls that
+determine whether a from-scratch version is competitive.
+
+## Why this section exists
+
+The hard-won knowledge of *why* a numerical algorithm is fast — the data
+structures, the asymptotic traps, the constant-factor techniques — tends to
+evaporate into a library's source code, where it is invisible to users and to
+the next maintainer. Re-deriving it later is expensive and error-prone.
+
+This section captures that knowledge as durable, implementation-independent
+documentation: the algorithm, its complexity, *why* a good implementation
+reaches that complexity, and the specific weaknesses a naive implementation
+exhibits. It is written to outlive any particular version of the code.
+
+Each page is a characterization, not a status page — it describes the algorithm
+and the engineering that makes it fast, using well-known reference
+implementations (e.g. SuiteSparse) as the performance yardstick. Where MTL5
+provides its own implementation, the page links to it and to the engineering
+effort tracking its performance, but the characterization stands on its own.
+
+## Pages
+
+- **[KLU](klu.md)** — sparse LU for circuit-simulation matrices: BTF +
+  block-wise Gilbert–Peierls LU with partial pivoting. A scalar, non-supernodal
+  solver, and a case study in where sparse-LU implementations lose performance.
+
+## Planned
+
+Future characterizations for the other core solvers — sparse Cholesky (up/left
+looking, supernodal), sparse QR, the fill-reducing orderings (AMD/COLAMD,
+nested dissection), and the Krylov methods (CG, GMRES, BiCGSTAB) — following the
+same template: algorithm, complexity, why-it-is-fast, implementation pitfalls.

--- a/docs/plans/klu-algorithm-and-weaknesses.md
+++ b/docs/plans/klu-algorithm-and-weaknesses.md
@@ -1,5 +1,11 @@
 # KLU: Algorithm and Implementation Weaknesses
 
+> **Note:** the durable, implementation-independent characterization of the KLU
+> algorithm is published in the docs site under **Linear Algebra Algorithms**
+> (`docs/algorithms/klu.md`). *This* document is the internal optimization
+> tracker: it maps each weakness to a phase and records MTL5's measured
+> native-vs-SuiteSparse numbers as the effort progresses.
+
 A reference for the native KLU performance effort ([epic #138](native-klu-performance.md)).
 It describes what KLU does, why it is fast, and the specific places a naive
 implementation (ours included) loses performance. Each weakness is tagged with


### PR DESCRIPTION
Adds a published docs-site section, **Linear Algebra Algorithms**, for durable, implementation-independent characterizations of MTL5's core algorithms — capturing the "why it is fast" engineering knowledge that otherwise lives only in source and gets lost.

## What's here
- **`docs/algorithms/overview.md`** — section intro, rationale ("this knowledge tends to be lost in library design"), and roadmap (Cholesky, QR, orderings, Krylov to follow the same template).
- **`docs/algorithms/klu.md`** — the KLU characterization: solver class (scalar, non-supernodal left-looking GP-LU), the BTF → order → factor → solve pipeline, *why it is fast* (BTF, AMD-on-A+Aᵀ, Eisenstat–Liu symmetric pruning, CSC kernels, analyze/factor/refactor), complexity, the **7 implementation pitfalls** where naive versions lose, and the "when BTF doesn't help" irreducible case (rajat30).
- Wired into the site: `FILE_MAP` entries (`sync-content.mjs`) + a new sidebar section (`astro.config.mjs`).
- The internal optimization tracker (`docs/plans/klu-algorithm-and-weaknesses.md`) now cross-links to the published page and remains the phase/measured-numbers tracker.

## Design choice
The published page is a **durable reference**, not a status page — it characterizes the algorithm using SuiteSparse as the yardstick and stands on its own, independent of MTL5's current parity numbers (those live in the internal tracker / epic #138).

## Verification
`node sync-content.mjs` and `npm run build` both succeed; pages render at `/algorithms/overview/` and `/algorithms/klu/`. Only source files committed — `src/content/docs/` and `dist/` are generated and git-ignored per CLAUDE.md.

Part of epic #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Linear Algebra Algorithms” documentation section to centralize durable, implementation-independent algorithm knowledge.
  * Added a dedicated KLU page covering the sparse LU solver for circuit-simulation matrices, including the end-to-end pipeline and key implementation considerations.
  * Added an overview page explaining the section’s scope and outlining planned future characterizations (e.g., Cholesky/QR, ordering strategies, and Krylov methods).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->