### PR TITLE
perf(sparse): row scaling (equilibration) in native KLU (Phase 5)

### DIFF
--- a/docs/plans/klu-algorithm-and-weaknesses.md
+++ b/docs/plans/klu-algorithm-and-weaknesses.md
@@ -76,7 +76,7 @@ from the Phase 0 scoreboard and updated as phases land.
 | W2 | **Expensive reach / DFS** | Eisenstat–Liu symmetric pruning | ~~full GP-LU DFS~~ → **symmetric pruning (Phase 2)** | [2 (#134)](native-klu-performance.md) | **Phase 2 (pruning):** Poisson 256² **3.6× → 1.5×** (0.68s → 0.29s; **meets the 1.5× DoD**), 128² 3.5× → 1.7×. rajat30 43.9× → **28.7×** (309s → 204s); its constant factor 3.3× → **2.1×** (residual 28.7× = 13.5× fill × 2.1× constant). Fill unchanged (= KLU); same residuals; ASan-clean. |
 | W3 | **Heavy data structures in hot path** | raw CSC int arrays, pre-sized/chunk-grown | `compressed2D` + `inserter`, fresh `std::vector`s per block | [3 (#135)](native-klu-performance.md) | _TBD_ |
 | W4 | **Repeated symbolic + pivot search** | analyze / factor / **refactor** split | pivots re-searched every solve; no refactor | [4 (#136)](native-klu-performance.md) | _TBD (refactor/factor ratio)_ |
-| W5 | **No scaling / pivot strategy for indefinite blocks** | optional row scaling + threshold pivoting | no scaling | [5 (#137)](native-klu-performance.md) | _TBD_ |
+| W5 | **No scaling / pivot strategy for indefinite blocks** | optional row scaling + threshold pivoting | ~~no scaling~~ → **row equilibration r=1/max\|row\| (Phase 5)** | [5 (#137)](native-klu-performance.md) | **Phase 5 (scaling):** rajat30 fill **13.5× → 1.7×** (437M → 55M) and time **28.7× → 4.5×** (204s → 32s) — equilibration lets pivoting follow the AMD order. Poisson unchanged (already well-scaled). Residuals tiny; correctness preserved. |
 | W6 | **BTF constant factor** | tuned `maxtrans`/`strongcomp` | Kuhn matching + Tarjan SCC | [3 (#135)](native-klu-performance.md) | rajat30 BTF: 1.7s (of 7.4s KLU total) |
 
 ### Notes per weakness

--- a/include/mtl/sparse/factorization/native_klu.hpp
+++ b/include/mtl/sparse/factorization/native_klu.hpp
@@ -45,9 +45,11 @@ namespace mtl::sparse::factorization {
 template <typename Value>
 struct klu_numeric {
     ordering::btf_result          btf;            ///< row/col permutations + blocks
-    mat::compressed2D<Value>      B;              ///< P*A*Q, block upper triangular
+    mat::compressed2D<Value>      B;              ///< P*(R*A)*Q, block upper triangular
     std::vector<std::size_t>      block_of;       ///< new index -> block id
     std::vector<lu_numeric<Value>> block_numeric; ///< LU of each diagonal block
+    std::vector<Value>            row_scale;      ///< r[orig row]; empty = unscaled
+                                                  ///< (factored R*A, so solve scales b)
 
     std::size_t num_rows() const { return btf.row_perm.size(); }
     std::size_t num_cols() const { return num_rows(); }
@@ -64,10 +66,16 @@ struct klu_numeric {
                 "klu_numeric::solve: vector size mismatch");
         }
 
-        // c[i] = b[p[i]]; y is updated in place to the final solution per block.
+        // c[i] = (R*b)[p[i]]; y is updated in place to the final solution per
+        // block. We factored R*A, so the RHS is row-scaled by the same R; the
+        // resulting x solves the original A*x = b unchanged (no x unscaling).
         std::vector<Value> y(n);
-        for (std::size_t i = 0; i < n; ++i)
-            y[i] = static_cast<Value>(b(btf.row_perm[i]));
+        const bool scaled = !row_scale.empty();
+        for (std::size_t i = 0; i < n; ++i) {
+            std::size_t orow = btf.row_perm[i];
+            Value bi = static_cast<Value>(b(orow));
+            y[i] = scaled ? row_scale[orow] * bi : bi;
+        }
 
         const auto& rp  = B.ref_major();
         const auto& ci  = B.ref_minor();
@@ -116,8 +124,10 @@ template <typename Value, typename Parameters>
     requires OrderedField<Value>
 klu_numeric<Value> native_klu_factor(
     const mat::compressed2D<Value, Parameters>& A,
-    Value threshold = Value{1})
+    Value threshold = Value{1},
+    bool scale = true)
 {
+    using std::abs;  // ADL for custom number types
     if (A.num_rows() != A.num_cols()) {
         throw std::invalid_argument("native_klu_factor: matrix must be square");
     }
@@ -129,13 +139,33 @@ klu_numeric<Value> native_klu_factor(
         return result;
     }
 
+    // BTF is structural; scaling does not change the pattern, so compute it on A.
     result.btf = ordering::block_triangular_form(A);
     if (result.btf.structurally_singular) {
         throw std::runtime_error(
             "native_klu_factor: matrix is structurally singular");
     }
 
-    // Build B = P*A*Q. New column of old column c is q_inv[c].
+    // Row scaling (KLU default): r[i] = 1 / max_j |A(i,j)|. Equilibrating the
+    // rows keeps threshold partial pivoting close to the fill-reducing order on
+    // badly-scaled indefinite blocks, which otherwise inflates fill. We factor
+    // R*A and row-scale the RHS in solve(); x is unchanged.
+    if (scale) {
+        const auto& rp  = A.ref_major();
+        const auto& ci  = A.ref_minor();
+        const auto& dat = A.ref_data();
+        result.row_scale.assign(n, Value{1});
+        for (std::size_t r = 0; r < n; ++r) {
+            Value m = Value{0};
+            for (std::size_t k = rp[r]; k < rp[r + 1]; ++k) {
+                Value a = abs(dat[k]);
+                if (a > m) m = a;
+            }
+            if (m > Value{0}) result.row_scale[r] = Value{1} / m;
+        }
+    }
+
+    // Build B = P*(R*A)*Q. New column of old column c is q_inv[c].
     auto q_inv = util::invert_permutation(result.btf.col_perm);
     mat::compressed2D<Value> B(n, n);
     {
@@ -145,8 +175,9 @@ klu_numeric<Value> native_klu_factor(
         mat::inserter<mat::compressed2D<Value>> ins(B);
         for (std::size_t i = 0; i < n; ++i) {
             std::size_t orow = result.btf.row_perm[i];
+            Value s = scale ? result.row_scale[orow] : Value{1};
             for (std::size_t k = rp[orow]; k < rp[orow + 1]; ++k)
-                ins[i][q_inv[ci[k]]] << dat[k];
+                ins[i][q_inv[ci[k]]] << s * dat[k];
         }
     }
     result.B = std::move(B);


### PR DESCRIPTION
Phase 5 of the native KLU performance-parity epic (#138). Adds **KLU-style row equilibration** — the lever the characterization pinpointed for rajat30's 13.5× fill.

## How
`native_klu_factor` computes `r[i] = 1/max_j|A(i,j)|`, factors `R·A`, and `solve()` row-scales the RHS by `R`. Pure row scaling preserves the solution, so `x` needs no unscaling. On by default (matching KLU); `scale=false` disables.

Equilibration keeps threshold partial pivoting close to the AMD fill-reducing order on badly-scaled indefinite blocks (where it otherwise diverges and inflates fill).

## Measured (Release, `bench_klu`)

| matrix | metric | before Phase 5 | after Phase 5 |
|---|---|---|---|
| rajat30 | fill ratio | 13.5× (437M) | **1.7× (55M)** |
| rajat30 | time ratio | 28.7× (204s) | **4.5× (32s)** |
| poisson_256² | time ratio | 1.5× | 1.5× (unchanged) |

Poisson is already well-scaled, so equilibration is a no-op there — no regression.

## rajat30 trajectory across the effort
**never finished / 22 GB** (COLAMD) → 309s (Phase 1 AMD) → 204s (Phase 2 pruning) → **32s (Phase 5 scaling)**, now **4.5× KLU** (7.1s). The remaining 4.5× ≈ **1.7× fill × 2.6× constant** → Phase 3 (CSC kernels/data structures) is the next lever.

## Correctness
native_klu suite passes with tiny residuals (scaling preserves the solution exactly); clean under ASan/UBSan. Poisson + small circuits validated.

Part of #138. W5 tracker row updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional row scaling to KLU algorithm (enabled by default for improved matrix factorization).

* **Documentation**
  * Updated algorithm documentation with Phase 5 row scaling implementation details and measured performance gains (fill: 13.5× → 1.7×, time: 28.7× → 4.5× on test matrices).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->