### PR TITLE
docs: residual-fill tuning negative result (pivot threshold doesn't move it)

### DIFF
--- a/docs/plans/klu-algorithm-and-weaknesses.md
+++ b/docs/plans/klu-algorithm-and-weaknesses.md
@@ -103,6 +103,17 @@ from the Phase 0 scoreboard and updated as phases land.
 - **W5 (scaling/pivoting).** Circuit matrices are badly scaled and indefinite;
   scaling reduces off-diagonal pivoting, which in turn reduces fill (couples back
   to W1).
+- **Residual fill is ordering-intrinsic, not pivot-induced (negative result).**
+  After Phase 5 row scaling, rajat30 still shows ~1.7× fill vs KLU. Hypothesis:
+  loosen the partial-pivoting threshold (KLU default 0.001) to keep pivoting on
+  the AMD order. *Measured: it did not help* — fill stayed ~55M (even rose
+  slightly), and Poisson fill rose ~3%. Because row scaling already equilibrated
+  the matrix, pivoting was already following the order; the threshold has little
+  effect. So the residual 1.7× fill is **intrinsic to our AMD ordering vs KLU's
+  AMD tuning** on this matrix, not a pivoting artifact. Closing it requires
+  ordering-quality work (matching KLU's AMD parameters / aggressive absorption),
+  a deeper investigation — not the threshold. Default kept at full partial
+  pivoting (threshold 1) for stability.
 - **W6 (BTF).** Smaller, but our BTF at 1.7s is a sizable fraction of KLU's
   entire 7.4s on rajat30, so it has room.
 

--- a/docs/plans/klu-algorithm-and-weaknesses.md
+++ b/docs/plans/klu-algorithm-and-weaknesses.md
@@ -105,15 +105,17 @@ from the Phase 0 scoreboard and updated as phases land.
   to W1).
 - **Residual fill is ordering-intrinsic, not pivot-induced (negative result).**
   After Phase 5 row scaling, rajat30 still shows ~1.7× fill vs KLU. Hypothesis:
-  loosen the partial-pivoting threshold (KLU default 0.001) to keep pivoting on
+  temporarily lower the partial-pivoting threshold from the native default of
+  **1.0 (full partial pivoting)** to KLU's looser **0.001**, to keep pivoting on
   the AMD order. *Measured: it did not help* — fill stayed ~55M (even rose
   slightly), and Poisson fill rose ~3%. Because row scaling already equilibrated
   the matrix, pivoting was already following the order; the threshold has little
   effect. So the residual 1.7× fill is **intrinsic to our AMD ordering vs KLU's
   AMD tuning** on this matrix, not a pivoting artifact. Closing it requires
   ordering-quality work (matching KLU's AMD parameters / aggressive absorption),
-  a deeper investigation — not the threshold. Default kept at full partial
-  pivoting (threshold 1) for stability.
+  a deeper investigation — not the threshold. **The 0.001 experiment was
+  reverted; the native default remains 1.0 (full partial pivoting) for
+  stability.**
 - **W6 (BTF).** Smaller, but our BTF at 1.7s is a sizable fraction of KLU's
   entire 7.4s on rajat30, so it has room.
 


### PR DESCRIPTION
Investigated the residual **~1.7× rajat30 fill** vs KLU (after Phase 5 row scaling) — the lever the W3/Phase-3 analysis flagged as the bigger remaining win.

## Hypothesis
Loosen the partial-pivoting threshold (KLU's default is 0.001) so pivoting prefers the diagonal and stays on the AMD fill-reducing order instead of chasing the max element.

## Measured — refuted
| matrix | fill before | fill with threshold=0.001 |
|---|---|---|
| rajat30 | 55.0M (1.7×) | 55.8M (1.7×, slightly *worse*) |
| poisson_256² | 3.94M (1.0×) | 4.06M (+3%) |

No improvement, and a small Poisson regression. **Reason:** Phase 5's row scaling already equilibrated the matrix, so pivoting was already following the AMD order — the threshold has little left to do. So the residual 1.7× fill is **intrinsic to our AMD ordering vs KLU's AMD tuning** on this matrix, *not* a pivoting artifact.

## Outcome
- **Reverted** the threshold change (kept full partial pivoting, `threshold=1`, for stability — it was also marginally better on fill).
- **Recorded the negative result** in the tracker so it isn't re-attempted, and redirected the residual-fill lever to **ordering-quality work** (matching KLU's AMD parameters / aggressive absorption) — a deeper, separate investigation.

Docs-only (the value here is the validated negative result + corrected direction). Part of #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the W5 section with a “negative result” note, including residual fill vs KLU after Phase 5 scaling.
  * Documented an attempted partial-pivoting threshold adjustment and confirmed it didn’t improve fill, so the default setting remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->