### PR TITLE
feat(sparse): thread accumulator policy through native_klu_factor

### DIFF
--- a/include/mtl/sparse/factorization/native_klu.hpp
+++ b/include/mtl/sparse/factorization/native_klu.hpp
@@ -119,11 +119,16 @@ struct klu_numeric {
 /// Factor A using native KLU: BTF, then a left-looking LU of each diagonal
 /// block with threshold partial pivoting.
 ///
+/// The optional `Accumulator` type selects the per-block numeric accumulator
+/// policy (see sparse_lu's accumulator_traits): defaulting to `Value` gives
+/// ordinary arithmetic, while a caller can inject an exact/extended-precision
+/// accumulator (e.g. a super-accumulator) for the inner products of every block.
+///
 /// \throws std::invalid_argument if A is not square.
 /// \throws std::runtime_error    if A is structurally singular (no perfect
 ///                               matching) or a diagonal block is numerically
 ///                               singular.
-template <typename Value, typename Parameters>
+template <typename Value, typename Parameters, typename Accumulator = Value>
     requires OrderedField<Value>
 klu_numeric<Value> native_klu_factor(
     const mat::compressed2D<Value, Parameters>& A,
@@ -239,8 +244,11 @@ klu_numeric<Value> native_klu_factor(
         // fill explodes; the symmetrized ordering keeps fill near-minimal (#133).
         lu_symbolic sym = (m > 4) ? sparse_lu_symbolic(block, ordering::amd{})
                                   : sparse_lu_symbolic(block);
+        // Forward the block matrix's own parameter type so the caller-selected
+        // Accumulator policy can be specified explicitly (it is not deducible).
+        using block_params = typename decltype(block)::param_type;
         result.block_numeric.push_back(
-            sparse_lu_numeric(block, sym, threshold));
+            sparse_lu_numeric<Value, block_params, Accumulator>(block, sym, threshold));
     }
 
     return result;

--- a/tests/unit/sparse/test_native_klu.cpp
+++ b/tests/unit/sparse/test_native_klu.cpp
@@ -28,6 +28,24 @@ using mtl::sparse::factorization::native_klu_factor;
 using mtl::sparse::factorization::native_klu_solve;
 
 namespace {
+// Extended (double-over-float) accumulator to exercise the accumulator policy
+// threaded through native KLU (#122 seam, native_klu threading).
+struct wide_acc { double v = 0.0; };
+} // namespace
+
+namespace mtl::sparse::factorization {
+template <>
+struct accumulator_traits<wide_acc, float> {
+    static void  clear(wide_acc& a)                  { a.v = 0.0; }
+    static void  assign(wide_acc& a, const float& x) { a.v = static_cast<double>(x); }
+    static float value(const wide_acc& a)            { return static_cast<float>(a.v); }
+    static void  add_product(wide_acc& a, const float& m, const float& x) {
+        a.v += static_cast<double>(m) * static_cast<double>(x);
+    }
+};
+} // namespace mtl::sparse::factorization
+
+namespace {
 
 template <typename Value>
 double residual_inf_norm(const mat::compressed2D<Value>& A,
@@ -293,6 +311,47 @@ TEST_CASE("native KLU refactor reuses structure for same-pattern matrices",
             REQUIRE_THAT(xr(static_cast<int>(i)), WithinAbs(xfresh(static_cast<int>(i)), 1e-9));
         REQUIRE(relative_residual(A2, xr, b) < 1e-9);
     }
+}
+
+TEST_CASE("native KLU threads a custom accumulator policy through the blocks",
+          "[sparse][klu][native][accumulator]") {
+    // Block-triangular float circuit matrix; factor it with the default (float)
+    // accumulator and with the extended double accumulator. The wide accumulator
+    // must thread through BTF + every block and solve at least as accurately.
+    std::size_t n = 6;
+    mat::compressed2D<float> A(n, n);
+    {
+        mat::inserter<mat::compressed2D<float>> ins(A);
+        ins[0][0] << 3.0f;  ins[0][1] << -1.0f; ins[0][5] << -2.0f;
+        ins[1][0] << -1.0f; ins[1][1] << 3.0f;  ins[1][2] << -1.0f;
+        ins[2][1] << -1.0f; ins[2][2] << 3.0f;
+        ins[3][3] << 4.0f;  ins[3][4] << -1.0f;
+        ins[4][3] << -1.0f; ins[4][4] << 4.0f;  ins[4][5] << -1.0f;
+        ins[5][4] << -1.0f; ins[5][5] << 4.0f;
+    }
+    vec::dense_vector<float> b(n, 1.0f), xd(n, 0.0f), xw(n, 0.0f);
+
+    auto fac_default = native_klu_factor(A);                                  // Accumulator = float
+    fac_default.solve(xd, b);
+
+    auto fac_wide = native_klu_factor<float, mat::parameters<>, wide_acc>(A); // double accumulation
+    fac_wide.solve(xw, b);
+
+    // Residual ||A x - b||_inf in double for each.
+    auto resid = [&](const vec::dense_vector<float>& x) {
+        const auto& rp = A.ref_major(); const auto& ci = A.ref_minor(); const auto& dat = A.ref_data();
+        double m = 0.0;
+        for (std::size_t r = 0; r < n; ++r) {
+            double ax = 0.0;
+            for (std::size_t k = rp[r]; k < rp[r + 1]; ++k)
+                ax += static_cast<double>(dat[k]) * static_cast<double>(x(static_cast<int>(ci[k])));
+            m = std::max(m, std::abs(ax - static_cast<double>(b(static_cast<int>(r)))));
+        }
+        return m;
+    };
+    // Both solve correctly; the extended accumulator is no worse.
+    REQUIRE(resid(xd) < 1e-4);
+    REQUIRE(resid(xw) <= resid(xd) + 1e-12);
 }
 
 #ifdef MTL5_HAS_KLU


### PR DESCRIPTION
Threads the #122 accumulator seam through the **full native KLU** driver, so an exact/extended accumulator (the posit quire from mp-spice #11) reaches every BTF block — not just a standalone `sparse_lu`. This is the MTL5 follow-up the quire study flagged.

## What
`native_klu_factor` gains an `Accumulator = Value` template parameter, forwarded to each diagonal block's `sparse_lu_numeric` via the block matrix's own `param_type`. A caller can now factor a real circuit matrix with a fused dot product per block:
```cpp
native_klu_factor<Posit, mat::parameters<>, quire_acc<Posit>>(A);
```

## Default unchanged
`Accumulator == Value` → byte-identical. `native_klu` / `sparse_lu` / cross-solver suites pass unchanged.

## Test
New case threads a double-over-float accumulator through BTF + every block and verifies it solves at least as accurately as the default float path. ASan/UBSan clean.

## Why
Unblocks the **full BTF-KLU + iterative-refinement + quire** study in mp-spice — the path to testing whether exact accumulation rescues the cfloat/posit IR-convergence finding from mp-spice #10.

Follow-up: `native_klu_refactor`'s replay still accumulates in `Value`. Part of #122 / mp-spice #3 / #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * KLU factorization now supports selecting custom numeric accumulator policies for improved numerical stability during factorization.

* **Tests**
  * Added unit tests validating factorization with multiple accumulator types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->