### PR TITLE
perf(sparse): patience-based termination for iterative_refine (#167)

### DIFF
--- a/include/mtl/sparse/iterative_refine.hpp
+++ b/include/mtl/sparse/iterative_refine.hpp
@@ -41,6 +41,9 @@ struct refine_options {
     int    max_iter = 20;     ///< maximum correction steps
     double rel_tol  = 0.0;    ///< stop when ||r||inf/||b||inf <= rel_tol (0 = disabled)
     bool   scaled   = false;  ///< normalize the residual before each correction solve
+    int    patience = 3;      ///< stop after this many consecutive non-improving steps
+                              ///< (>=1; tolerates a noisy low-precision residual so IR
+                              ///< reaches its floor instead of quitting on one bad step)
 };
 
 /// Outcome of iterative_refine.
@@ -88,7 +91,8 @@ refine_result iterative_refine(
     vec::dense_vector<Residual> r(n), dx(n, Residual{0});
     vec::dense_vector<Residual> best_x = x;
     double best_rn = std::numeric_limits<double>::infinity();
-    double prev_rn = std::numeric_limits<double>::infinity();
+    const int patience = std::max(1, opt.patience);
+    int stalls = 0;                          // consecutive non-improving steps
 
     refine_result res;
     for (int it = 0; it < opt.max_iter; ++it) {
@@ -100,12 +104,15 @@ refine_result iterative_refine(
             r(static_cast<int>(i)) = b(static_cast<int>(i)) - ax;
         }
         double rn = norm_inf(r);
-        if (rn < best_rn) { best_rn = rn; best_x = x; }
+        // Track the best iterate; a low-precision residual is noisy, so allow up
+        // to `patience` consecutive non-improving steps before giving up (the
+        // returned x is always the best seen, so extra steps never degrade it).
+        if (rn < best_rn) { best_rn = rn; best_x = x; stalls = 0; }
+        else              { ++stalls; }
 
         double rel = (bnorm > 0.0) ? rn / bnorm : rn;
         if (opt.rel_tol > 0.0 && rel <= opt.rel_tol) { res.converged = true; break; }
-        if (rn >= prev_rn) break;            // stopped improving (or diverging)
-        prev_rn = rn;
+        if (stalls >= patience) break;       // plateaued / diverging
 
         // Correction solve through the factorization (in its own precision).
         if (opt.scaled) {

--- a/tests/unit/sparse/test_iterative_refine.cpp
+++ b/tests/unit/sparse/test_iterative_refine.cpp
@@ -120,3 +120,25 @@ TEST_CASE("scaled iterative_refine matches unscaled for a wide-range factor type
     for (std::size_t i = 0; i < n; ++i)
         REQUIRE_THAT(xs(static_cast<int>(i)), WithinAbs(xu(static_cast<int>(i)), 1e-9));
 }
+
+TEST_CASE("iterative_refine patience never degrades the result",
+          "[sparse][iterative_refine]") {
+    // Patience tolerates non-improving steps so noisy low-precision IR reaches its
+    // floor (validated with posit/cfloat in mp-spice). The invariant testable here:
+    // since the best iterate is always returned, varying patience never worsens the
+    // result, and a larger patience reaches at least as good a residual.
+    std::size_t n = 50;
+    auto Ad = dense_mixed<double>(n);
+    auto fac = sparse::factorization::native_klu_factor(dense_mixed<float>(n));
+    auto b  = rhs_ones(Ad);
+
+    vec::dense_vector<double> x1(n, 0.0), x5(n, 0.0);
+    sparse::refine_options o1; o1.max_iter = 50; o1.patience = 1;
+    sparse::refine_options o5; o5.max_iter = 50; o5.patience = 5;
+    auto r1 = sparse::iterative_refine<double>(Ad, fac, b, x1, o1);
+    auto r5 = sparse::iterative_refine<double>(Ad, fac, b, x5, o5);
+
+    REQUIRE(forward_error(x1) < 1e-10);
+    REQUIRE(forward_error(x5) < 1e-10);
+    REQUIRE(r5.rel_residual <= r1.rel_residual);   // more patience never worse
+}


### PR DESCRIPTION
Fixes the rough edge in the `iterative_refine` core (#119/#166) surfaced when delegating mp-spice's study to it: the strict "stop at the first non-improving step" quit before a **noisy low-precision residual** had actually plateaued.

## What
`refine_options::patience` (default 3): tolerate up to `patience` consecutive non-improving steps before stopping, resetting the counter on any improvement. The best iterate is still always returned, so more patience **never degrades** the result — it just spends a few extra cheap solves to reach the floor.

## Verified (mp-spice study, factor in posit + double-residual IR on add32)
| | strict break (#166) | **patience (#167)** |
|---|---|---|
| posit<16,2> IR fwd err | 6.8e-12 / 11 it | **2.7e-12 / 20 it** |
| half IR | 5.7e-5 / 6 (stalls) | 5.7e-5 / 8 (still stalls, correctly) |
| float / posit<32,2> | unchanged | unchanged |

posit<16,2> now reaches a **better floor** than both the strict break and even the original hand-rolled loop (4.5e-12) — because it descends through noisy steps and keeps the best iterate.

## Tests
New case asserts more patience never worsens the outcome (best-iterate invariant); monotone float/double results unchanged; default path + ASan/UBSan clean.

Resolves #167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "patience" mechanism to iterative refinement for improved handling of noisy low-precision residuals.
  * New `refine_options::patience` parameter (default: 3) allows users to tune early-stopping behavior.

* **Tests**
  * Added verification that solution quality remains consistent across different patience settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->