### PR TITLE
feat(math): shared accumulator_traits + result-type round-out (#158)

### DIFF
--- a/include/mtl/math/accumulator_traits.hpp
+++ b/include/mtl/math/accumulator_traits.hpp
@@ -1,0 +1,45 @@
+#pragma once
+// MTL5 -- accumulator policy for inner-product accumulation (issue #158)
+//
+// A single, cross-cutting customization point for how an inner product (a dot
+// product, the columns of an LU, a GEMM element) is accumulated. It lets the
+// THREE precisions of a mixed-precision tensor op be chosen independently:
+//
+//   * Value  -- the element/storage precision of the operands (bandwidth in)
+//   * Acc    -- the accumulator precision the products are summed in (registers)
+//   * Result -- the precision the rounded result is delivered/stored in (out)
+//
+// MTL5 stays free of any external number library: a caller supplies a custom
+// `Acc` (a compensated/Kahan accumulator, a Universal `quire` super-accumulator,
+// or simply a wider IEEE type) by specializing `accumulator_traits<Acc, Value>`.
+//
+// The default specialization makes `Acc == Value` (plain arithmetic, zero
+// overhead, identical results) -- the behavior unless a caller opts in.
+//
+// Used by the sparse factorizations and the dense BLAS-level operations.
+
+namespace mtl::math {
+
+/// Accumulator policy for accumulating products of `Value`s into an `Acc`.
+template <typename Acc, typename Value>
+struct accumulator_traits {
+    /// Reset the accumulator to zero.
+    static void clear(Acc& a) { a = Acc{}; }
+
+    /// Set the accumulator to a single value.
+    static void assign(Acc& a, const Value& v) { a = v; }
+
+    /// Round the accumulator out to `Result` (default: the element type `Value`),
+    /// once, at the point the accumulated entry is consumed -- giving
+    /// single-rounding ("exact dot product") semantics when `Acc` is exact, and
+    /// fusing the accumulate->output conversion when `Result` differs from `Acc`.
+    template <typename Result = Value>
+    static Result value(const Acc& a) { return static_cast<Result>(a); }
+
+    /// a += m * v : the canonical accumulate-a-product primitive (a dot product /
+    /// quire is a sum of products). Callers pass a negated multiplier for a
+    /// subtraction (e.g. the LU elimination update).
+    static void add_product(Acc& a, const Value& m, const Value& v) { a += m * v; }
+};
+
+} // namespace mtl::math

--- a/include/mtl/sparse/factorization/sparse_lu.hpp
+++ b/include/mtl/sparse/factorization/sparse_lu.hpp
@@ -40,6 +40,7 @@
 #include <mtl/mat/compressed2D.hpp>
 #include <mtl/vec/dense_vector.hpp>
 #include <mtl/concepts/scalar.hpp>
+#include <mtl/math/accumulator_traits.hpp>
 #include <mtl/sparse/util/csc.hpp>
 #include <mtl/sparse/util/permutation.hpp>
 #include <mtl/sparse/factorization/triangular_solve.hpp>
@@ -155,28 +156,13 @@ lu_symbolic sparse_lu_symbolic(
 
 /// Accumulator policy for the numeric workspace of the left-looking solve.
 ///
-/// The dense workspace column is held as `Acc` and the algorithm touches it only
-/// through this trait, so the accumulation can be made exact/extended-precision
-/// without MTL5 depending on any external number library: a caller supplies a
-/// custom `Acc` (e.g. a Kahan/compensated accumulator, or a Universal `quire`
-/// super-accumulator) by specializing `accumulator_traits<Acc, Value>`.
-///
-/// The default specialization makes `Acc == Value` (plain arithmetic, zero
-/// overhead, identical results) -- the behavior unless a caller opts in.
-///
-/// `value()` rounds the accumulator to `Value` once, at the point the column
-/// entry is consumed -- giving single-rounding ("exact dot product") semantics
-/// when `Acc` is exact.
+/// The canonical, cross-cutting trait lives in `mtl::math::accumulator_traits`
+/// (#158); this name inherits it for the sparse kernels and source compatibility.
+/// Specialize `mtl::math::accumulator_traits<Acc, Value>` to affect both the
+/// sparse factorizations and the dense BLAS ops at once (it propagates here via
+/// the base); specialize this one for a sparse-only customization.
 template <typename Acc, typename Value>
-struct accumulator_traits {
-    static void  clear(Acc& a)                                   { a = Acc{}; }
-    static void  assign(Acc& a, const Value& v)                  { a = v; }
-    static Value value(const Acc& a)                             { return static_cast<Value>(a); }
-    // add_product(a, m, v) == a += m*v: the canonical accumulate-a-product
-    // primitive (a dot product / quire is a sum of products). The caller passes
-    // a negated multiplier for the elimination subtraction.
-    static void  add_product(Acc& a, const Value& m, const Value& v) { a += m * v; }
-};
+struct accumulator_traits : mtl::math::accumulator_traits<Acc, Value> {};
 
 /// Perform numeric LU factorization with threshold partial pivoting.
 ///

--- a/tests/unit/math/test_accumulator_traits.cpp
+++ b/tests/unit/math/test_accumulator_traits.cpp
@@ -1,0 +1,95 @@
+// MTL5 -- mtl::math::accumulator_traits (issue #158).
+// The shared accumulator policy: clear/assign/add_product, plus the generalized
+// value<Result> round-out that delivers the accumulator in a result type distinct
+// from both the element type and the accumulator type (the Element -> Accumulate
+// -> Result model behind mixed-precision tensor ops).
+#include <catch2/catch_test_macros.hpp>
+
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+#include <mtl/math/accumulator_traits.hpp>
+#include <mtl/sparse/factorization/sparse_lu.hpp>   // for the inheriting sparse alias
+
+namespace {
+// Extended accumulator: hold the running sum in double, accumulate products in
+// double, and deliver in any result type via value<Result>.
+struct wide_acc { double v = 0.0; };
+} // namespace
+
+namespace mtl::math {
+template <>
+struct accumulator_traits<wide_acc, float> {
+    static void clear(wide_acc& a) { a.v = 0.0; }
+    static void assign(wide_acc& a, const float& x) { a.v = static_cast<double>(x); }
+    template <typename Result = float>
+    static Result value(const wide_acc& a) { return static_cast<Result>(a.v); }
+    static void add_product(wide_acc& a, const float& m, const float& x) {
+        a.v += static_cast<double>(m) * static_cast<double>(x);   // product in double
+    }
+};
+} // namespace mtl::math
+
+using mtl::math::accumulator_traits;
+
+TEST_CASE("accumulator_traits default: plain arithmetic", "[math][accumulator]") {
+    using AT = accumulator_traits<double, double>;
+    double a;
+    AT::clear(a);            REQUIRE(a == 0.0);
+    AT::assign(a, 1.5);      REQUIRE(a == 1.5);
+    AT::add_product(a, 2.0, 3.0);  REQUIRE(a == 7.5);   // 1.5 + 6
+    REQUIRE(AT::value(a) == 7.5);
+}
+
+TEST_CASE("accumulator_traits value<Result> rounds to a distinct result type",
+          "[math][accumulator]") {
+    // Accumulate in double (Acc), elements are float (Value), deliver as float
+    // (Result default = Value) or as double (explicit Result) -- the fused
+    // accumulate->output conversion.
+    using AT = accumulator_traits<double, float>;
+    double a; AT::clear(a);
+    AT::assign(a, 1.0f);
+    AT::add_product(a, 0.1f, 1.0f);   // a += 0.1f
+
+    float  rf = AT::value(a);             // Result defaults to Value (float)
+    double rd = AT::value<double>(a);     // explicit wider Result
+    REQUIRE(rf == static_cast<float>(a));
+    REQUIRE(rd == a);
+}
+
+TEST_CASE("accumulator_traits: extended accumulator beats element-precision sum",
+          "[math][accumulator]") {
+    // Sum many float products. A double accumulator (with double products)
+    // rounded once to float is more accurate than summing in float throughout.
+    const std::size_t n = 4096;
+    std::vector<float> x(n), y(n);
+    for (std::size_t i = 0; i < n; ++i) { x[i] = 1.0f + 1e-3f * static_cast<float>(i % 7);
+                                          y[i] = 1.0f - 1e-3f * static_cast<float>(i % 5); }
+
+    // exact-ish reference in double
+    double ref = 0.0;
+    for (std::size_t i = 0; i < n; ++i) ref += static_cast<double>(x[i]) * static_cast<double>(y[i]);
+
+    float naive = 0.0f;
+    for (std::size_t i = 0; i < n; ++i) naive += x[i] * y[i];   // float accumulate
+
+    using ATW = accumulator_traits<wide_acc, float>;
+    wide_acc w; ATW::clear(w);
+    for (std::size_t i = 0; i < n; ++i) ATW::add_product(w, x[i], y[i]);
+    float wide = ATW::value(w);                                  // round once to float
+
+    double err_naive = std::abs(static_cast<double>(naive) - ref);
+    double err_wide  = std::abs(static_cast<double>(wide)  - ref);
+    INFO("naive err = " << err_naive << ", wide err = " << err_wide);
+    REQUIRE(err_wide <= err_naive);
+}
+
+TEST_CASE("sparse accumulator_traits inherits the canonical mtl::math trait",
+          "[math][accumulator][sparse]") {
+    // The sparse alias forwards to mtl::math, including value<Result>.
+    using SAT = mtl::sparse::factorization::accumulator_traits<double, float>;
+    double a; SAT::clear(a); SAT::assign(a, 2.0f);
+    REQUIRE(SAT::value(a) == 2.0f);
+    REQUIRE(SAT::value<double>(a) == 2.0);
+}


### PR DESCRIPTION
Foundation for the mixed-precision tensor-ops epic (#157).

## What
- New canonical, cross-cutting trait **`mtl::math::accumulator_traits<Acc, Value>`** (`clear`/`assign`/`add_product` + generalized round-out).
- **`value<Result>(acc)`** (default `Result = Value`) — delivers the accumulator in a result type distinct from both the element and accumulator types: the **Element → Accumulate → Result** model (storage / compute / serialize precisions), with the accumulate→output conversion fused into the round-out.
- `mtl::sparse::factorization::accumulator_traits` now **inherits** the canonical trait: specialize `mtl::math::accumulator_traits` to affect **both** the sparse factorizations and the upcoming dense BLAS ops at once (it propagates via the base); sparse-only specializations still work.

## Non-breaking (verified across repos)
Default `Acc == Value` is byte-identical. The sparse suite, native KLU, the accumulator-policy + iterative-refine tests, **and mp-spice's quire adapter** (which specializes the sparse trait) all build/pass unchanged.

## Test
New `math/test_accumulator_traits`: `value<Result>` rounding to a distinct type, and an extended (double-over-float) accumulator rounded once to float beating element-precision summation. ASan/UBSan clean.

Resolves #158; unblocks the per-operation sub-issues (#159 dot, #161 gemm, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced configurable accumulator precision for mathematical operations, enabling independent specification of accumulator and operand precision for improved numerical accuracy in matrix computations.

* **Tests**
  * Added unit tests verifying accumulator precision behavior and numerical accuracy across different precision configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->