### PR TITLE
feat(operation): accumulator + result-type policy for dot (#159)

### DIFF
--- a/include/mtl/math/accumulator_traits.hpp
+++ b/include/mtl/math/accumulator_traits.hpp
@@ -38,8 +38,13 @@ struct accumulator_traits {
 
     /// a += m * v : the canonical accumulate-a-product primitive (a dot product /
     /// quire is a sum of products). Callers pass a negated multiplier for a
-    /// subtraction (e.g. the LU elimination update).
-    static void add_product(Acc& a, const Value& m, const Value& v) { a += m * v; }
+    /// subtraction (e.g. the LU elimination update). The product is formed in the
+    /// accumulator precision `Acc`, so a wider `Acc` than `Value` (e.g. fp32
+    /// accumulate over bf16 elements) gains accuracy out of the box; this is a
+    /// no-op cast and byte-identical when `Acc == Value`.
+    static void add_product(Acc& a, const Value& m, const Value& v) {
+        a += static_cast<Acc>(m) * static_cast<Acc>(v);
+    }
 };
 
 } // namespace mtl::math

--- a/include/mtl/operation/dot.hpp
+++ b/include/mtl/operation/dot.hpp
@@ -10,6 +10,7 @@
 #include <mtl/concepts/vector.hpp>
 #include <mtl/concepts/scalar.hpp>
 #include <mtl/math/identity.hpp>
+#include <mtl/math/accumulator_traits.hpp>
 #include <mtl/functor/scalar/conj.hpp>
 #include <mtl/interface/dispatch_traits.hpp>
 #include <mtl/simd/algorithm.hpp>
@@ -19,10 +20,29 @@
 
 namespace mtl {
 
-/// Hermitian dot product: sum(conj(v1[i]) * v2[i])
-template <Vector V1, Vector V2>
+/// Hermitian dot product: sum(conj(v1[i]) * v2[i]).
+///
+/// Mixed precision: pass an explicit `Accumulator` to sum the products in a
+/// precision distinct from the element type (e.g. `dot<float>(a, b)` over
+/// bfloat16 vectors accumulates in fp32), and an optional `Result` to round the
+/// sum out to a delivery type (default = the accumulator type). With the default
+/// `Accumulator = void`, behavior is unchanged (BLAS/SIMD fast path or the
+/// common-type loop). The mixed path is scalar; a SIMD variant is a follow-up.
+template <typename Accumulator = void, typename Result = Accumulator,
+          Vector V1, Vector V2>
 auto dot(const V1& v1, const V2& v2) {
     assert(v1.size() == v2.size());
+    if constexpr (!std::is_void_v<Accumulator>) {
+        using Value = std::common_type_t<typename V1::value_type, typename V2::value_type>;
+        using AT = math::accumulator_traits<Accumulator, Value>;
+        Accumulator acc{};
+        AT::clear(acc);
+        for (typename V1::size_type i = 0; i < v1.size(); ++i)
+            AT::add_product(acc,
+                static_cast<Value>(functor::scalar::conj<typename V1::value_type>::apply(v1(i))),
+                static_cast<Value>(v2(i)));
+        return AT::template value<Result>(acc);
+    } else {
 #ifdef MTL5_HAS_BLAS
     // BlasDenseVector is real float/double, where conj is the identity, so
     // BLAS ?dot matches the Hermitian product on these types. Guard the int
@@ -47,12 +67,26 @@ auto dot(const V1& v1, const V2& v2) {
         }
         return acc;
     }
+    }
 }
 
-/// Real dot product: sum(v1[i] * v2[i]) -- no conjugation
-template <Vector V1, Vector V2>
+/// Real dot product: sum(v1[i] * v2[i]) -- no conjugation.
+///
+/// Mixed precision: see `dot` -- pass `Accumulator` (and optional `Result`) to
+/// accumulate in a precision distinct from the element type.
+template <typename Accumulator = void, typename Result = Accumulator,
+          Vector V1, Vector V2>
 auto dot_real(const V1& v1, const V2& v2) {
     assert(v1.size() == v2.size());
+    if constexpr (!std::is_void_v<Accumulator>) {
+        using Value = std::common_type_t<typename V1::value_type, typename V2::value_type>;
+        using AT = math::accumulator_traits<Accumulator, Value>;
+        Accumulator acc{};
+        AT::clear(acc);
+        for (typename V1::size_type i = 0; i < v1.size(); ++i)
+            AT::add_product(acc, static_cast<Value>(v1(i)), static_cast<Value>(v2(i)));
+        return AT::template value<Result>(acc);
+    } else {
 #ifdef MTL5_HAS_BLAS
     if constexpr (interface::BlasDenseVector<V1> && interface::BlasDenseVector<V2>) {
         if (v1.size() <= static_cast<std::size_t>(std::numeric_limits<int>::max())) {
@@ -71,6 +105,7 @@ auto dot_real(const V1& v1, const V2& v2) {
             acc += v1(i) * v2(i);
         }
         return acc;
+    }
     }
 }
 

--- a/tests/unit/operation/test_dot_accumulator.cpp
+++ b/tests/unit/operation/test_dot_accumulator.cpp
@@ -1,0 +1,59 @@
+// MTL5 -- mixed-precision accumulator/result policy for dot (issue #159).
+// dot<Accumulator,Result>(a,b) sums the products in Accumulator precision (which
+// may differ from the element type) and rounds out to Result -- the dot-product
+// instance of the Element -> Accumulate -> Result model behind the BLAS epic #157.
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <cmath>
+#include <cstddef>
+#include <type_traits>
+
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/operation/dot.hpp>
+
+using namespace mtl;
+using Catch::Matchers::WithinRel;
+
+TEST_CASE("dot default behavior is unchanged", "[operation][dot][accumulator]") {
+    vec::dense_vector<double> a = {1.0, 2.0, 3.0}, b = {4.0, 5.0, 6.0};
+    REQUIRE_THAT(dot(a, b), WithinRel(32.0, 1e-12));      // 4+10+18
+    REQUIRE_THAT(dot_real(a, b), WithinRel(32.0, 1e-12));
+}
+
+TEST_CASE("dot accumulator/result types are honored", "[operation][dot][accumulator]") {
+    vec::dense_vector<float> a = {1.0f, 2.0f, 3.0f}, b = {4.0f, 5.0f, 6.0f};
+    // fp32 elements, fp64 accumulate -> result defaults to the accumulator type.
+    auto s = dot<double>(a, b);
+    static_assert(std::is_same_v<decltype(s), double>);
+    REQUIRE_THAT(s, WithinRel(32.0, 1e-12));
+    // Explicit result type rounds the accumulator out to float.
+    auto sf = dot<double, float>(a, b);
+    static_assert(std::is_same_v<decltype(sf), float>);
+    REQUIRE_THAT(sf, WithinRel(32.0f, 1e-6f));
+}
+
+TEST_CASE("dot fp64 accumulator beats fp32 accumulation on a cancellation-prone sum",
+          "[operation][dot][accumulator]") {
+    // A long sum with a small true value relative to the partial sums: float
+    // accumulation loses digits a double accumulator recovers.
+    const std::size_t n = 100000;
+    vec::dense_vector<float> a(n), b(n);
+    for (std::size_t i = 0; i < n; ++i) {
+        a(static_cast<int>(i)) = 1.0f;
+        b(static_cast<int>(i)) = (i % 2 == 0) ? 1.0f : -1.0f + 1.0e-6f;  // ~cancels
+    }
+    // exact-ish reference in double
+    double ref = 0.0;
+    for (std::size_t i = 0; i < n; ++i)
+        ref += static_cast<double>(a(static_cast<int>(i))) * static_cast<double>(b(static_cast<int>(i)));
+
+    float  naive = dot<float>(a, b);     // fp32 accumulate (via the policy path)
+    double wide  = dot<double>(a, b);    // fp64 accumulate
+
+    double err_naive = std::abs(static_cast<double>(naive) - ref);
+    double err_wide  = std::abs(wide - ref);
+    INFO("ref = " << ref << ", naive(f32) err = " << err_naive << ", wide(f64) err = " << err_wide);
+    REQUIRE(err_wide <= err_naive);
+    REQUIRE(err_wide < 1e-6);
+}


### PR DESCRIPTION
First per-operation slice of the mixed-precision tensor-ops epic (#157), on the merged #158 foundation.

## What
`dot` / `dot_real` gain optional `Accumulator` and `Result` template parameters:
```cpp
float  s  = dot<float>(a, b);          // bf16/fp32 elements, fp32 accumulate, fp32 result
auto   sf = dot<double, float>(a, b);  // fp64 accumulate, rounded out to fp32
dot(a, b);                             // unchanged: BLAS/SIMD fast path or common-type loop
```
- `Accumulator = void` (default) → **today's behavior exactly**.
- Otherwise the products are summed via `mtl::math::accumulator_traits` in `Accumulator` precision and rounded out to `Result` (default = the accumulator type). Scalar path; SIMD variant is #165.

Also promotes `accumulator_traits::add_product` to form the product in the accumulator precision (`static_cast<Acc>(m)*static_cast<Acc>(v)`) — a no-op cast / byte-identical when `Acc == Value`, so **fp32-accumulate-over-bf16 gains accuracy out of the box** without a custom specialization.

## Tests
Default behavior unchanged; accumulator/result types (and return type) honored; **fp64 accumulate beats fp32 on a cancellation-prone sum (err 3e-3 → 0)**. The sparse suite (trait with `Acc==Value`) is byte-identical; ASan/UBSan clean.

Part of #157; next up #161 (gemm) and #163 (dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended dot and dot_real product functions with optional accumulator and result type template parameters, enabling fine-grained control over mixed-precision computation workflows.

* **Improvements**
  * Enhanced precision management in dot product calculations through improved type casting and accumulation strategies, reducing numerical errors in mixed-precision computation scenarios.
  * Strengthened accumulation logic for improved accuracy and consistency across different precision levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->