### PR TITLE
feat(operation): accumulator policy for gemm/mult; result type from C (#161)

### DIFF
--- a/include/mtl/operation/mult.hpp
+++ b/include/mtl/operation/mult.hpp
@@ -2,9 +2,11 @@
 // MTL5 -- Matrix multiplication: mat*vec and mat*mat into pre-allocated output
 // Optional BLAS dispatch when MTL5_HAS_BLAS is defined and types qualify.
 #include <cassert>
+#include <type_traits>
 #include <mtl/concepts/matrix.hpp>
 #include <mtl/concepts/vector.hpp>
 #include <mtl/math/identity.hpp>
+#include <mtl/math/accumulator_traits.hpp>
 #include <mtl/interface/dispatch_traits.hpp>
 #ifdef MTL5_HAS_BLAS
 #include <mtl/interface/blas.hpp>
@@ -33,17 +35,38 @@ void mult_generic(const M& A, const VIn& x, VOut& y) {
     }
 }
 
-/// Generic mat*mat: C = A * B
-template <Matrix MA, Matrix MB, Matrix MC>
+/// Generic mat*mat: C = A * B.
+///
+/// With `Accumulator = void` (default) each C element is summed in C's own value
+/// type (unchanged). With an explicit `Accumulator`, the inner product is summed
+/// in that precision via mtl::math::accumulator_traits and the result is rounded
+/// out (fused convert) to C's element type on store -- the Element -> Accumulate
+/// -> Result model, with the result type inferred from C.
+template <typename Accumulator = void, Matrix MA, Matrix MB, Matrix MC>
 void mult_generic(const MA& A, const MB& B, MC& C) {
-    using T = typename MC::value_type;
-    for (typename MC::size_type r = 0; r < C.num_rows(); ++r) {
-        for (typename MC::size_type c = 0; c < C.num_cols(); ++c) {
-            auto acc = math::zero<T>();
-            for (typename MA::size_type k = 0; k < A.num_cols(); ++k) {
-                acc += A(r, k) * B(k, c);
+    using Result = typename MC::value_type;
+    if constexpr (std::is_void_v<Accumulator>) {
+        for (typename MC::size_type r = 0; r < C.num_rows(); ++r) {
+            for (typename MC::size_type c = 0; c < C.num_cols(); ++c) {
+                auto acc = math::zero<Result>();
+                for (typename MA::size_type k = 0; k < A.num_cols(); ++k) {
+                    acc += A(r, k) * B(k, c);
+                }
+                C(r, c) = acc;
             }
-            C(r, c) = acc;
+        }
+    } else {
+        using Value = std::common_type_t<typename MA::value_type, typename MB::value_type>;
+        using AT = math::accumulator_traits<Accumulator, Value>;
+        for (typename MC::size_type r = 0; r < C.num_rows(); ++r) {
+            for (typename MC::size_type c = 0; c < C.num_cols(); ++c) {
+                Accumulator acc{};
+                AT::clear(acc);
+                for (typename MA::size_type k = 0; k < A.num_cols(); ++k) {
+                    AT::add_product(acc, static_cast<Value>(A(r, k)), static_cast<Value>(B(k, c)));
+                }
+                C(r, c) = AT::template value<Result>(acc);   // fused convert to C's type
+            }
         }
     }
 }
@@ -101,12 +124,26 @@ void mult(const M& A, const VIn& x, VOut& y) {
     detail::mult_generic(A, x, y);
 }
 
-/// mat*mat multiply into pre-allocated C: C = A * B
-template <Matrix MA, Matrix MB, Matrix MC>
+/// mat*mat multiply into pre-allocated C: C = A * B.
+///
+/// Mixed precision: pass an explicit `Accumulator` to sum each C element in a
+/// precision distinct from the operand element type (e.g. `mult<float>(A, B, C)`
+/// with bfloat16 A/B accumulates in fp32); the accumulator is rounded out to C's
+/// element type on store, so C's type selects the output precision. The default
+/// `Accumulator = void` keeps the BLAS / native-fast / generic dispatch
+/// unchanged. The mixed path is the generic kernel (scalar; SIMD is #165).
+template <typename Accumulator = void, Matrix MA, Matrix MB, Matrix MC>
 void mult(const MA& A, const MB& B, MC& C) {
     assert(A.num_cols() == B.num_rows());
     assert(A.num_rows() == C.num_rows());
     assert(B.num_cols() == C.num_cols());
+
+    if constexpr (!std::is_void_v<Accumulator>) {
+        // Custom accumulator: external BLAS / native-fast GEMM use hardware-fixed
+        // accumulation, so route to the accumulator-aware generic kernel.
+        detail::mult_generic<Accumulator>(A, B, C);
+        return;
+    } else {
 
 #ifdef MTL5_HAS_BLAS
     if constexpr (interface::BlasDenseMatrix<MA> &&
@@ -169,6 +206,7 @@ void mult(const MA& A, const MB& B, MC& C) {
     }
 #endif
     detail::mult_generic(A, B, C);
+    }
 }
 
 } // namespace mtl

--- a/tests/unit/operation/test_gemm_accumulator.cpp
+++ b/tests/unit/operation/test_gemm_accumulator.cpp
@@ -1,0 +1,67 @@
+// MTL5 -- mixed-precision accumulator policy for GEMM (issue #161).
+// mult<Accumulator>(A, B, C) sums each C element in Accumulator precision and
+// rounds out to C's element type on store -- the result type is inferred from C
+// (the Element -> Accumulate -> Result model, headline kernel of epic #157).
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/operation/mult.hpp>
+
+using namespace mtl;
+using Catch::Matchers::WithinRel;
+
+namespace {
+// Deterministic fill with mixed magnitudes / signs so the inner products have
+// cancellation that low-precision accumulation loses.
+template <typename T>
+mat::dense2D<T> filled(std::size_t m, std::size_t n, int seed) {
+    mat::dense2D<T> A(m, n);
+    for (std::size_t i = 0; i < m; ++i)
+        for (std::size_t j = 0; j < n; ++j)
+            A(i, j) = static_cast<T>(std::sin(static_cast<double>((i * 13 + j * 7 + seed) % 97)));
+    return A;
+}
+} // namespace
+
+TEST_CASE("gemm default behavior is unchanged", "[operation][gemm][accumulator]") {
+    mat::dense2D<double> A(2, 3), B(3, 2), C(2, 2);
+    A(0, 0)=1; A(0, 1)=2; A(0, 2)=3; A(1, 0)=4; A(1, 1)=5; A(1, 2)=6;
+    B(0, 0)=7; B(0, 1)=8; B(1, 0)=9; B(1, 1)=10; B(2, 0)=11; B(2, 1)=12;
+    mult(A, B, C);
+    REQUIRE_THAT(C(0, 0), WithinRel(58.0, 1e-12));   // 7+18+33
+    REQUIRE_THAT(C(1, 1), WithinRel(154.0, 1e-12));  // 32+50+72
+}
+
+TEST_CASE("gemm accumulator precision is independent of element/result type",
+          "[operation][gemm][accumulator]") {
+    // fp32 operands, fp32 result tensor, but fp64 accumulation.
+    const std::size_t m = 8, k = 200, n = 6;
+    auto Af = filled<float>(m, k, 1);
+    auto Bf = filled<float>(k, n, 2);
+    auto Ad = filled<double>(m, k, 1);   // same values, double
+    auto Bd = filled<double>(k, n, 2);
+
+    mat::dense2D<double> Cref(m, n);
+    mult(Ad, Bd, Cref);                  // double reference
+
+    mat::dense2D<float> Cnaive(m, n);
+    mult(Af, Bf, Cnaive);                // fp32 accumulate (default)
+
+    mat::dense2D<float> Cwide(m, n);
+    mult<double>(Af, Bf, Cwide);         // fp64 accumulate, fp32 result (from C)
+
+    double err_naive = 0.0, err_wide = 0.0;
+    for (std::size_t i = 0; i < m; ++i)
+        for (std::size_t j = 0; j < n; ++j) {
+            double ref = Cref(i, j);
+            err_naive = std::max(err_naive, std::abs(static_cast<double>(Cnaive(i, j)) - ref));
+            err_wide  = std::max(err_wide,  std::abs(static_cast<double>(Cwide(i, j))  - ref));
+        }
+    INFO("naive(f32-acc) err = " << err_naive << ", wide(f64-acc) err = " << err_wide);
+    REQUIRE(err_wide <= err_naive);   // fp64 accumulate is at least as accurate
+}


### PR DESCRIPTION
The headline kernel of the mixed-precision tensor-ops epic (#157), on the #158 foundation + the #159 dot pattern.

## What
`mult(A, B, C)` gains an optional `Accumulator` template parameter:
```cpp
mult(A, B, C);                          // unchanged: BLAS / native-fast / generic
mult<float>(A_bf16, B_bf16, C_bf16);    // accumulate in fp32, write bf16 once
```
- Each C element is summed in `Accumulator` precision via `mtl::math::accumulator_traits`, then **rounded out (fused convert) to C's element type on store** — so **C's type selects the output precision** (Element → Accumulate → Result, result inferred from C). No separate downcast pass.
- `Accumulator = void` (default) preserves the **full BLAS / native-fast / generic dispatch unchanged**; the custom-accumulator case routes to the accumulator-aware generic kernel (external BLAS / blocked GEMM use hardware-fixed accumulation). Scalar path; SIMD/threaded mixed-accumulate is #165.

## Tests
Default GEMM unchanged; fp64 accumulate over fp32 operands into an fp32 result is at least as accurate as fp32 accumulation (err **6.5e-6 → 1.2e-6**). Existing `gemm_blocked` / `gemm_mt` / `fast_gemm_numeric` suites pass unchanged (**12k+ assertions**); ASan/UBSan clean.

Part of #157. Remaining: #160 gemv · #162 norms · #163 dispatch · #164 convert · #165 SIMD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced mixed-precision accumulation option for matrix multiplication, enabling intermediate calculations in higher precision for improved numerical accuracy.

* **Tests**
  * Added unit tests validating mixed-precision accumulator functionality and accuracy improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->