### PR TITLE
feat(interface): dispatch rule -- custom accumulator forces native kernel (#163)

### DIFF
--- a/include/mtl/interface/dispatch_traits.hpp
+++ b/include/mtl/interface/dispatch_traits.hpp
@@ -13,6 +13,17 @@ template <typename T>
 inline constexpr bool is_blas_scalar_v =
     std::is_same_v<T, float> || std::is_same_v<T, double>;
 
+/// Whether the requested accumulator policy permits a hardware-fixed BLAS /
+/// native-fast path. External BLAS/LAPACK (and the blocked native GEMM)
+/// accumulate inner products in a fixed precision and cannot honor a
+/// caller-selected accumulator or result type, so ANY non-default accumulator
+/// (`Accumulator != void`) MUST fall to the native (generic) kernel -- even for
+/// float/double operands (e.g. a double accumulator over float storage). The
+/// default `void` selects today's accelerated dispatch. Operations gate their
+/// BLAS path on this predicate.
+template <typename Accumulator>
+inline constexpr bool accumulator_allows_blas_v = std::is_void_v<Accumulator>;
+
 /// Concept satisfied by dense matrix types eligible for BLAS/LAPACK dispatch.
 /// Requires: float/double value_type, contiguous data() pointer, num_rows/num_cols.
 template <typename M>

--- a/include/mtl/operation/dot.hpp
+++ b/include/mtl/operation/dot.hpp
@@ -32,7 +32,7 @@ template <typename Accumulator = void, typename Result = Accumulator,
           Vector V1, Vector V2>
 auto dot(const V1& v1, const V2& v2) {
     assert(v1.size() == v2.size());
-    if constexpr (!std::is_void_v<Accumulator>) {
+    if constexpr (!interface::accumulator_allows_blas_v<Accumulator>) {
         using Value = std::common_type_t<typename V1::value_type, typename V2::value_type>;
         using AT = math::accumulator_traits<Accumulator, Value>;
         Accumulator acc{};
@@ -78,7 +78,7 @@ template <typename Accumulator = void, typename Result = Accumulator,
           Vector V1, Vector V2>
 auto dot_real(const V1& v1, const V2& v2) {
     assert(v1.size() == v2.size());
-    if constexpr (!std::is_void_v<Accumulator>) {
+    if constexpr (!interface::accumulator_allows_blas_v<Accumulator>) {
         using Value = std::common_type_t<typename V1::value_type, typename V2::value_type>;
         using AT = math::accumulator_traits<Accumulator, Value>;
         Accumulator acc{};

--- a/include/mtl/operation/mult.hpp
+++ b/include/mtl/operation/mult.hpp
@@ -138,7 +138,7 @@ void mult(const MA& A, const MB& B, MC& C) {
     assert(A.num_rows() == C.num_rows());
     assert(B.num_cols() == C.num_cols());
 
-    if constexpr (!std::is_void_v<Accumulator>) {
+    if constexpr (!interface::accumulator_allows_blas_v<Accumulator>) {
         // Custom accumulator: external BLAS / native-fast GEMM use hardware-fixed
         // accumulation, so route to the accumulator-aware generic kernel.
         detail::mult_generic<Accumulator>(A, B, C);

--- a/tests/unit/operation/test_accumulator_dispatch.cpp
+++ b/tests/unit/operation/test_accumulator_dispatch.cpp
@@ -1,0 +1,76 @@
+// MTL5 -- dispatch rule: a non-default accumulator forces the native kernel (#163).
+// External BLAS / native-fast paths use hardware-fixed accumulation, so any
+// custom accumulator must bypass them -- even for float/double operands. Proven
+// with a "counting" accumulator: if the result equals the contraction count, the
+// native (generic) accumulator path was taken; a BLAS path would compute A*B.
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstddef>
+#include <type_traits>
+
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/operation/dot.hpp>
+#include <mtl/operation/mult.hpp>
+#include <mtl/interface/dispatch_traits.hpp>
+
+namespace {
+// Accumulator that counts the number of products instead of summing them.
+struct count_acc { long n = 0; };
+} // namespace
+
+namespace mtl::math {
+template <>
+struct accumulator_traits<count_acc, float> {
+    static void clear(count_acc& a) { a.n = 0; }
+    static void assign(count_acc& a, const float&) { a.n = 1; }
+    template <typename Result = float>
+    static Result value(const count_acc& a) { return static_cast<Result>(a.n); }
+    static void add_product(count_acc& a, const float&, const float&) { ++a.n; }
+};
+} // namespace mtl::math
+
+using namespace mtl;
+
+TEST_CASE("accumulator_allows_blas_v: only the default void permits BLAS",
+          "[operation][dispatch][accumulator]") {
+    static_assert(interface::accumulator_allows_blas_v<void>);
+    static_assert(!interface::accumulator_allows_blas_v<float>);
+    static_assert(!interface::accumulator_allows_blas_v<double>);
+    static_assert(!interface::accumulator_allows_blas_v<count_acc>);
+    SUCCEED();
+}
+
+TEST_CASE("dot with a custom accumulator bypasses BLAS (float operands)",
+          "[operation][dispatch][accumulator]") {
+    vec::dense_vector<float> a = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+    vec::dense_vector<float> b = {9.0f, 9.0f, 9.0f, 9.0f, 9.0f};
+    // A BLAS ?dot would return the sum of products (= 135). The counting
+    // accumulator returns 5 only if the native accumulator path was taken.
+    auto cnt = dot<count_acc, long>(a, b);
+    static_assert(std::is_same_v<decltype(cnt), long>);
+    REQUIRE(cnt == 5);
+    // Default path still computes the real dot product.
+    REQUIRE(dot(a, b) == 135.0f);
+}
+
+TEST_CASE("gemm with a custom accumulator bypasses BLAS/native-fast (float operands)",
+          "[operation][dispatch][accumulator]") {
+    const std::size_t m = 4, k = 7, n = 3;
+    mat::dense2D<float> A(m, k), B(k, n), C(m, n);
+    for (std::size_t i = 0; i < m; ++i) for (std::size_t j = 0; j < k; ++j) A(i, j) = 2.0f;
+    for (std::size_t i = 0; i < k; ++i) for (std::size_t j = 0; j < n; ++j) B(i, j) = 3.0f;
+
+    // BLAS/native-fast would give C(i,j) = k * 2 * 3 = 42. The counting
+    // accumulator gives C(i,j) = k (one count per contraction step) iff the
+    // generic accumulator kernel ran instead.
+    mult<count_acc>(A, B, C);
+    for (std::size_t i = 0; i < m; ++i)
+        for (std::size_t j = 0; j < n; ++j)
+            REQUIRE(C(i, j) == static_cast<float>(k));
+
+    // Default path still computes the real product.
+    mat::dense2D<float> Cd(m, n);
+    mult(A, B, Cd);
+    REQUIRE(Cd(0, 0) == 42.0f);
+}


### PR DESCRIPTION
Locks down the float/double correctness guarantee for the mixed-precision tensor-ops epic (#157): a non-default accumulator must never silently fall through to external BLAS (which ignores it).

## What
- New **`interface::accumulator_allows_blas_v<Accumulator>`** — a named, documented predicate: external BLAS/LAPACK and the blocked native-fast GEMM accumulate in hardware-fixed precision and cannot honor a caller-selected accumulator/result type, so **any non-default accumulator must use the native kernel — even for float/double operands** (e.g. a double accumulator over float storage). Default `void` keeps the accelerated dispatch.
- `dot` and `mult` now gate their BLAS/native-fast path on this predicate instead of an ad-hoc `is_void` check (behavior unchanged, rule centralized).

## Proof
A counting accumulator (returns the contraction count, not the sum) makes the path observable on **float** operands:
- `dot<count_acc,long>(a,b)` returns **5, not 135** (the BLAS sum)
- `mult<count_acc>(A,B,C)` returns **k, not 42** (the BLAS product)

→ the custom-accumulator path provably bypasses BLAS; the default path still computes the real product. Static asserts pin the predicate values. dot/gemm regression suites pass unchanged (**11k+ assertions**); ASan/UBSan clean.

Part of #157. Remaining: #160 gemv · #162 norms · #164 convert · #165 SIMD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved accumulator dispatch mechanism for dot product and matrix multiplication operations, enabling refined control over optimization path selection based on accumulator type configuration.

* **Tests**
  * Added comprehensive test coverage validating accumulator dispatch behavior across linear algebra operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->