### PR TITLE
feat(operation): standalone tensor convert/cast operator (#164)

### DIFF
--- a/include/mtl/mtl.hpp
+++ b/include/mtl/mtl.hpp
@@ -147,6 +147,7 @@
 #include <mtl/operation/num_rows.hpp>
 #include <mtl/operation/num_cols.hpp>
 #include <mtl/operation/dot.hpp>
+#include <mtl/operation/convert.hpp>
 #include <mtl/operation/axpy.hpp>
 #include <mtl/operation/sum.hpp>
 #include <mtl/operation/product.hpp>

--- a/include/mtl/operation/convert.hpp
+++ b/include/mtl/operation/convert.hpp
@@ -1,0 +1,59 @@
+#pragma once
+// MTL5 -- element-wise tensor convert/cast between number types (issue #164)
+//
+// A standalone re-quantization operator: copy a dense vector or matrix into a
+// different element type (e.g. fp32 -> bfloat16 to stage a tensor at lower
+// precision between kernels, or a low-precision tensor up to fp64 for analysis).
+//
+// IMPORTANT: this is for NON-FUSED re-typing. It is *not* the accumulate->output
+// path -- a mixed-precision dot/gemv/gemm fuses the accumulator->result
+// conversion into its final store (see mtl::math::accumulator_traits::value and
+// the Accumulator/Result parameters on dot/mult). Reach for `convert` only when
+// you genuinely need a separate pass over a stored tensor.
+
+#include <cassert>
+#include <cstddef>
+#include <mtl/concepts/vector.hpp>
+#include <mtl/concepts/matrix.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/mat/dense2D.hpp>
+
+namespace mtl {
+
+/// Convert a vector into a pre-allocated destination of (possibly) another type.
+template <Vector VSrc, Vector VDst>
+void convert(const VSrc& src, VDst& dst) {
+    assert(static_cast<std::size_t>(src.size()) == static_cast<std::size_t>(dst.size()));
+    using D = typename VDst::value_type;
+    for (typename VSrc::size_type i = 0; i < src.size(); ++i)
+        dst(static_cast<int>(i)) = static_cast<D>(src(static_cast<int>(i)));
+}
+
+/// Convert a matrix into a pre-allocated destination of (possibly) another type.
+template <Matrix MSrc, Matrix MDst>
+void convert(const MSrc& src, MDst& dst) {
+    assert(src.num_rows() == dst.num_rows());
+    assert(src.num_cols() == dst.num_cols());
+    using D = typename MDst::value_type;
+    for (typename MSrc::size_type r = 0; r < src.num_rows(); ++r)
+        for (typename MSrc::size_type c = 0; c < src.num_cols(); ++c)
+            dst(r, c) = static_cast<D>(src(r, c));
+}
+
+/// Convert a vector to a new dense_vector<DstValue> (out-of-place convenience).
+template <typename DstValue, Vector VSrc>
+vec::dense_vector<DstValue> convert(const VSrc& src) {
+    vec::dense_vector<DstValue> dst(static_cast<typename vec::dense_vector<DstValue>::size_type>(src.size()));
+    convert(src, dst);
+    return dst;
+}
+
+/// Convert a matrix to a new dense2D<DstValue> (out-of-place convenience).
+template <typename DstValue, Matrix MSrc>
+mat::dense2D<DstValue> convert(const MSrc& src) {
+    mat::dense2D<DstValue> dst(src.num_rows(), src.num_cols());
+    convert(src, dst);
+    return dst;
+}
+
+} // namespace mtl

--- a/tests/unit/operation/test_convert.cpp
+++ b/tests/unit/operation/test_convert.cpp
@@ -1,0 +1,56 @@
+// MTL5 -- element-wise tensor convert/cast (issue #164).
+// Non-fused re-quantization of a stored dense vector/matrix between number types.
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <cstddef>
+#include <type_traits>
+
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/operation/convert.hpp>
+
+using namespace mtl;
+using Catch::Matchers::WithinRel;
+
+TEST_CASE("convert vector out-of-place to a new element type", "[operation][convert]") {
+    vec::dense_vector<double> v = {1.0, 2.5, -3.0, 4.25};
+    auto f = convert<float>(v);
+    static_assert(std::is_same_v<decltype(f)::value_type, float>);
+    REQUIRE(f.size() == v.size());
+    for (std::size_t i = 0; i < v.size(); ++i)
+        REQUIRE(f(static_cast<int>(i)) == static_cast<float>(v(static_cast<int>(i))));
+}
+
+TEST_CASE("convert vector in-place into a preallocated destination", "[operation][convert]") {
+    vec::dense_vector<float> src = {1.5f, 2.5f, 3.5f};
+    vec::dense_vector<double> dst(3, 0.0);
+    convert(src, dst);
+    REQUIRE_THAT(dst(0), WithinRel(1.5, 1e-12));
+    REQUIRE_THAT(dst(2), WithinRel(3.5, 1e-12));
+}
+
+TEST_CASE("convert matrix out-of-place and in-place", "[operation][convert]") {
+    mat::dense2D<double> A(2, 2);
+    A(0,0)=1.0; A(0,1)=2.0; A(1,0)=3.0; A(1,1)=4.0;
+
+    auto Af = convert<float>(A);
+    static_assert(std::is_same_v<decltype(Af)::value_type, float>);
+    REQUIRE(Af.num_rows() == 2);
+    REQUIRE(Af(1,1) == 4.0f);
+
+    mat::dense2D<double> B(2, 2);
+    convert(Af, B);                 // float -> double, in-place
+    REQUIRE_THAT(B(0,1), WithinRel(2.0, 1e-12));
+    REQUIRE_THAT(B(1,0), WithinRel(3.0, 1e-12));
+}
+
+TEST_CASE("convert round-trip through a narrower type loses precision as expected",
+          "[operation][convert]") {
+    // A value not representable in float: round-tripping double->float->double
+    // changes it, confirming convert performs a real element cast (not a bit-copy).
+    vec::dense_vector<double> v = {1.0 + 1e-12};
+    auto back = convert<double>(convert<float>(v));
+    REQUIRE(back(0) != v(0));
+    REQUIRE_THAT(back(0), WithinRel(1.0, 1e-6));
+}


### PR DESCRIPTION
The complementary (non-fused) re-quantization operator for the mixed-precision tensor-ops epic (#157).

## What
`mtl::convert` — element-wise cast of a dense vector or matrix between number types:
```cpp
convert(src, dst);              // in-place into a preallocated dst (any type/layout)
auto d = convert<float>(src);   // out-of-place -> new dense_vector / dense2D<float>
```
Use it to stage a tensor at lower precision between kernels, or widen a low-precision tensor for analysis.

## Explicitly NOT the accumulate→output path
A mixed-precision `dot`/`gemv`/`gemm` **fuses** the accumulator→result conversion into its final store (`accumulator_traits::value` + the `Accumulator`/`Result` parameters, #159/#160/#161) — writing the output once in the small type. `convert` is for the cases where you genuinely need a **separate pass**; the header says so prominently.

## Tests
Vector + matrix, in-place + out-of-place, and a double→float→double round-trip confirming a real element cast (not a bit-copy). ASan/UBSan clean; `mtl.hpp` umbrella compiles with it wired in.

Part of #157 — the last functional piece. Remaining: #165 (SIMD fast path, perf).

🤖 Generated with [Claude Code](https://claude.com/claude-code)