### PR TITLE
feat(sparse): opt-in zero-pivot perturbation for low-precision robustness (#123)

### DIFF
--- a/include/mtl/sparse/factorization/native_klu.hpp
+++ b/include/mtl/sparse/factorization/native_klu.hpp
@@ -53,6 +53,7 @@ struct klu_numeric {
     std::vector<lu_numeric<Value>> block_numeric; ///< LU of each diagonal block
     std::vector<Value>            row_scale;      ///< r[orig row]; empty = unscaled
                                                   ///< (factored R*A, so solve scales b)
+    std::size_t                   num_perturbed = 0; ///< total perturbed pivots across blocks (0 = clean)
 
     std::size_t num_rows() const { return btf.row_perm.size(); }
     std::size_t num_cols() const { return num_rows(); }
@@ -124,16 +125,25 @@ struct klu_numeric {
 /// ordinary arithmetic, while a caller can inject an exact/extended-precision
 /// accumulator (e.g. a super-accumulator) for the inner products of every block.
 ///
+/// The optional `pivot_perturb` (default 0 = off) enables opt-in zero-pivot
+/// perturbation in each block's LU (see sparse_lu_numeric): a pivot that
+/// cancellation has driven below `pivot_perturb * ||column||` is replaced by that
+/// floor instead of failing. This keeps a low-precision factorization going on
+/// stiff blocks; `klu_numeric::num_perturbed` reports how many pivots were
+/// perturbed, and the result is meant to be cleaned up by iterative refinement.
+///
 /// \throws std::invalid_argument if A is not square.
 /// \throws std::runtime_error    if A is structurally singular (no perfect
 ///                               matching) or a diagonal block is numerically
-///                               singular.
+///                               singular and perturbation is off (or the block's
+///                               pivot column is numerically zero).
 template <typename Value, typename Parameters, typename Accumulator = Value>
     requires OrderedField<Value>
 klu_numeric<Value> native_klu_factor(
     const mat::compressed2D<Value, Parameters>& A,
     Value threshold = Value{1},
-    bool scale = true)
+    bool scale = true,
+    Value pivot_perturb = Value{0})
 {
     using std::abs;  // ADL for custom number types
     if (A.num_rows() != A.num_cols()) {
@@ -248,7 +258,8 @@ klu_numeric<Value> native_klu_factor(
         // Accumulator policy can be specified explicitly (it is not deducible).
         using block_params = typename decltype(block)::param_type;
         result.block_numeric.push_back(
-            sparse_lu_numeric<Value, block_params, Accumulator>(block, sym, threshold));
+            sparse_lu_numeric<Value, block_params, Accumulator>(block, sym, threshold, pivot_perturb));
+        result.num_perturbed += result.block_numeric.back().num_perturbed;
     }
 
     return result;

--- a/include/mtl/sparse/factorization/sparse_lu.hpp
+++ b/include/mtl/sparse/factorization/sparse_lu.hpp
@@ -493,6 +493,7 @@ lu_numeric<Value> sparse_lu_refactor(
 
     const auto& pinv = prev.row_pinv;    // original row -> pivot position (fixed)
     lu_numeric<Value> result = prev;     // reuse pattern + perms + symbolic
+    result.num_perturbed = 0;            // refactor recomputes values without perturbing (throws on zero pivot)
     auto& L = result.L;                  // overwrite values in place
     auto& U = result.U;
 

--- a/include/mtl/sparse/factorization/sparse_lu.hpp
+++ b/include/mtl/sparse/factorization/sparse_lu.hpp
@@ -66,6 +66,7 @@ struct lu_numeric {
     util::csc_matrix<Value> U;           // upper triangular factor (CSC)
     std::vector<std::size_t> row_perm;   // row permutation from pivoting (p[new]=old)
     std::vector<std::size_t> row_pinv;   // inverse row permutation
+    std::size_t num_perturbed = 0;       // pivots replaced by perturbation (0 = clean factor)
     lu_symbolic symbolic;                // symbolic analysis used
 
     std::size_t num_rows() const { return symbolic.n; }
@@ -176,15 +177,27 @@ struct accumulator_traits : mtl::math::accumulator_traits<Acc, Value> {};
 ///                  is acceptable if |a(i,k)| >= threshold * max|a(j,k)| for j>=k.
 ///                  Default 1.0 = full partial pivoting. Smaller values trade
 ///                  stability for sparsity preservation.
+/// \param pivot_perturb Opt-in zero-pivot perturbation (default 0 = off). When
+///                  > 0, a chosen pivot whose magnitude is below
+///                  `pivot_perturb * ||column||_inf` is replaced (sign-preserving)
+///                  by that floor and `num_perturbed` is incremented, instead of
+///                  throwing. This keeps a low-precision factorization going when
+///                  cancellation drives a structurally-nonzero pivot numerically
+///                  to zero; the result is meant to be cleaned up by iterative
+///                  refinement (see mtl::sparse::iterative_refine). With the
+///                  default 0, behavior is byte-identical to before (hard throw).
 /// \return          Numeric factorization result containing L, U, and permutations
 ///
-/// \throws std::runtime_error if a zero pivot is encountered (singular matrix)
+/// \throws std::runtime_error if a zero pivot is encountered and perturbation is
+///                  off, or the whole pivot column is numerically zero (truly
+///                  singular: nothing to perturb).
 template <typename Value, typename Parameters, typename Accumulator = Value>
     requires OrderedField<Value>
 lu_numeric<Value> sparse_lu_numeric(
     const mat::compressed2D<Value, Parameters>& A,
     const lu_symbolic& sym,
-    Value threshold = Value{1})
+    Value threshold = Value{1},
+    Value pivot_perturb = Value{0})
 {
     using size_type = std::size_t;
     using std::abs;  // ADL: also find abs() for custom number types (e.g. posit/cfloat)
@@ -243,6 +256,7 @@ lu_numeric<Value> sparse_lu_numeric(
     std::vector<idx32> Ui;  std::vector<Value> Ux;
     Li.reserve(C.values.size() * 2); Lx.reserve(C.values.size() * 2);
     Ui.reserve(C.values.size() * 2); Ux.reserve(C.values.size() * 2);
+    std::size_t num_perturbed = 0;     // count of perturbed pivots (pivot_perturb > 0)
 
     for (size_type k = 0; k < n; ++k) {
         Lp[k] = Li.size();
@@ -302,20 +316,28 @@ lu_numeric<Value> sparse_lu_numeric(
         }
 
         // --- threshold partial pivoting + emit U(:,k) for already-pivotal rows ---
-        Value a = Value{0};
+        Value a = Value{0};                                // max |candidate|
+        Value colnorm = Value{0};                          // ||column k||_inf over the reach
         std::ptrdiff_t ipiv = -1;
         bool have = false;
         for (size_type px = top; px < n; ++px) {
             std::ptrdiff_t i = xi[px];
+            Value mag = abs(AT::value(x[i]));
+            if (mag > colnorm) colnorm = mag;
             if (pinv[i] < 0) {                             // pivot candidate / L entry
-                Value t = abs(AT::value(x[i]));
-                if (!have || t > a) { a = t; ipiv = i; have = true; }
+                if (!have || mag > a) { a = mag; ipiv = i; have = true; }
             } else {                                       // U(pinv[i], k)
                 Ui.push_back(pinv[i]);
                 Ux.push_back(AT::value(x[i]));
             }
         }
-        if (ipiv < 0 || a == Value{0}) {
+        const bool perturb = pivot_perturb > Value{0};
+        if (ipiv < 0) {                                    // no candidate row at all
+            throw std::runtime_error(
+                "sparse_lu_numeric: zero pivot at column " + std::to_string(k)
+                + " (matrix is singular)");
+        }
+        if (!perturb && a == Value{0}) {                   // default: hard throw, unchanged
             throw std::runtime_error(
                 "sparse_lu_numeric: zero pivot at column " + std::to_string(k)
                 + " (matrix is singular)");
@@ -327,6 +349,21 @@ lu_numeric<Value> sparse_lu_numeric(
         }
 
         Value pivot = AT::value(x[ipiv]);
+        // Opt-in zero-pivot perturbation: if the chosen pivot has collapsed below
+        // pivot_perturb * ||column||, replace it (sign-preserving) by that floor
+        // rather than failing. A truly zero column (colnorm == 0) cannot be
+        // perturbed -- it is genuinely singular, so still throw.
+        if (perturb) {
+            const Value floor = pivot_perturb * colnorm;
+            if (abs(pivot) < floor) {
+                pivot = (pivot < Value{0}) ? -floor : floor;
+                ++num_perturbed;
+            } else if (abs(pivot) == Value{0}) {           // colnorm == 0 too
+                throw std::runtime_error(
+                    "sparse_lu_numeric: zero pivot at column " + std::to_string(k)
+                    + " (matrix is singular; pivot column is numerically zero)");
+            }
+        }
         Ui.push_back(static_cast<std::ptrdiff_t>(k));      // U(k,k) stored last
         Ux.push_back(pivot);
         pinv[ipiv] = static_cast<std::ptrdiff_t>(k);
@@ -381,6 +418,7 @@ lu_numeric<Value> sparse_lu_numeric(
 
     lu_numeric<Value> result;
     result.symbolic = sym;
+    result.num_perturbed = num_perturbed;
 
     // Row permutation: pinv[old] = position; row_perm[position] = old.
     result.row_perm.resize(n);

--- a/tests/unit/sparse/test_native_klu.cpp
+++ b/tests/unit/sparse/test_native_klu.cpp
@@ -375,3 +375,35 @@ TEST_CASE("native KLU agrees with the external SuiteSparse KLU binding",
     }
 }
 #endif
+
+// Issue #123: opt-in zero-pivot perturbation threaded through the native-KLU driver.
+TEST_CASE("native KLU zero-pivot perturbation (#123)", "[sparse][klu][native][perturb]") {
+    // A numerically singular diagonal block (structurally fine: BTF matches it).
+    mtl::mat::compressed2D<double> A(2, 2);
+    { mtl::mat::inserter<mtl::mat::compressed2D<double>> ins(A);
+      ins[0][0] << 1.0; ins[0][1] << 1.0;
+      ins[1][0] << 1.0; ins[1][1] << 1.0; }
+
+    // Default (perturbation off): hard throw on the singular block.
+    REQUIRE_THROWS_AS(native_klu_factor(A), std::runtime_error);
+
+    // Perturbation on: completes; the perturbed pivots are reported.
+    auto fac = native_klu_factor(A, /*threshold=*/1.0, /*scale=*/true, /*pivot_perturb=*/1e-8);
+    REQUIRE(fac.num_perturbed >= 1);
+    mtl::vec::dense_vector<double> b = {1.0, 2.0}, x(2, 0.0);
+    fac.solve(x, b);
+    REQUIRE(std::isfinite(x(0)));
+    REQUIRE(std::isfinite(x(1)));
+
+    // A well-conditioned matrix never perturbs, even with perturbation enabled.
+    mtl::mat::compressed2D<double> G(3, 3);
+    { mtl::mat::inserter<mtl::mat::compressed2D<double>> ins(G);
+      ins[0][0] << 4.0; ins[0][1] << 1.0;
+      ins[1][0] << 1.0; ins[1][1] << 5.0; ins[1][2] << 2.0;
+      ins[2][1] << 1.0; ins[2][2] << 6.0; }
+    auto gfac = native_klu_factor(G, 1.0, true, 1e-8);
+    REQUIRE(gfac.num_perturbed == 0);
+    mtl::vec::dense_vector<double> gb = {1.0, 2.0, 3.0}, gx(3, 0.0);
+    gfac.solve(gx, gb);
+    REQUIRE(relative_residual(G, gx, gb) < 1e-12);
+}

--- a/tests/unit/sparse/test_sparse_lu.cpp
+++ b/tests/unit/sparse/test_sparse_lu.cpp
@@ -327,6 +327,41 @@ TEST_CASE("Sparse LU zero-pivot perturbation (#123)", "[sparse][lu][perturb]") {
         REQUIRE(std::isfinite(x(1)));
     }
 
+    SECTION("truly empty pivot column still throws even with perturbation on") {
+        // Column 1 has no entries -> no pivot row to perturb (nothing to perturb):
+        // perturbation must not paper over a genuine singularity.
+        mat::compressed2D<double> A(2, 2);
+        { mat::inserter<mat::compressed2D<double>> ins(A);
+          ins[0][0] << 1.0; }
+        auto sym = factorization::sparse_lu_symbolic(A);
+        REQUIRE_THROWS_AS(
+            factorization::sparse_lu_numeric(A, sym, /*threshold=*/1.0, /*pivot_perturb=*/1e-8),
+            std::runtime_error);
+    }
+
+    SECTION("refactor reports a clean perturbation count (no stale carry-over)") {
+        // Factor a singular matrix WITH perturbation (num_perturbed >= 1), then
+        // refactor a well-conditioned same-pattern matrix: the refactor path does
+        // not perturb, so its count must reset to 0 rather than carrying prev's.
+        mat::compressed2D<double> A1(2, 2);
+        { mat::inserter<mat::compressed2D<double>> ins(A1);
+          ins[0][0] << 1.0; ins[0][1] << 1.0;
+          ins[1][0] << 1.0; ins[1][1] << 1.0; }
+        auto sym = factorization::sparse_lu_symbolic(A1);
+        auto prev = factorization::sparse_lu_numeric(A1, sym, 1.0, 1e-8);
+        REQUIRE(prev.num_perturbed >= 1);
+
+        mat::compressed2D<double> A2(2, 2);   // same pattern, well-conditioned
+        { mat::inserter<mat::compressed2D<double>> ins(A2);
+          ins[0][0] << 2.0; ins[0][1] << 1.0;
+          ins[1][0] << 1.0; ins[1][1] << 3.0; }
+        auto re = factorization::sparse_lu_refactor(A2, prev);
+        REQUIRE(re.num_perturbed == 0);       // refactor count is clean
+        vec::dense_vector<double> b = {1.0, 2.0}, x(2, 0.0);
+        re.solve(x, b);
+        REQUIRE(relative_residual(A2, x, b) < 1e-12);
+    }
+
     SECTION("nonsingular: perturbation never fires (clean factor, same accuracy)") {
         mat::compressed2D<double> A(3, 3);
         { mat::inserter<mat::compressed2D<double>> ins(A);

--- a/tests/unit/sparse/test_sparse_lu.cpp
+++ b/tests/unit/sparse/test_sparse_lu.cpp
@@ -307,3 +307,57 @@ TEST_CASE("Sparse LU symbolic reuse for same pattern", "[sparse][lu]") {
     num2.solve(x2, b);
     REQUIRE(relative_residual(A2, x2, b) < 1e-12);
 }
+
+// Issue #123: opt-in zero-pivot perturbation for low-precision robustness.
+TEST_CASE("Sparse LU zero-pivot perturbation (#123)", "[sparse][lu][perturb]") {
+    SECTION("exactly singular: default throws; perturbation completes") {
+        mat::compressed2D<double> A(2, 2);
+        { mat::inserter<mat::compressed2D<double>> ins(A);
+          ins[0][0] << 1.0; ins[0][1] << 1.0;
+          ins[1][0] << 1.0; ins[1][1] << 1.0; }
+        auto sym = factorization::sparse_lu_symbolic(A);
+
+        REQUIRE_THROWS_AS(factorization::sparse_lu_numeric(A, sym), std::runtime_error);
+
+        auto num = factorization::sparse_lu_numeric(A, sym, /*threshold=*/1.0, /*pivot_perturb=*/1e-8);
+        REQUIRE(num.num_perturbed >= 1);                 // the collapsed pivot was perturbed
+        vec::dense_vector<double> b = {1.0, 2.0}, x(2, 0.0);
+        num.solve(x, b);                                 // no throw; finite (if inexact) result
+        REQUIRE(std::isfinite(x(0)));
+        REQUIRE(std::isfinite(x(1)));
+    }
+
+    SECTION("nonsingular: perturbation never fires (clean factor, same accuracy)") {
+        mat::compressed2D<double> A(3, 3);
+        { mat::inserter<mat::compressed2D<double>> ins(A);
+          ins[0][0] << 4.0; ins[0][1] << 1.0;
+          ins[1][0] << 1.0; ins[1][1] << 5.0; ins[1][2] << 2.0;
+          ins[2][1] << 1.0; ins[2][2] << 6.0; }
+        auto sym = factorization::sparse_lu_symbolic(A);
+        auto num = factorization::sparse_lu_numeric(A, sym, /*threshold=*/1.0, /*pivot_perturb=*/1e-8);
+        REQUIRE(num.num_perturbed == 0);                 // well-conditioned -> no perturbation
+        vec::dense_vector<double> b = {1.0, 2.0, 3.0}, x(3, 0.0);
+        num.solve(x, b);
+        REQUIRE(relative_residual(A, x, b) < 1e-12);     // accuracy unaffected
+    }
+
+    SECTION("low precision (float) that throws completes when perturbed") {
+        // [[1,1],[1,1+d]] is nonsingular in double, but d = 5e-8 is below float
+        // epsilon so 1+d rounds to 1.0f and the column-1 pivot cancels to zero.
+        const double d = 5e-8;
+        mat::compressed2D<float> Af(2, 2);
+        { mat::inserter<mat::compressed2D<float>> ins(Af);
+          ins[0][0] << 1.0f; ins[0][1] << 1.0f;
+          ins[1][0] << 1.0f; ins[1][1] << static_cast<float>(1.0 + d); }
+        auto symf = factorization::sparse_lu_symbolic(Af);
+
+        REQUIRE_THROWS_AS(factorization::sparse_lu_numeric(Af, symf), std::runtime_error);
+
+        auto numf = factorization::sparse_lu_numeric(Af, symf, /*threshold=*/1.0f, /*pivot_perturb=*/1e-6f);
+        REQUIRE(numf.num_perturbed >= 1);
+        vec::dense_vector<float> bf = {2.0f, 2.0f}, xf(2, 0.0f);
+        numf.solve(xf, bf);                              // completes instead of throwing
+        REQUIRE(std::isfinite(xf(0)));
+        REQUIRE(std::isfinite(xf(1)));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds **opt-in zero-pivot perturbation** (KLU/UMFPACK style) so a low-precision factorization that would throw `zero pivot ... singular` instead **completes** with a perturbed pivot — to be cleaned up by `iterative_refine` (#119).
- **Root cause:** native KLU's per-block Gilbert–Peierls LU fails on stiff matrices in low precision (e.g. `cfloat<16,5>` on `rajat11`) when cancellation drives a structurally-nonzero pivot column numerically to zero, with no fallback.
- **Default off** (`pivot_perturb = 0`) → behavior byte-identical to before (hard throw).

## Changes
- `include/mtl/sparse/factorization/sparse_lu.hpp` — `lu_numeric::num_perturbed`; new `pivot_perturb` relative tolerance on `sparse_lu_numeric`; tracks `‖column‖∞` and, when a chosen pivot falls below `pivot_perturb · ‖column‖∞`, replaces it (sign-preserving) and counts it instead of throwing. A wholly-zero column (`colnorm == 0`) is still reported singular.
- `include/mtl/sparse/factorization/native_klu.hpp` — `klu_numeric::num_perturbed`; `pivot_perturb` param on `native_klu_factor`, threaded per block and aggregated.
- `tests/unit/sparse/test_sparse_lu.cpp`, `test_native_klu.cpp` — perturbation tests.

## Behavior
- Pivot below `pivot_perturb · ‖column‖∞` → replaced by that floor (sign-preserving), `num_perturbed++`.
- `pivot_perturb == 0` (default) → unchanged hard throw.
- Truly zero pivot column → still singular (nothing to perturb).

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| sparse_test_sparse_lu | OK | PASS (27 assertions) | OK | PASS |
| sparse_test_native_klu | OK | PASS (99 assertions) | OK | PASS |

Key cases: a float matrix nonsingular in double but whose pivot cancels to zero in float **throws without perturbation, completes with it** (`num_perturbed ≥ 1`); a well-conditioned matrix has `num_perturbed == 0` and unchanged accuracy. No regression in refactor / scaling / supernodal_lu / iterative_refine suites.

## Test plan
- [ ] Fast CI passes (gcc + clang)
- [ ] Promote to ready: `gh pr ready`

Resolves #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional pivot-perturbation setting for sparse LU and native KLU factorization, allowing some zero-pivot cases to complete successfully instead of failing.
  * Added tracking for how many pivots were perturbed during factorization.

* **Tests**
  * Added coverage for perturbation-enabled factorization on singular and well-conditioned matrices.
  * Verified solutions remain finite and residuals stay small when perturbation is not needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->