### PR TITLE
feat(sparse): zero-pivot perturbation for supernodal LU (pivot robustness, #185)

### DIFF
--- a/include/mtl/sparse/factorization/supernodal_lu.hpp
+++ b/include/mtl/sparse/factorization/supernodal_lu.hpp
@@ -67,6 +67,7 @@ struct supernodal_lu_factor {
     std::vector<std::size_t> row_pinv;     // inverse
     std::vector<std::size_t> lsuper_first; // dynamic L-supernode boundaries (size nsuper+1)
     std::vector<Value>       row_scale;    // r[orig row]; empty = unscaled (factored R*A)
+    std::size_t              num_perturbed = 0; // pivots replaced by perturbation (0 = clean factor)
     supernodal_lu_symbolic   symbolic;
 
     std::size_t num_rows() const { return symbolic.n; }
@@ -139,7 +140,17 @@ struct lu_snode {
 ///
 /// \param threshold pivoting threshold in (0,1]; 1 = full partial pivoting.
 /// \param max_super maximum supernode width (relaxation cap).
-/// \throws std::runtime_error on a singular (zero) pivot.
+/// \param scale     opt-in row equilibration (factor R*A; RHS scaled in solve()).
+/// \param pivot_perturb opt-in zero-pivot perturbation (default 0 = off). When
+///                  > 0, a chosen pivot whose magnitude is below
+///                  `pivot_perturb * ||column||_inf` is replaced (sign-preserving)
+///                  by that floor and `num_perturbed` is incremented, instead of
+///                  throwing -- keeping a low-precision factorization going when
+///                  cancellation drives a structurally-nonzero pivot numerically
+///                  to zero (clean up with iterative_refine). Default 0 is
+///                  byte-identical to before (hard throw). Mirrors sparse_lu.
+/// \throws std::runtime_error on a singular (zero) pivot when perturbation is off,
+///                  or when the whole pivot column is numerically zero.
 template <typename Value, typename Parameters, typename Accumulator = Value>
     requires OrderedField<Value>
 supernodal_lu_factor<Value> supernodal_lu_numeric(
@@ -147,7 +158,8 @@ supernodal_lu_factor<Value> supernodal_lu_numeric(
     const supernodal_lu_symbolic& sym,
     Value threshold = Value{1},
     std::size_t max_super = 64,
-    bool scale = false)
+    bool scale = false,
+    Value pivot_perturb = Value{0})
 {
     using size_type = std::size_t;
     using std::abs;
@@ -203,6 +215,7 @@ supernodal_lu_factor<Value> supernodal_lu_numeric(
     std::vector<detail::lu_snode<Value>> snodes;   // closed supernodes
     std::vector<idx32> col_csuper(n, -1);          // col -> closed supernode id (or -1 if open/unset)
     std::vector<size_type> lsuper_first;           // boundaries, recorded as supernodes close
+    std::size_t num_perturbed = 0;                 // count of perturbed pivots (pivot_perturb > 0)
     size_type open_sf = 0;                         // first column of the currently-open supernode
     std::vector<size_type> prev_cand;              // sorted orig candidate rows of column k-1
 
@@ -322,17 +335,24 @@ supernodal_lu_factor<Value> supernodal_lu_numeric(
         }
 
         // --- threshold partial pivoting + emit U(:,k) for pivotal rows ---
-        Value a = Value{0}; std::ptrdiff_t ipiv = -1; bool have = false;
+        Value a = Value{0};                          // max |candidate|
+        Value colnorm = Value{0};                    // ||column k||_inf over the reach
+        std::ptrdiff_t ipiv = -1; bool have = false;
         for (size_type px = top; px < n; ++px) {
             std::ptrdiff_t i = xi[px];
+            Value mag = abs(AT::value(x[i]));
+            if (mag > colnorm) colnorm = mag;
             if (pinv[i] < 0) {
-                Value t = abs(AT::value(x[i]));
-                if (!have || t > a) { a = t; ipiv = i; have = true; }
+                if (!have || mag > a) { a = mag; ipiv = i; have = true; }
             } else {
                 Ui.push_back(pinv[i]); Ux.push_back(AT::value(x[i]));
             }
         }
-        if (ipiv < 0 || a == Value{0})
+        const bool perturb = pivot_perturb > Value{0};
+        if (ipiv < 0)                                // no candidate row: nothing to perturb
+            throw std::runtime_error(
+                "supernodal_lu_numeric: zero pivot at column " + std::to_string(k) + " (singular)");
+        if (!perturb && a == Value{0})               // default: hard throw, unchanged
             throw std::runtime_error(
                 "supernodal_lu_numeric: zero pivot at column " + std::to_string(k) + " (singular)");
         if (pinv[static_cast<std::ptrdiff_t>(k)] < 0
@@ -340,6 +360,20 @@ supernodal_lu_factor<Value> supernodal_lu_numeric(
             ipiv = static_cast<std::ptrdiff_t>(k);
 
         Value pivot = AT::value(x[ipiv]);
+        // Opt-in zero-pivot perturbation: replace a collapsed pivot (below
+        // pivot_perturb * ||column||) sign-preservingly rather than failing. A
+        // wholly-zero column (colnorm == 0) is genuinely singular -> still throw.
+        if (perturb) {
+            const Value floor = pivot_perturb * colnorm;
+            if (abs(pivot) < floor) {
+                pivot = (pivot < Value{0}) ? -floor : floor;
+                ++num_perturbed;
+            } else if (abs(pivot) == Value{0}) {
+                throw std::runtime_error(
+                    "supernodal_lu_numeric: zero pivot at column " + std::to_string(k)
+                    + " (pivot column is numerically zero)");
+            }
+        }
         Ui.push_back(static_cast<idx32>(k)); Ux.push_back(pivot);
         pinv[ipiv] = static_cast<idx32>(k);
         piv_row[k] = static_cast<size_type>(ipiv);
@@ -421,6 +455,7 @@ supernodal_lu_factor<Value> supernodal_lu_numeric(
     supernodal_lu_factor<Value> result;
     result.symbolic = sym;
     result.row_scale = std::move(row_scale);
+    result.num_perturbed = num_perturbed;
     result.lsuper_first.assign(lsuper_first.begin(), lsuper_first.end());
     result.row_perm.resize(n); result.row_pinv.resize(n);
     for (size_type i = 0; i < n; ++i) {
@@ -477,6 +512,7 @@ supernodal_lu_factor<Value> supernodal_lu_refactor(
     auto C = util::crs_to_csc(util::column_permute(A, prev.symbolic.col_perm));
     const auto& pinv = prev.row_pinv;        // original row -> pivot position (fixed)
     supernodal_lu_factor<Value> result = prev;   // reuse pattern + perms + symbolic + supernodes
+    result.num_perturbed = 0;                    // refactor replays values without perturbing (throws on zero pivot)
 
     // If the prior factorization was row-equilibrated, re-equilibrate the new
     // values (same pattern) and factor R*A; solve() row-scales the RHS by R.

--- a/tests/unit/sparse/test_supernodal_lu.cpp
+++ b/tests/unit/sparse/test_supernodal_lu.cpp
@@ -292,3 +292,57 @@ TEST_CASE("Supernodal LU edge cases", "[sparse][lu][supernodal]") {
         REQUIRE_THROWS_AS(factorization::supernodal_lu_numeric(A, sym, 1.5), std::invalid_argument);
     }
 }
+
+// Issue #185 (pivot robustness): opt-in zero-pivot perturbation, mirroring #123
+// for sparse_lu / native_klu. Default off => byte-identical hard-throw behavior.
+TEST_CASE("Supernodal LU zero-pivot perturbation (#185)", "[sparse][lu][supernodal][perturb]") {
+    SECTION("exactly singular: default throws; perturbation completes") {
+        mat::compressed2D<double> A(2, 2);
+        { mat::inserter<mat::compressed2D<double>> ins(A);
+          ins[0][0] << 1.0; ins[0][1] << 1.0;
+          ins[1][0] << 1.0; ins[1][1] << 1.0; }
+        auto sym = factorization::supernodal_lu_symbolic_analyze(A, ordering::colamd{});
+
+        REQUIRE_THROWS_AS(factorization::supernodal_lu_numeric(A, sym), std::runtime_error);
+
+        auto num = factorization::supernodal_lu_numeric(
+            A, sym, /*threshold=*/1.0, /*max_super=*/64, /*scale=*/false, /*pivot_perturb=*/1e-8);
+        REQUIRE(num.num_perturbed >= 1);
+        vec::dense_vector<double> b = {1.0, 2.0}, x(2, 0.0);
+        num.solve(x, b);
+        REQUIRE(std::isfinite(x(0)));
+        REQUIRE(std::isfinite(x(1)));
+    }
+
+    SECTION("nonsingular: perturbation never fires (clean factor, same accuracy)") {
+        auto A = dense_unsym(12);
+        std::size_t n = A.num_rows();
+        auto sym = factorization::supernodal_lu_symbolic_analyze(A, ordering::colamd{});
+        auto num = factorization::supernodal_lu_numeric(A, sym, 1.0, 64, false, 1e-8);
+        REQUIRE(num.num_perturbed == 0);
+        vec::dense_vector<double> b(n), x(n, 0.0);
+        for (std::size_t i = 0; i < n; ++i) b(static_cast<int>(i)) = 1.0 + 0.3 * static_cast<double>(i);
+        num.solve(x, b);
+        REQUIRE(rel_residual(A, x, b) < 1e-12);
+    }
+
+    SECTION("refactor reports a clean perturbation count (no stale carry-over)") {
+        mat::compressed2D<double> A1(2, 2);
+        { mat::inserter<mat::compressed2D<double>> ins(A1);
+          ins[0][0] << 1.0; ins[0][1] << 1.0;
+          ins[1][0] << 1.0; ins[1][1] << 1.0; }
+        auto sym = factorization::supernodal_lu_symbolic_analyze(A1, ordering::colamd{});
+        auto prev = factorization::supernodal_lu_numeric(A1, sym, 1.0, 64, false, 1e-8);
+        REQUIRE(prev.num_perturbed >= 1);
+
+        mat::compressed2D<double> A2(2, 2);                  // same pattern, well-conditioned
+        { mat::inserter<mat::compressed2D<double>> ins(A2);
+          ins[0][0] << 2.0; ins[0][1] << 1.0;
+          ins[1][0] << 1.0; ins[1][1] << 3.0; }
+        auto re = factorization::supernodal_lu_refactor(A2, prev);
+        REQUIRE(re.num_perturbed == 0);
+        vec::dense_vector<double> b = {1.0, 2.0}, x(2, 0.0);
+        re.solve(x, b);
+        REQUIRE(rel_residual(A2, x, b) < 1e-12);
+    }
+}


### PR DESCRIPTION
## Summary
Completes the **pivot-robustness** item of Phase 5 (#185) by porting the opt-in zero-pivot perturbation from `sparse_lu` / `native_klu` (#123) to **supernodal LU**.

When a low-precision factorization drives a structurally-nonzero pivot numerically to zero, the solver can now perturb instead of throwing — keeping it going, to be cleaned up by `iterative_refine`.

## Changes
- `include/mtl/sparse/factorization/supernodal_lu.hpp`
  - `supernodal_lu_numeric` gains `pivot_perturb` (default `0` = off, byte-identical hard-throw). When `> 0`, a pivot below `pivot_perturb · ‖column‖∞` is replaced sign-preservingly and `supernodal_lu_factor::num_perturbed` is incremented. A wholly-zero column is still reported singular.
  - `supernodal_lu_refactor` resets `num_perturbed` (replays values without perturbing).
- `tests/unit/sparse/test_supernodal_lu.cpp` — singular→perturb completes; nonsingular never perturbs; refactor clean-count.

## Scope vs #185 (partial)
- ✅ **Pivot robustness** — this PR.
- ✅ **Row equilibration** — already merged (#193).
- ✅ **Mixed-precision accumulator + IR** — already shipped Phase 2 (`supernodal_lu_solve_refined`).
- ⏸ **FP64 performance-parity DoD** — parked as a dedicated project (#195 / #183).

So `Relates to #185` (not `Resolves`); #185 stays open tracking the parked parity sweep.

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| sparse_test_supernodal_lu | OK | PASS (308 assertions) | OK | PASS (308) |

No regression across sparse_lu / native_klu / supernodal_lu / refactor / scaling / iterative_refine (6/6).

## Test plan
- [ ] Fast CI passes (gcc + clang)
- [ ] Promote to ready: `gh pr ready`

Relates to #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional pivot perturbation during sparse LU factorization for better handling of near-zero pivots.
  * Factorization results now report how many pivots were adjusted.

* **Bug Fixes**
  * Improved behavior for singular or ill-conditioned matrices by allowing controlled fallback instead of immediate failure when perturbation is enabled.
  * Refactor-based solves now correctly reset perturbation counts.

* **Tests**
  * Added coverage for singular, well-conditioned, and refactor-reuse cases with the new pivot perturbation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->