### PR TITLE
feat(operation): general (non-symmetric) eigenvector generator + eigen API (#203)

### DIFF
--- a/docs-site/sync-content.mjs
+++ b/docs-site/sync-content.mjs
@@ -50,6 +50,7 @@ const FILE_MAP = {
 
   // ── Linear Algebra Algorithms ───────────────────────────────────
   'algorithms/overview.md':                     'algorithms/overview.md',
+  'algorithms/eigenvalues.md':                  'algorithms/eigenvalues.md',
   'algorithms/mixed-precision-kernels.md':      'algorithms/mixed-precision-kernels.md',
   'algorithms/measuring-solver-accuracy.md':    'algorithms/measuring-solver-accuracy.md',
   'algorithms/klu.md':                          'algorithms/klu.md',

--- a/docs/algorithms/eigenvalues.md
+++ b/docs/algorithms/eigenvalues.md
@@ -1,0 +1,77 @@
+# Eigenvalues and Eigenvectors
+
+MTL5 provides a dense eigen suite in namespace `mtl` (headers under
+`include/mtl/operation/`). This page covers the routines available today and how
+to choose between them. It is the seed of a fuller guide that will grow as the
+iterative and sparse eigensolvers land.
+
+## Which routine do I call?
+
+| Function | Matrix | Output | Backend |
+|---|---|---|---|
+| `eigenvalue(A)` | general (non-symmetric) | eigenvalues only, `dense_vector<complex>` | pure C++ Francis QR |
+| `eigen(A)` | general (non-symmetric) | eigenvalues **and** right eigenvectors (`complex`) | C++ QR + inverse iteration |
+| `eigenvalue_symmetric(A)` | symmetric | eigenvalues, ascending | LAPACK `syev` if available, else C++ |
+| `eigenvalue_symmetric_generic(A)` | symmetric | eigenvalues, ascending | pure C++ |
+| `eigen_symmetric(A)` | symmetric | eigenvalues **and** eigenvectors | pure C++ |
+
+All routines take an optional `tol` and `max_iter`; the pure-C++ paths also work
+with custom number types (posits, LNS, ...) since they do not depend on LAPACK.
+
+## General eigenvalues and eigenvectors
+
+```cpp
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/operation/eigenvalue.hpp>
+
+mtl::mat::dense2D<double> A(4, 4);
+// ... fill A ...
+
+// Eigenvalues only.
+auto lambda = mtl::eigenvalue(A);            // dense_vector<complex<double>>
+
+// Eigenvalues and right eigenvectors.
+auto [eigs, V] = mtl::eigen(A);              // structured binding
+// Column k of V is the right eigenvector for eigs(k): A * V(:,k) = eigs(k) * V(:,k)
+```
+
+`eigen` returns a struct `{ eigenvalues, eigenvectors }` (structured-bindable),
+mirroring `eigen_symmetric`. Eigenvalue and eigenvector are paired by column.
+Eigenvectors are returned with unit 2-norm and a canonical phase (the
+largest-magnitude entry is rotated to be real and positive), so results are
+deterministic. Real and complex-conjugate eigenpairs are handled uniformly in
+complex arithmetic.
+
+### Algorithm
+
+`eigen` computes the spectrum with the tested general QR path (`eigenvalue`,
+Hessenberg reduction followed by Francis QR iteration), then recovers each
+eigenvector by **inverse iteration** on `A - lambda_k * I`. A partial-pivot
+complex LU with a pivot floor keeps the (near-singular) system solvable — which
+is exactly the regime inverse iteration exploits.
+
+### Accuracy note
+
+`eigen`'s accuracy is bounded by the eigenvalues that `eigenvalue` produces:
+inverse iteration recovers the eigenvector of the true eigenvalue nearest each
+computed `lambda_k`. For symmetric matrices and for general matrices whose
+complex-conjugate pairs deflate cleanly in the QR iteration, results are
+accurate to near machine precision. Strongly non-normal matrices whose complex
+eigenvalues require a **double-shift (Francis)** step are not yet resolved by the
+current single-shift `eigenvalue` path and are correspondingly inaccurate; a
+LAPACK `geev` acceleration and/or a double-shift QR improvement are tracked
+separately for the general eigenproblem.
+
+## Symmetric problems
+
+For symmetric matrices, prefer the symmetric routines — they exploit real
+spectra and orthogonal eigenvectors, and `eigenvalue_symmetric` transparently
+dispatches to LAPACK `syev` when built with `-DMTL5_WITH_LAPACK=ON` and the
+matrix is a column-major `dense2D<float/double>`.
+
+```cpp
+#include <mtl/operation/eigenvalue_symmetric.hpp>
+
+auto s = mtl::eigenvalue_symmetric(S);       // ascending eigenvalues
+auto [eigs, Q] = mtl::eigen_symmetric(S);     // A = Q * diag(eigs) * Q^T
+```

--- a/docs/algorithms/eigenvalues.md
+++ b/docs/algorithms/eigenvalues.md
@@ -58,9 +58,9 @@ computed `lambda_k`. For symmetric matrices and for general matrices whose
 complex-conjugate pairs deflate cleanly in the QR iteration, results are
 accurate to near machine precision. Strongly non-normal matrices whose complex
 eigenvalues require a **double-shift (Francis)** step are not yet resolved by the
-current single-shift `eigenvalue` path and are correspondingly inaccurate; a
-LAPACK `geev` acceleration and/or a double-shift QR improvement are tracked
-separately for the general eigenproblem.
+current single-shift `eigenvalue` path and are correspondingly inaccurate. A
+double-shift QR fix and a LAPACK `geev` acceleration are tracked separately for
+the general eigenproblem.
 
 ## Symmetric problems
 

--- a/include/mtl/operation/eigenvalue.hpp
+++ b/include/mtl/operation/eigenvalue.hpp
@@ -237,8 +237,8 @@ auto eigenvalue(const M& A, typename M::value_type tol = 1e-10,
 /// recovers the eigenvector of the true eigenvalue nearest each computed
 /// lambda_k. Strongly non-normal matrices whose complex eigenvalues require a
 /// double-shift (Francis) QR step are not yet resolved by the single-shift
-/// `eigenvalue` path and are correspondingly inaccurate here (tracked with the
-/// general-eigenproblem LAPACK/double-shift work).
+/// `eigenvalue` path and are correspondingly inaccurate here (tracked in the
+/// Francis double-shift issue #209 / general-eigenproblem LAPACK work #204).
 template <Matrix M>
 auto eigen(const M& A, typename M::value_type tol = 1e-10,
            typename M::size_type max_iter = 0) {

--- a/include/mtl/operation/eigenvalue.hpp
+++ b/include/mtl/operation/eigenvalue.hpp
@@ -5,6 +5,8 @@
 #include <complex>
 #include <algorithm>
 #include <cassert>
+#include <limits>
+#include <vector>
 #include <mtl/concepts/matrix.hpp>
 #include <mtl/vec/dense_vector.hpp>
 #include <mtl/mat/dense2D.hpp>
@@ -12,6 +14,63 @@
 #include <mtl/math/identity.hpp>
 
 namespace mtl {
+
+namespace detail {
+
+/// In-place LU factorization of an n x n complex matrix (row-major, `M[i*n+j]`)
+/// with partial pivoting. Tiny pivots are floored to `pivot_floor` so that a
+/// (near-)singular system stays solvable -- exactly the regime that inverse
+/// iteration relies on, since A - lambda*I is singular at a true eigenvalue.
+/// `piv[i]` holds the original row now living in row i after pivoting.
+template <typename Complex, typename Real>
+void eig_lu_factor(std::vector<Complex>& M, std::vector<std::size_t>& piv,
+                   std::size_t n, Real pivot_floor) {
+    using std::abs;
+    for (std::size_t i = 0; i < n; ++i) piv[i] = i;
+    for (std::size_t k = 0; k < n; ++k) {
+        // Partial pivot: largest-magnitude entry in column k at or below k.
+        std::size_t p = k;
+        Real best = abs(M[k * n + k]);
+        for (std::size_t i = k + 1; i < n; ++i) {
+            Real v = abs(M[i * n + k]);
+            if (v > best) { best = v; p = i; }
+        }
+        if (p != k) {
+            for (std::size_t j = 0; j < n; ++j)
+                std::swap(M[k * n + j], M[p * n + j]);
+            std::swap(piv[k], piv[p]);
+        }
+        Complex akk = M[k * n + k];
+        if (abs(akk) < pivot_floor) { akk = Complex(pivot_floor); M[k * n + k] = akk; }
+        for (std::size_t i = k + 1; i < n; ++i) {
+            Complex f = M[i * n + k] / akk;
+            M[i * n + k] = f;
+            for (std::size_t j = k + 1; j < n; ++j)
+                M[i * n + j] -= f * M[k * n + j];
+        }
+    }
+}
+
+/// Solve M x = b in place given the LU factors from eig_lu_factor.
+template <typename Complex>
+void eig_lu_solve(const std::vector<Complex>& M, const std::vector<std::size_t>& piv,
+                  std::size_t n, std::vector<Complex>& b) {
+    std::vector<Complex> x(n);
+    for (std::size_t i = 0; i < n; ++i) x[i] = b[piv[i]];
+    // Forward substitution (unit lower triangle).
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < i; ++j)
+            x[i] -= M[i * n + j] * x[j];
+    // Back substitution (upper triangle).
+    for (std::size_t i = n; i-- > 0; ) {
+        for (std::size_t j = i + 1; j < n; ++j)
+            x[i] -= M[i * n + j] * x[j];
+        x[i] /= M[i * n + i];
+    }
+    b = std::move(x);
+}
+
+} // namespace detail
 
 /// Compute eigenvalues of a general (non-symmetric) square matrix.
 /// Returns eigenvalues as dense_vector of complex values.
@@ -160,6 +219,125 @@ auto eigenvalue(const M& A, typename M::value_type tol = 1e-10,
         eigs(i) = complex_type(H(i, i));
 
     return eigs;
+}
+
+/// Compute eigenvalues AND right eigenvectors of a general (non-symmetric)
+/// square matrix. Returns {eigenvalues, eigenvectors} where:
+///   eigenvalues:  dense_vector<complex> of size n
+///   eigenvectors: dense2D<complex> of size n x n, column k is the right
+///                 eigenvector for eigenvalues(k), i.e. A * v_k = lambda_k * v_k
+///
+/// Eigenvalues come from the tested general QR path (`eigenvalue`); each
+/// eigenvector is then recovered by inverse iteration on A - lambda_k*I. This
+/// handles real and complex-conjugate eigenpairs uniformly in complex
+/// arithmetic. Eigenvectors are unit 2-norm with a canonical phase (largest
+/// entry made real-positive). Eigenvalue/eigenvector pairing matches by column.
+///
+/// Accuracy is bounded by the eigenvalues from `eigenvalue`: inverse iteration
+/// recovers the eigenvector of the true eigenvalue nearest each computed
+/// lambda_k. Strongly non-normal matrices whose complex eigenvalues require a
+/// double-shift (Francis) QR step are not yet resolved by the single-shift
+/// `eigenvalue` path and are correspondingly inaccurate here (tracked with the
+/// general-eigenproblem LAPACK/double-shift work).
+template <Matrix M>
+auto eigen(const M& A, typename M::value_type tol = 1e-10,
+           typename M::size_type max_iter = 0) {
+    using value_type   = typename M::value_type;
+    using complex_type = std::complex<value_type>;
+    using size_type    = typename M::size_type;
+    using std::abs;
+    using std::sqrt;
+    const size_type n = A.num_rows();
+    assert(n == A.num_cols());
+
+    struct EigenResult {
+        vec::dense_vector<complex_type> eigenvalues;
+        mat::dense2D<complex_type> eigenvectors;
+    };
+
+    if (n == 0)
+        return EigenResult{vec::dense_vector<complex_type>(0),
+                           mat::dense2D<complex_type>(0, 0)};
+
+    // Eigenvalues via the general QR iteration.
+    vec::dense_vector<complex_type> eigs = eigenvalue(A, tol, max_iter);
+
+    mat::dense2D<complex_type> V(n, n);
+    if (n == 1) {
+        V(0, 0) = complex_type(value_type(1));
+        return EigenResult{eigs, V};
+    }
+
+    // Frobenius norm of A -- sets the scale for the pivot floor.
+    value_type anorm = value_type(0);
+    for (size_type i = 0; i < n; ++i)
+        for (size_type j = 0; j < n; ++j)
+            anorm += A(i, j) * A(i, j);
+    anorm = sqrt(anorm);
+    if (anorm == value_type(0)) anorm = value_type(1);
+    const value_type eps = std::numeric_limits<value_type>::epsilon();
+    const value_type pivot_floor = eps * anorm;
+
+    const std::size_t nn = static_cast<std::size_t>(n);
+    const int max_inv_iter = 5;
+
+    for (size_type k = 0; k < n; ++k) {
+        const complex_type lambda = eigs(k);
+
+        // Build M = A - lambda*I (row-major complex) and factor once.
+        std::vector<complex_type> Mc(nn * nn);
+        for (size_type i = 0; i < n; ++i)
+            for (size_type j = 0; j < n; ++j)
+                Mc[static_cast<std::size_t>(i) * nn + static_cast<std::size_t>(j)] =
+                    complex_type(A(i, j)) - (i == j ? lambda : complex_type(0));
+
+        std::vector<std::size_t> piv(nn);
+        detail::eig_lu_factor(Mc, piv, nn, pivot_floor);
+
+        // Start vector: entries varied by index so that repeated/clustered
+        // eigenvalues are seeded with non-parallel starts.
+        std::vector<complex_type> x(nn);
+        for (size_type i = 0; i < n; ++i)
+            x[static_cast<std::size_t>(i)] =
+                complex_type(value_type(1) + value_type(i) / value_type(n));
+
+        for (int it = 0; it < max_inv_iter; ++it) {
+            detail::eig_lu_solve(Mc, piv, nn, x);
+            value_type nrm = value_type(0);
+            for (std::size_t i = 0; i < nn; ++i) nrm += std::norm(x[i]);
+            nrm = sqrt(nrm);
+            if (nrm == value_type(0)) break;
+            for (std::size_t i = 0; i < nn; ++i) x[i] /= nrm;
+
+            // Residual ||A x - lambda x|| against the (unperturbed) eigenvalue.
+            value_type res = value_type(0);
+            for (size_type i = 0; i < n; ++i) {
+                complex_type axi(0);
+                for (size_type j = 0; j < n; ++j)
+                    axi += complex_type(A(i, j)) * x[static_cast<std::size_t>(j)];
+                axi -= lambda * x[static_cast<std::size_t>(i)];
+                res += std::norm(axi);
+            }
+            if (sqrt(res) <= tol * anorm) break;
+        }
+
+        // Canonical phase: rotate so the largest-magnitude entry is real-positive.
+        std::size_t imax = 0;
+        value_type mmax = value_type(0);
+        for (std::size_t i = 0; i < nn; ++i) {
+            value_type m = abs(x[i]);
+            if (m > mmax) { mmax = m; imax = i; }
+        }
+        if (mmax > value_type(0)) {
+            complex_type phase = x[imax] / abs(x[imax]);
+            for (std::size_t i = 0; i < nn; ++i) x[i] /= phase;
+        }
+
+        for (size_type i = 0; i < n; ++i)
+            V(i, k) = x[static_cast<std::size_t>(i)];
+    }
+
+    return EigenResult{eigs, V};
 }
 
 } // namespace mtl

--- a/include/mtl/operation/eigenvalue.hpp
+++ b/include/mtl/operation/eigenvalue.hpp
@@ -281,8 +281,14 @@ auto eigen(const M& A, typename M::value_type tol = 1e-10,
     const std::size_t nn = static_cast<std::size_t>(n);
     const int max_inv_iter = 5;
 
+    // Two eigenvalues are treated as one cluster (a repeated eigenvalue) when
+    // they agree to within this scale. Kept tiny so genuinely distinct
+    // eigenvalues -- including complex-conjugate partners -- are never merged.
+    const value_type cluster_scale = sqrt(eps);
+
     for (size_type k = 0; k < n; ++k) {
         const complex_type lambda = eigs(k);
+        const value_type cluster_tol = cluster_scale * (anorm + std::abs(lambda));
 
         // Build M = A - lambda*I (row-major complex) and factor once.
         std::vector<complex_type> Mc(nn * nn);
@@ -294,18 +300,51 @@ auto eigen(const M& A, typename M::value_type tol = 1e-10,
         std::vector<std::size_t> piv(nn);
         detail::eig_lu_factor(Mc, piv, nn, pivot_floor);
 
-        // Start vector: entries varied by index so that repeated/clustered
-        // eigenvalues are seeded with non-parallel starts.
+        // Modified Gram-Schmidt deflation of v against previously computed
+        // eigenvectors that share this eigenvalue. For a repeated eigenvalue the
+        // whole eigenspace is (near-)null for M, so plain inverse iteration would
+        // return the same vector each time; deflating keeps successive iterates
+        // in the orthogonal complement of what is already found, yielding an
+        // independent basis of the eigenspace. (Orthonormal combinations within
+        // one eigenspace are still eigenvectors.)
+        auto deflate = [&](std::vector<complex_type>& v) {
+            for (size_type m = 0; m < k; ++m) {
+                if (std::abs(eigs(m) - lambda) > cluster_tol) continue;
+                complex_type proj(0);
+                for (size_type i = 0; i < n; ++i)
+                    proj += std::conj(V(i, m)) * v[static_cast<std::size_t>(i)];
+                for (size_type i = 0; i < n; ++i)
+                    v[static_cast<std::size_t>(i)] -= proj * V(i, m);
+            }
+        };
+        auto norm2 = [&](const std::vector<complex_type>& v) {
+            value_type s = value_type(0);
+            for (std::size_t i = 0; i < nn; ++i) s += std::norm(v[i]);
+            return sqrt(s);
+        };
+
+        // Seed: index-varied base plus a k-dependent emphasis, so repeated
+        // eigenvalues start from non-parallel vectors. Reseed if a seed happens
+        // to lie in the span of the already-found cluster vectors.
         std::vector<complex_type> x(nn);
-        for (size_type i = 0; i < n; ++i)
-            x[static_cast<std::size_t>(i)] =
-                complex_type(value_type(1) + value_type(i) / value_type(n));
+        for (int attempt = 0; attempt <= static_cast<int>(nn); ++attempt) {
+            for (size_type i = 0; i < n; ++i)
+                x[static_cast<std::size_t>(i)] =
+                    complex_type(value_type(1) + value_type(i) / value_type(n));
+            x[(static_cast<std::size_t>(k) + static_cast<std::size_t>(attempt)) % nn]
+                += complex_type(value_type(1));
+            deflate(x);
+            value_type s = norm2(x);
+            if (s > pivot_floor) {
+                for (std::size_t i = 0; i < nn; ++i) x[i] /= s;
+                break;
+            }
+        }
 
         for (int it = 0; it < max_inv_iter; ++it) {
             detail::eig_lu_solve(Mc, piv, nn, x);
-            value_type nrm = value_type(0);
-            for (std::size_t i = 0; i < nn; ++i) nrm += std::norm(x[i]);
-            nrm = sqrt(nrm);
+            deflate(x);
+            value_type nrm = norm2(x);
             if (nrm == value_type(0)) break;
             for (std::size_t i = 0; i < nn; ++i) x[i] /= nrm;
 

--- a/tests/unit/operation/test_eigen_general.cpp
+++ b/tests/unit/operation/test_eigen_general.cpp
@@ -1,0 +1,171 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/operation/eigenvalue.hpp>
+#include <mtl/generators/frank.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <vector>
+
+using namespace mtl;
+using cplx = std::complex<double>;
+
+namespace {
+
+// Max_i | (A v_k - lambda_k v_k)_i | over all eigenpairs (columns of V).
+double max_eigen_residual(const mat::dense2D<double>& A,
+                          const vec::dense_vector<cplx>& eigs,
+                          const mat::dense2D<cplx>& V) {
+    const std::size_t n = A.num_rows();
+    double worst = 0.0;
+    for (std::size_t k = 0; k < n; ++k) {
+        for (std::size_t i = 0; i < n; ++i) {
+            cplx axi(0.0, 0.0);
+            for (std::size_t j = 0; j < n; ++j)
+                axi += cplx(A(i, j), 0.0) * V(j, k);
+            axi -= eigs(k) * V(i, k);
+            worst = std::max(worst, std::abs(axi));
+        }
+    }
+    return worst;
+}
+
+// 2-norm of column k of V.
+double col_norm(const mat::dense2D<cplx>& V, std::size_t k) {
+    double s = 0.0;
+    for (std::size_t i = 0; i < V.num_rows(); ++i)
+        s += std::norm(V(i, k));
+    return std::sqrt(s);
+}
+
+} // namespace
+
+TEST_CASE("General eigen: known 2x2 real eigenvalues", "[operation][eigen]") {
+    // {{0,1},{-2,-3}} has eigenvalues -1, -2 (both real).
+    mat::dense2D<double> A(2, 2);
+    A(0,0) = 0;  A(0,1) = 1;
+    A(1,0) = -2; A(1,1) = -3;
+
+    auto [eigs, V] = eigen(A);
+    REQUIRE(eigs.size() == 2);
+    REQUIRE(V.num_rows() == 2);
+    REQUIRE(V.num_cols() == 2);
+
+    // Each eigenpair satisfies A v = lambda v; each eigenvector is unit-norm.
+    REQUIRE(max_eigen_residual(A, eigs, V) < 1e-9);
+    REQUIRE_THAT(col_norm(V, 0), Catch::Matchers::WithinAbs(1.0, 1e-12));
+    REQUIRE_THAT(col_norm(V, 1), Catch::Matchers::WithinAbs(1.0, 1e-12));
+}
+
+TEST_CASE("General eigen: complex-conjugate pair", "[operation][eigen]") {
+    // {{0,-1},{1,0}} has eigenvalues +/- i with complex eigenvectors.
+    mat::dense2D<double> A(2, 2);
+    A(0,0) = 0; A(0,1) = -1;
+    A(1,0) = 1; A(1,1) =  0;
+
+    auto [eigs, V] = eigen(A);
+    REQUIRE(eigs.size() == 2);
+
+    // Eigenvalues are purely imaginary +/- i.
+    std::vector<double> im = {eigs(0).imag(), eigs(1).imag()};
+    std::sort(im.begin(), im.end());
+    REQUIRE_THAT(im[0], Catch::Matchers::WithinAbs(-1.0, 1e-8));
+    REQUIRE_THAT(im[1], Catch::Matchers::WithinAbs( 1.0, 1e-8));
+
+    // Genuinely complex eigenvectors must still satisfy the eigen relation.
+    REQUIRE(max_eigen_residual(A, eigs, V) < 1e-9);
+    REQUIRE_THAT(col_norm(V, 0), Catch::Matchers::WithinAbs(1.0, 1e-12));
+    REQUIRE_THAT(col_norm(V, 1), Catch::Matchers::WithinAbs(1.0, 1e-12));
+}
+
+TEST_CASE("General eigen: diagonal matrix -> canonical basis", "[operation][eigen]") {
+    mat::dense2D<double> A(3, 3);
+    A(0,0) = 2; A(0,1) = 0; A(0,2) = 0;
+    A(1,0) = 0; A(1,1) = 5; A(1,2) = 0;
+    A(2,0) = 0; A(2,1) = 0; A(2,2) = 7;
+
+    auto [eigs, V] = eigen(A);
+    REQUIRE(max_eigen_residual(A, eigs, V) < 1e-10);
+
+    // Each eigenvector is a unit axis vector (single nonzero, magnitude 1).
+    for (std::size_t k = 0; k < 3; ++k) {
+        int nonzero = 0;
+        for (std::size_t i = 0; i < 3; ++i)
+            if (std::abs(V(i, k)) > 1e-8) ++nonzero;
+        REQUIRE(nonzero == 1);
+    }
+}
+
+TEST_CASE("General eigen: 1x1 matrix", "[operation][eigen]") {
+    mat::dense2D<double> A(1, 1);
+    A(0,0) = 3.5;
+
+    auto [eigs, V] = eigen(A);
+    REQUIRE(eigs.size() == 1);
+    REQUIRE_THAT(eigs(0).real(), Catch::Matchers::WithinAbs(3.5, 1e-12));
+    REQUIRE_THAT(std::abs(V(0, 0)), Catch::Matchers::WithinAbs(1.0, 1e-12));
+}
+
+TEST_CASE("General eigen: 0x0 matrix", "[operation][eigen]") {
+    mat::dense2D<double> A(0, 0);
+    auto [eigs, V] = eigen(A);
+    REQUIRE(eigs.size() == 0);
+    REQUIRE(V.num_rows() == 0);
+    REQUIRE(V.num_cols() == 0);
+}
+
+TEST_CASE("General eigen: Frank matrix eigenpairs", "[operation][eigen][generator]") {
+    constexpr std::size_t n = 6;
+    auto F = generators::frank<double>(n);
+
+    auto [eigs, V] = eigen(F);
+    REQUIRE(eigs.size() == n);
+    REQUIRE(max_eigen_residual(F, eigs, V) < 1e-8);
+    for (std::size_t k = 0; k < n; ++k)
+        REQUIRE_THAT(col_norm(V, k), Catch::Matchers::WithinAbs(1.0, 1e-10));
+}
+
+TEST_CASE("General eigen: mixed real + complex-conjugate spectrum", "[operation][eigen]") {
+    // Block-triangular 4x4 with eigenvalues 5, 2, and the pair 1 +/- 2i.
+    // Exercises real eigenvectors and a genuine complex-conjugate eigenpair
+    // together (the 2x2 trailing block deflates cleanly in the QR iteration).
+    mat::dense2D<double> A(4, 4);
+    const double B[4][4] = {{5, 1, 0,  0},
+                            {0, 2, 1,  0},
+                            {0, 0, 1, -2},
+                            {0, 0, 2,  1}};
+    for (std::size_t i = 0; i < 4; ++i)
+        for (std::size_t j = 0; j < 4; ++j)
+            A(i, j) = B[i][j];
+
+    auto [eigs, V] = eigen(A);
+    REQUIRE(eigs.size() == 4);
+    REQUIRE(max_eigen_residual(A, eigs, V) < 1e-10);
+    for (std::size_t k = 0; k < 4; ++k)
+        REQUIRE_THAT(col_norm(V, k), Catch::Matchers::WithinAbs(1.0, 1e-10));
+
+    // Confirm the spectrum: two real (5, 2) and a conjugate pair 1 +/- 2i.
+    int complex_pair = 0, real_vals = 0;
+    for (std::size_t k = 0; k < 4; ++k) {
+        if (std::abs(eigs(k).imag()) > 1e-8) ++complex_pair; else ++real_vals;
+    }
+    REQUIRE(real_vals == 2);
+    REQUIRE(complex_pair == 2);
+}
+
+TEST_CASE("General eigen: eigenvalues match eigenvalue()", "[operation][eigen]") {
+    mat::dense2D<double> A(3, 3);
+    A(0,0) = 4; A(0,1) = 1; A(0,2) = -1;
+    A(1,0) = 2; A(1,1) = 3; A(1,2) =  0;
+    A(2,0) = 1; A(2,1) = 0; A(2,2) =  2;
+
+    auto vals_only = eigenvalue(A);
+    auto [eigs, V] = eigen(A);
+    REQUIRE(eigs.size() == vals_only.size());
+    for (std::size_t k = 0; k < eigs.size(); ++k)
+        REQUIRE(std::abs(eigs(k) - vals_only(k)) < 1e-12);
+}

--- a/tests/unit/operation/test_eigen_general.cpp
+++ b/tests/unit/operation/test_eigen_general.cpp
@@ -157,6 +157,61 @@ TEST_CASE("General eigen: mixed real + complex-conjugate spectrum", "[operation]
     REQUIRE(complex_pair == 2);
 }
 
+TEST_CASE("General eigen: repeated eigenvalue yields an independent basis", "[operation][eigen]") {
+    // Identity: eigenvalue 1 with multiplicity 4. A correct result returns four
+    // *independent* eigenvectors spanning R^4, not four copies of one vector.
+    constexpr std::size_t n = 4;
+    mat::dense2D<double> A(n, n);
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j)
+            A(i, j) = (i == j) ? 1.0 : 0.0;
+
+    auto [eigs, V] = eigen(A);
+    REQUIRE(eigs.size() == n);
+
+    // Every column is an eigenvector (trivially, for I) and unit norm.
+    REQUIRE(max_eigen_residual(A, eigs, V) < 1e-12);
+    for (std::size_t k = 0; k < n; ++k)
+        REQUIRE_THAT(col_norm(V, k), Catch::Matchers::WithinAbs(1.0, 1e-10));
+
+    // Columns must be mutually orthogonal (an orthonormal basis of the
+    // eigenspace) -- off-diagonal Gram entries near zero.
+    for (std::size_t a = 0; a < n; ++a) {
+        for (std::size_t b = a + 1; b < n; ++b) {
+            cplx dot(0.0, 0.0);
+            for (std::size_t i = 0; i < n; ++i)
+                dot += std::conj(V(i, a)) * V(i, b);
+            REQUIRE(std::abs(dot) < 1e-9);
+        }
+    }
+}
+
+TEST_CASE("General eigen: partial multiplicity (2,2,5)", "[operation][eigen]") {
+    // Diagonal diag(2,2,5): eigenvalue 2 has multiplicity 2, 5 is simple.
+    // The two lambda=2 columns must be independent eigenvectors of that space.
+    mat::dense2D<double> A(3, 3);
+    A(0,0) = 2; A(0,1) = 0; A(0,2) = 0;
+    A(1,0) = 0; A(1,1) = 2; A(1,2) = 0;
+    A(2,0) = 0; A(2,1) = 0; A(2,2) = 5;
+
+    auto [eigs, V] = eigen(A);
+    REQUIRE(max_eigen_residual(A, eigs, V) < 1e-10);
+
+    // Identify the two columns belonging to eigenvalue 2 and check independence
+    // via the magnitude of their normalized cross product being non-degenerate.
+    std::vector<std::size_t> two_cols;
+    for (std::size_t k = 0; k < 3; ++k)
+        if (std::abs(eigs(k).real() - 2.0) < 1e-9 && std::abs(eigs(k).imag()) < 1e-9)
+            two_cols.push_back(k);
+    REQUIRE(two_cols.size() == 2);
+
+    cplx dot(0.0, 0.0);
+    for (std::size_t i = 0; i < 3; ++i)
+        dot += std::conj(V(i, two_cols[0])) * V(i, two_cols[1]);
+    // Independent (here orthogonalized) -> inner product well below 1.
+    REQUIRE(std::abs(dot) < 1e-6);
+}
+
 TEST_CASE("General eigen: eigenvalues match eigenvalue()", "[operation][eigen]") {
     mat::dense2D<double> A(3, 3);
     A(0,0) = 4; A(0,1) = 1; A(0,2) = -1;


### PR DESCRIPTION
Closes #203. Part of epic #202.

## What

Adds `mtl::eigen(A)` — eigenvalues **and right eigenvectors** for a general
(non-symmetric) square matrix, filling the gap where `eigenvalue(A)` returned
values only.

```cpp
auto [eigs, V] = mtl::eigen(A);   // column k of V is the eigenvector for eigs(k)
// A * V(:,k) = eigs(k) * V(:,k)
```

Returns a structured-bindable `{ eigenvalues, eigenvectors }` (both `complex`),
mirroring `eigen_symmetric`. Eigenvectors are unit 2-norm with a canonical
phase (largest entry real-positive) for deterministic output.

## How

- Eigenvalues from the existing, tested general QR path (`eigenvalue`).
- Each eigenvector via **inverse iteration** on `A - lambda_k*I`, using a small
  partial-pivot complex LU with a pivot floor so the (near-singular) system
  stays solvable — the regime inverse iteration relies on. Real and
  complex-conjugate pairs are handled uniformly in complex arithmetic.
- Chosen over Schur+`trevc` because it reuses the validated eigenvalue path
  rather than rewriting the Francis iteration to accumulate Schur vectors
  (far less error-prone for a reference implementation). The LAPACK `geev`
  path (#204) will supersede it for float/double.

## Tests (`tests/unit/operation/test_eigen_general.cpp`, GCC + Clang)

Known real eigenvalues, a genuine complex-conjugate pair, diagonal, 1x1, 0x0,
Frank (n=6, non-symmetric real spectrum), a mixed real+complex-conjugate 4x4,
and consistency with `eigenvalue()`. Acceptance metric is the eigen residual
`max_i |(A v_k - lambda_k v_k)_i|` (< 1e-8..1e-10) plus unit-norm checks.

## Docs

`docs/algorithms/eigenvalues.md` — "which routine do I call?" table + the
general eigen API, wired into `FILE_MAP`. Seeds the fuller guide in #207.

## Known limitation (discovered, pre-existing)

`eigenvalue()`'s single-shift real QR **stalls on strongly non-normal matrices**
whose complex eigenvalues need a double-shift (Francis) step — e.g. the Forsythe
companion matrix, where it returns `3,3,3,3,3` (all shift value) instead of the
true radius-0.87 circle. The existing Forsythe test only checked trace-sum and a
loose distance bound, so this was masked. `eigen`'s accuracy inherits this bound;
the doc-comment and docs page call it out, and it's the province of #204
(LAPACK `geev`) / a double-shift QR fix — **out of scope** for the eigenvector
generator itself. Happy to file a dedicated issue for the `eigenvalue()`
double-shift gap if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `eigen` functionality for general square matrices, returning eigenvalues and normalized right eigenvectors.
  * Eigenvectors use a consistent, deterministic sign/phase convention.
* **Documentation**
  * Added comprehensive guidance and examples for general and symmetric eigenvalue routines, including backend and accuracy details.
* **Tests**
  * Added coverage for real and complex spectra, diagonal and block matrices, edge cases, eigenvector normalization, and residual accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->