### PR TITLE
feat(interface): conditional LAPACK geev for the general eigenproblem (#204)

### DIFF
--- a/docs/algorithms/eigenvalues.md
+++ b/docs/algorithms/eigenvalues.md
@@ -9,11 +9,17 @@ iterative and sparse eigensolvers land.
 
 | Function | Matrix | Output | Backend |
 |---|---|---|---|
-| `eigenvalue(A)` | general (non-symmetric) | eigenvalues only, `dense_vector<complex>` | pure C++ Francis QR |
-| `eigen(A)` | general (non-symmetric) | eigenvalues **and** right eigenvectors (`complex`) | C++ QR + inverse iteration |
+| `eigenvalue(A)` | general (non-symmetric) | eigenvalues only, `dense_vector<complex>` | LAPACK `geev` if available, else C++ Francis QR |
+| `eigen(A)` | general (non-symmetric) | eigenvalues **and** right eigenvectors (`complex`) | LAPACK `geev` if available, else C++ QR + inverse iteration |
 | `eigenvalue_symmetric(A)` | symmetric | eigenvalues, ascending | LAPACK `syev` if available, else C++ |
 | `eigenvalue_symmetric_generic(A)` | symmetric | eigenvalues, ascending | pure C++ |
 | `eigen_symmetric(A)` | symmetric | eigenvalues **and** eigenvectors | pure C++ |
+
+The LAPACK `geev` fast path for the general problem engages when built with
+`-DMTL5_WITH_LAPACK=ON` and the matrix is a **column-major** `dense2D<float/double>`
+(mirroring the symmetric `syev` dispatch). Row-major matrices and custom number
+types use the in-house path, which is always available and numerically identical
+up to sign/phase conventions.
 
 All routines take an optional `tol` and `max_iter`; the pure-C++ paths also work
 with custom number types (posits, LNS, ...) since they do not depend on LAPACK.

--- a/include/mtl/interface/lapack.hpp
+++ b/include/mtl/interface/lapack.hpp
@@ -44,6 +44,16 @@ void dsyev_(const char* jobz, const char* uplo, const int* n,
             double* A, const int* lda, double* W,
             double* work, const int* lwork, int* info);
 
+// General (non-symmetric) eigenvalue + optional left/right eigenvectors
+void sgeev_(const char* jobvl, const char* jobvr, const int* n,
+            float* A, const int* lda, float* wr, float* wi,
+            float* vl, const int* ldvl, float* vr, const int* ldvr,
+            float* work, const int* lwork, int* info);
+void dgeev_(const char* jobvl, const char* jobvr, const int* n,
+            double* A, const int* lda, double* wr, double* wi,
+            double* vl, const int* ldvl, double* vr, const int* ldvr,
+            double* work, const int* lwork, int* info);
+
 // Solve using LU factorization (after getrf)
 void sgetrs_(const char* trans, const int* n, const int* nrhs,
              const float* A, const int* lda, const int* ipiv,
@@ -156,6 +166,25 @@ inline int syev(char jobz, char uplo, int n, double* A, int lda,
                 double* W, double* work, int lwork) {
     int info = 0;
     dsyev_(&jobz, &uplo, &n, A, &lda, W, work, &lwork, &info);
+    return info;
+}
+
+// -- General (non-symmetric) eigenvalue ---------------------------------
+
+inline int geev(char jobvl, char jobvr, int n, float* A, int lda,
+                float* wr, float* wi, float* vl, int ldvl,
+                float* vr, int ldvr, float* work, int lwork) {
+    int info = 0;
+    sgeev_(&jobvl, &jobvr, &n, A, &lda, wr, wi, vl, &ldvl, vr, &ldvr,
+           work, &lwork, &info);
+    return info;
+}
+inline int geev(char jobvl, char jobvr, int n, double* A, int lda,
+                double* wr, double* wi, double* vl, int ldvl,
+                double* vr, int ldvr, double* work, int lwork) {
+    int info = 0;
+    dgeev_(&jobvl, &jobvr, &n, A, &lda, wr, wi, vl, &ldvl, vr, &ldvr,
+           work, &lwork, &info);
     return info;
 }
 

--- a/include/mtl/operation/eigenvalue.hpp
+++ b/include/mtl/operation/eigenvalue.hpp
@@ -13,10 +13,112 @@
 #include <mtl/mat/dense2D.hpp>
 #include <mtl/operation/hessenberg.hpp>
 #include <mtl/math/identity.hpp>
+#include <mtl/interface/dispatch_traits.hpp>
+#ifdef MTL5_HAS_LAPACK
+#include <mtl/interface/lapack.hpp>
+#endif
 
 namespace mtl {
 
 namespace detail {
+
+#ifdef MTL5_HAS_LAPACK
+/// LAPACK geev on a real float/double dense matrix. Fills `eigs` (size n) with
+/// the eigenvalues; if `V != nullptr`, also fills right eigenvectors (column k
+/// pairs with eigs(k)) into *V, unpacking LAPACK's real/complex-conjugate
+/// column packing into complex columns, unit-normalized with a canonical phase
+/// (largest-magnitude entry real-positive) to match the in-house path.
+template <typename M>
+void lapack_geev(const M& A,
+                 vec::dense_vector<std::complex<typename M::value_type>>& eigs,
+                 mat::dense2D<std::complex<typename M::value_type>>* V) {
+    using value_type   = typename M::value_type;
+    using complex_type = std::complex<value_type>;
+    using size_type    = typename M::size_type;
+    using std::abs;
+    using std::sqrt;
+    const size_type n  = A.num_rows();
+    const int ni = static_cast<int>(n);
+
+    // Column-major working copy (LAPACK is Fortran/column-major); built through
+    // the (i,j) accessor so it is correct regardless of M's own orientation.
+    std::vector<value_type> a(static_cast<std::size_t>(n) * n);
+    for (size_type i = 0; i < n; ++i)
+        for (size_type j = 0; j < n; ++j)
+            a[static_cast<std::size_t>(j) * n + i] = A(i, j);
+
+    std::vector<value_type> wr(n), wi(n);
+    std::vector<value_type> vr;
+    value_type vl_dummy[1] = {value_type(0)};
+    char jobvr = 'N';
+    value_type* vrp = vl_dummy;   // unreferenced when jobvr == 'N'
+    int ldvr = 1;
+    if (V != nullptr) {
+        jobvr = 'V';
+        vr.resize(static_cast<std::size_t>(n) * n);
+        vrp = vr.data();
+        ldvr = ni;
+    }
+
+    // Workspace query, then compute.
+    value_type wq = value_type(0);
+    interface::lapack::geev('N', jobvr, ni, a.data(), ni, wr.data(), wi.data(),
+                            vl_dummy, 1, vrp, ldvr, &wq, -1);
+    int lwork = static_cast<int>(wq);
+    if (lwork < 4 * ni) lwork = 4 * ni;   // LAPACK minimum for jobvr='V'
+    std::vector<value_type> work(static_cast<std::size_t>(lwork));
+    int info = interface::lapack::geev('N', jobvr, ni, a.data(), ni,
+                                       wr.data(), wi.data(),
+                                       vl_dummy, 1, vrp, ldvr,
+                                       work.data(), lwork);
+    if (info != 0)
+        throw std::runtime_error("mtl::eigenvalue: LAPACK geev failed to converge");
+
+    for (size_type i = 0; i < n; ++i)
+        eigs(i) = complex_type(wr[i], wi[i]);
+
+    if (V == nullptr) return;
+
+    // Unpack right eigenvectors from the column-major vr buffer. A real
+    // eigenvalue j uses column j; a complex-conjugate pair (j, j+1) with
+    // wi[j] > 0 uses vr[:,j] +/- i*vr[:,j+1].
+    auto vrc = [&](size_type c, size_type row) -> value_type {
+        return vr[static_cast<std::size_t>(c) * n + row];
+    };
+    for (size_type j = 0; j < n; ) {
+        if (wi[j] == value_type(0)) {
+            for (size_type i = 0; i < n; ++i)
+                (*V)(i, j) = complex_type(vrc(j, i), value_type(0));
+            ++j;
+        } else {
+            for (size_type i = 0; i < n; ++i) {
+                value_type re = vrc(j, i), im = vrc(j + 1, i);
+                (*V)(i, j)     = complex_type(re,  im);
+                (*V)(i, j + 1) = complex_type(re, -im);
+            }
+            j += 2;
+        }
+    }
+    // Unit-normalize and fix a canonical phase, matching the in-house path.
+    for (size_type k = 0; k < n; ++k) {
+        value_type nrm = value_type(0);
+        for (size_type i = 0; i < n; ++i) nrm += std::norm((*V)(i, k));
+        nrm = sqrt(nrm);
+        if (nrm > value_type(0))
+            for (size_type i = 0; i < n; ++i) (*V)(i, k) /= nrm;
+        size_type imax = 0;
+        value_type mmax = value_type(0);
+        for (size_type i = 0; i < n; ++i) {
+            value_type m = abs((*V)(i, k));
+            if (m > mmax) { mmax = m; imax = i; }
+        }
+        if (mmax > value_type(0)) {
+            complex_type phase = (*V)(imax, k) / abs((*V)(imax, k));
+            for (size_type i = 0; i < n; ++i) (*V)(i, k) /= phase;
+        }
+    }
+}
+#endif // MTL5_HAS_LAPACK
 
 /// In-place LU factorization of an n x n complex matrix (row-major, `M[i*n+j]`)
 /// with partial pivoting. Tiny pivots are floored to `pivot_floor` so that a
@@ -78,6 +180,10 @@ void eig_lu_solve(const std::vector<Complex>& M, const std::vector<std::size_t>&
 /// Returns eigenvalues as a dense_vector of complex values (real and
 /// complex-conjugate pairs read from the 1x1/2x2 blocks of the real Schur form).
 /// Throws std::runtime_error if the QR iteration fails to converge.
+///
+/// Dispatches to LAPACK geev when MTL5_HAS_LAPACK is defined and the type
+/// qualifies (column-major dense2D<float/double>); otherwise uses the in-house
+/// path above, which also serves custom number types (posits, LNS, ...).
 template <Matrix M>
 auto eigenvalue(const M& A, typename M::value_type tol = 1e-10,
                 typename M::size_type max_iter = 0) {
@@ -91,6 +197,16 @@ auto eigenvalue(const M& A, typename M::value_type tol = 1e-10,
 
     vec::dense_vector<complex_type> eigs(n);
     if (n == 0) return eigs;
+
+#ifdef MTL5_HAS_LAPACK
+    // Accelerate real float/double column-major dense matrices via LAPACK geev
+    // (mirrors the symmetric syev dispatch). Custom number types and other
+    // orientations fall through to the in-house double-shift QR below.
+    if constexpr (interface::BlasDenseMatrix<M> && !interface::is_row_major_v<M>) {
+        detail::lapack_geev(A, eigs, static_cast<mat::dense2D<complex_type>*>(nullptr));
+        return eigs;
+    }
+#endif
 
     // Reduce to upper Hessenberg form.
     mat::dense2D<value_type> H = hessenberg(A);
@@ -269,6 +385,10 @@ auto eigenvalue(const M& A, typename M::value_type tol = 1e-10,
 /// recovers the eigenvector of the true eigenvalue nearest each computed
 /// lambda_k. Since `eigenvalue` now uses a Francis double-shift QR, complex
 /// spectra of strongly non-normal matrices are resolved accurately here too.
+///
+/// Dispatches to LAPACK geev (eigenvalues + right eigenvectors) when
+/// MTL5_HAS_LAPACK is defined and the type qualifies (column-major
+/// dense2D<float/double>); otherwise uses the in-house path above.
 template <Matrix M>
 auto eigen(const M& A, typename M::value_type tol = 1e-10,
            typename M::size_type max_iter = 0) {
@@ -288,6 +408,17 @@ auto eigen(const M& A, typename M::value_type tol = 1e-10,
     if (n == 0)
         return EigenResult{vec::dense_vector<complex_type>(0),
                            mat::dense2D<complex_type>(0, 0)};
+
+#ifdef MTL5_HAS_LAPACK
+    // LAPACK geev computes eigenvalues and right eigenvectors together for real
+    // float/double column-major dense matrices (mirrors the eigenvalue dispatch).
+    if constexpr (interface::BlasDenseMatrix<M> && !interface::is_row_major_v<M>) {
+        vec::dense_vector<complex_type> eigs_l(n);
+        mat::dense2D<complex_type> V_l(n, n);
+        detail::lapack_geev(A, eigs_l, &V_l);
+        return EigenResult{eigs_l, V_l};
+    }
+#endif
 
     // Eigenvalues via the general QR iteration.
     vec::dense_vector<complex_type> eigs = eigenvalue(A, tol, max_iter);

--- a/tests/unit/interface/test_geev_dispatch.cpp
+++ b/tests/unit/interface/test_geev_dispatch.cpp
@@ -1,0 +1,130 @@
+// Exercises the LAPACK geev dispatch for the general (non-symmetric)
+// eigenproblem. The dispatch triggers for column-major float/double dense
+// matrices when MTL5_HAS_LAPACK is defined; without LAPACK these same cases
+// run the in-house double-shift QR + inverse iteration, so the test validates
+// both paths identically.
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/mat/parameter.hpp>
+#include <mtl/tag/orientation.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/operation/eigenvalue.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <vector>
+
+using namespace mtl;
+using cplx = std::complex<double>;
+using col_params = mat::parameters<tag::col_major>;
+using colmat = mat::dense2D<double, col_params>;
+
+namespace {
+
+template <typename Mat>
+double max_eigen_residual(const Mat& A,
+                          const vec::dense_vector<cplx>& eigs,
+                          const mat::dense2D<cplx>& V) {
+    const std::size_t n = A.num_rows();
+    double worst = 0.0;
+    for (std::size_t k = 0; k < n; ++k)
+        for (std::size_t i = 0; i < n; ++i) {
+            cplx axi(0.0, 0.0);
+            for (std::size_t j = 0; j < n; ++j)
+                axi += cplx(A(i, j), 0.0) * V(j, k);
+            axi -= eigs(k) * V(i, k);
+            worst = std::max(worst, std::abs(axi));
+        }
+    return worst;
+}
+
+bool spectra_match(std::vector<cplx> computed, std::vector<cplx> expected, double tol) {
+    if (computed.size() != expected.size()) return false;
+    for (const auto& e : expected) {
+        std::size_t best = computed.size();
+        double bestd = tol;
+        for (std::size_t j = 0; j < computed.size(); ++j) {
+            double d = std::abs(computed[j] - e);
+            if (d <= bestd) { bestd = d; best = j; }
+        }
+        if (best == computed.size()) return false;
+        computed.erase(computed.begin() + best);
+    }
+    return true;
+}
+
+} // namespace
+
+TEST_CASE("geev dispatch: real spectrum eigenvalues", "[interface][lapack][geev]") {
+    // Column-major matrix with eigenvalues -1, -2.
+    colmat A(2, 2);
+    A(0,0) = 0;  A(0,1) = 1;
+    A(1,0) = -2; A(1,1) = -3;
+
+    auto eigs = eigenvalue(A);
+    REQUIRE(eigs.size() == 2);
+    std::vector<cplx> computed = {eigs(0), eigs(1)};
+    REQUIRE(spectra_match(computed, {cplx(-1,0), cplx(-2,0)}, 1e-9));
+}
+
+TEST_CASE("geev dispatch: complex-conjugate spectrum", "[interface][lapack][geev]") {
+    // {{0,-1},{1,0}} -> eigenvalues +/- i.
+    colmat A(2, 2);
+    A(0,0) = 0; A(0,1) = -1;
+    A(1,0) = 1; A(1,1) =  0;
+
+    auto [eigs, V] = eigen(A);
+    REQUIRE(eigs.size() == 2);
+    std::vector<cplx> computed = {eigs(0), eigs(1)};
+    REQUIRE(spectra_match(computed, {cplx(0,1), cplx(0,-1)}, 1e-9));
+    // Complex eigenvectors satisfy the eigen relation and are unit norm.
+    REQUIRE(max_eigen_residual(A, eigs, V) < 1e-10);
+    for (std::size_t k = 0; k < 2; ++k) {
+        double s = 0.0;
+        for (std::size_t i = 0; i < 2; ++i) s += std::norm(V(i, k));
+        REQUIRE_THAT(std::sqrt(s), Catch::Matchers::WithinAbs(1.0, 1e-10));
+    }
+}
+
+TEST_CASE("geev dispatch: mixed real + complex 4x4 eigenpairs", "[interface][lapack][geev]") {
+    // Block-triangular: eigenvalues 5, 2, and 1 +/- 2i.
+    colmat A(4, 4);
+    const double B[4][4] = {{5, 1, 0,  0},
+                            {0, 2, 1,  0},
+                            {0, 0, 1, -2},
+                            {0, 0, 2,  1}};
+    for (std::size_t i = 0; i < 4; ++i)
+        for (std::size_t j = 0; j < 4; ++j)
+            A(i, j) = B[i][j];
+
+    auto [eigs, V] = eigen(A);
+    REQUIRE(eigs.size() == 4);
+    REQUIRE(max_eigen_residual(A, eigs, V) < 1e-10);
+
+    std::vector<cplx> computed(4);
+    for (std::size_t k = 0; k < 4; ++k) computed[k] = eigs(k);
+    REQUIRE(spectra_match(computed, {cplx(5,0), cplx(2,0), cplx(1,2), cplx(1,-2)}, 1e-9));
+}
+
+TEST_CASE("geev dispatch: agrees with the in-house path (row-major)", "[interface][lapack][geev]") {
+    // Same matrix in both orientations: column-major goes through geev (when
+    // LAPACK is on), row-major always through the in-house QR. Spectra match.
+    const double B[3][3] = {{4, 1, -1},
+                            {2, 3,  0},
+                            {1, 0,  2}};
+    colmat Ac(3, 3);
+    mat::dense2D<double> Ar(3, 3);
+    for (std::size_t i = 0; i < 3; ++i)
+        for (std::size_t j = 0; j < 3; ++j) { Ac(i, j) = B[i][j]; Ar(i, j) = B[i][j]; }
+
+    auto ec = eigenvalue(Ac);
+    auto er = eigenvalue(Ar);
+    std::vector<cplx> vc(3), vr(3);
+    for (std::size_t k = 0; k < 3; ++k) { vc[k] = ec(k); vr[k] = er(k); }
+    // Cross-check both spectra against each other.
+    std::vector<cplx> vr_copy = vr;
+    REQUIRE(spectra_match(vc, vr_copy, 1e-8));
+}


### PR DESCRIPTION
Closes #204. Part of epic #202.

## What

Adds a LAPACK `geev` fast path for the **general (non-symmetric)** eigenproblem,
mirroring the existing symmetric `syev` dispatch. Both entry points route
through `geev` when `MTL5_HAS_LAPACK` is defined and the type qualifies:

- `eigenvalue(A)` — values only (`jobvr='N'`)
- `eigen(A)` — values + right eigenvectors (`jobvr='V'`)

Everything else — row-major matrices and custom number types (posits, LNS, …) —
falls through to the in-house **Francis double-shift QR + inverse iteration**
path from #209/#203, which is always available.

## Gating

`interface::BlasDenseMatrix<M> && !interface::is_row_major_v<M>` — real
`float`/`double`, **column-major** `dense2D` (same convention as `syev`). The
column-major working copy is built through the `(i,j)` accessor, so it is
correct irrespective of the source orientation.

## Eigenvector unpacking

`geev` packs a complex-conjugate pair `(j, j+1)` as `vr[:,j] ± i·vr[:,j+1]`;
this is unpacked into complex columns, unit-normalized with the **same canonical
phase** (largest-magnitude entry real-positive) as the in-house path, so the two
backends are interchangeable up to sign/phase.

## Behavior on failure

Throws `std::runtime_error` if `geev` reports non-convergence (`info != 0`) —
consistent with the in-house path's non-convergence signal.

## Verification

- New `tests/unit/interface/test_geev_dispatch.cpp`: real, complex-conjugate,
  mixed real+complex 4×4, and a cross-check of the column-major (`geev`) vs
  row-major (in-house) spectra.
- **Confirmed the `geev` path is genuinely exercised**, not silently skipped:
  `dgeev_` is an undefined symbol in the test binary, and compile-time probes
  confirm the predicates route `colmat → geev`, `rowmat → in-house`.
- Full suite green **with LAPACK (131 tests) and without (130)**, on **GCC and
  Clang**. The existing row-major eigen tests are unaffected (still the in-house
  path).

## Note

`interface/lapack.hpp` still has no `hseqr`/`gehrd`/`trevc` bindings — `geev`
covers the whole general eigenproblem in one call, which is sufficient here.
Those finer-grained routines can be added later if a Schur-vector-accumulating
path is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
