### PR TITLE
feat(itl): matrix-free iterative eigensolvers -- power / Lanczos / Arnoldi (#205)

### DIFF
--- a/docs/algorithms/eigenvalues.md
+++ b/docs/algorithms/eigenvalues.md
@@ -1,9 +1,13 @@
 # Eigenvalues and Eigenvectors
 
-MTL5 provides a dense eigen suite in namespace `mtl` (headers under
-`include/mtl/operation/`). This page covers the routines available today and how
-to choose between them. It is the seed of a fuller guide that will grow as the
-iterative and sparse eigensolvers land.
+MTL5 provides a **dense** eigen suite in namespace `mtl` (headers under
+`include/mtl/operation/`) and a set of **matrix-free iterative** eigensolvers in
+namespace `mtl::itl` (headers under `include/mtl/itl/eigen/`). This page covers
+the routines available today and how to choose between them.
+
+Use the dense suite for small/medium matrices where you want the whole spectrum;
+use the iterative solvers for large or matrix-free operators where you want a few
+eigenpairs and can only apply `A * x`.
 
 ## Which routine do I call?
 
@@ -78,3 +82,44 @@ matrix is a column-major `dense2D<float/double>`.
 auto s = mtl::eigenvalue_symmetric(S);       // ascending eigenvalues
 auto [eigs, Q] = mtl::eigen_symmetric(S);     // A = Q * diag(eigs) * Q^T
 ```
+
+## Iterative (matrix-free) eigensolvers
+
+For large matrices where a full dense factorization is infeasible, use the
+Krylov eigensolvers in `mtl::itl`. They operate through the `LinearOperator`
+concept — only `A * x` is required — so they apply to `dense2D`, `compressed2D`,
+and user-supplied matrix-free operators alike.
+
+| Function | Operator | Returns |
+|---|---|---|
+| `itl::power_iteration(A, v0)` | any (real dominant) | dominant eigenpair (`eigenpair<T>`) |
+| `itl::lanczos(A, v0, k, which)` | **symmetric** | k extremal Ritz pairs (`ritz_pairs<T>`) |
+| `itl::arnoldi(A, v0, k, which)` | general | k Ritz pairs (`ritz_pairs<complex<T>>`) |
+
+`which` is an `itl::eigen_which` selector — `largest_magnitude`,
+`smallest_magnitude`, `largest_algebraic`, `smallest_algebraic`. The optional
+`subspace` argument sets the Krylov dimension (default: a modest multiple of `k`,
+capped at `n`); a larger subspace converges more eigenpairs to tighter residuals.
+Each solver projects onto its Krylov subspace and solves the small projected
+problem (tridiagonal for Lanczos, Hessenberg for Arnoldi) with the dense
+routines above — so accuracy of the projected solve rides on the same code.
+
+```cpp
+#include <mtl/itl/eigen/eigensolvers.hpp>
+
+// Dominant eigenpair of a symmetric/SPD operator.
+auto p = mtl::itl::power_iteration(A, v0);
+// p.value, p.vector, p.converged
+
+// The 5 largest eigenpairs of a large symmetric operator (matrix-free ok).
+auto r = mtl::itl::lanczos(A, v0, 5, mtl::itl::eigen_which::largest_algebraic);
+// r.values (dense_vector), r.vectors (columns), r.converged
+
+// A few eigenpairs of a nonsymmetric operator (complex Ritz values).
+auto g = mtl::itl::arnoldi(A, v0, 4, mtl::itl::eigen_which::largest_magnitude);
+```
+
+These are single-shot (non-restarted) builds with full reorthogonalization —
+robust and simple. Implicit/thick restarting and shift-invert for interior
+eigenvalues (which turns "smallest" into "largest of `(A - sigma I)^{-1}`" using
+the sparse direct solvers) are planned follow-ups for the sparse eigensolver.

--- a/include/mtl/itl/eigen/arnoldi.hpp
+++ b/include/mtl/itl/eigen/arnoldi.hpp
@@ -1,0 +1,137 @@
+#pragma once
+// MTL5 -- Arnoldi iteration for a few eigenpairs of a GENERAL (non-symmetric)
+// linear operator. Matrix-free (only needs A * x). Builds an orthonormal Krylov
+// basis and an upper Hessenberg projection, whose eigenpairs (via the dense
+// general eigen) give the Ritz pairs. Full reorthogonalization for robustness.
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <limits>
+#include <vector>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/operation/dot.hpp>
+#include <mtl/operation/norms.hpp>
+#include <mtl/operation/eigenvalue.hpp>
+#include <mtl/itl/eigen/eigen_common.hpp>
+
+namespace mtl::itl {
+
+/// Compute `k` eigenpairs of a general operator `A` by the Arnoldi method.
+/// `v0` is the starting vector; `which` selects which Ritz values to keep
+/// (magnitude selectors, or algebraic selectors on the real part); `subspace`
+/// is the Krylov dimension to build (default: a modest multiple of k, capped at
+/// n); `tol` flags convergence via the Ritz residual estimate.
+///
+/// Returns k complex Ritz values (ordered per `which`) and their complex Ritz
+/// vectors (columns). A is any LinearOperator.
+template <typename LinearOp, typename T>
+ritz_pairs<std::complex<T>> arnoldi(const LinearOp& A, vec::dense_vector<T> v0,
+                                    std::size_t k,
+                                    eigen_which which = eigen_which::largest_magnitude,
+                                    std::size_t subspace = 0, T tol = T(1e-8)) {
+    using std::abs;
+    using complex_type = std::complex<T>;
+    using size_type = typename vec::dense_vector<T>::size_type;
+    const size_type n = v0.size();
+
+    ritz_pairs<complex_type> out;
+    if (n == 0 || k == 0) return out;
+
+    size_type m = subspace ? subspace
+                           : std::max<size_type>(2 * k + 20, 20);
+    if (m > n) m = n;
+    if (k > m) k = m;
+
+    const T breakdown = std::sqrt(std::numeric_limits<T>::epsilon());
+
+    mat::dense2D<T> V(n, m);
+    mat::dense2D<T> H(m, m);            // upper Hessenberg projection
+    for (size_type i = 0; i < m; ++i)
+        for (size_type j = 0; j < m; ++j)
+            H(i, j) = T(0);
+
+    T nv = mtl::two_norm(v0);
+    if (nv == T(0)) { v0(0) = T(1); nv = T(1); }
+    vec::dense_vector<T> q(n), w(n);
+    for (size_type i = 0; i < n; ++i) q(i) = v0(i) / nv;
+
+    size_type built = 0;
+    T h_next = T(0);   // ||r_m||: subdiagonal past the last built column
+    for (size_type j = 0; j < m; ++j) {
+        for (size_type i = 0; i < n; ++i) V(i, j) = q(i);
+
+        w = ev_matvec(A, q);
+
+        // Modified Gram-Schmidt with a second pass for numerical stability.
+        for (int pass = 0; pass < 2; ++pass)
+            for (size_type c = 0; c <= j; ++c) {
+                T s = T(0);
+                for (size_type i = 0; i < n; ++i) s += V(i, c) * w(i);
+                H(c, j) += s;
+                for (size_type i = 0; i < n; ++i) w(i) -= s * V(i, c);
+            }
+
+        built = j + 1;
+        T hn = mtl::two_norm(w);
+        h_next = hn;
+        if (hn <= breakdown) break;         // invariant subspace found
+        if (j + 1 < m) { H(j + 1, j) = hn; for (size_type i = 0; i < n; ++i) q(i) = w(i) / hn; }
+    }
+    m = built;
+
+    // Trim H to the built m x m block if we stopped early.
+    mat::dense2D<T> Hm(m, m);
+    for (size_type i = 0; i < m; ++i)
+        for (size_type j = 0; j < m; ++j)
+            Hm(i, j) = H(i, j);
+
+    // Dense general eigensolve of the small Hessenberg block.
+    auto es = mtl::eigen(Hm);
+    const auto& mu = es.eigenvalues;    // size m, complex
+    const auto& S  = es.eigenvectors;   // m x m, complex, column i = eigvec of Hm
+
+    // Order the m Ritz values per `which`, then take the first k.
+    std::vector<size_type> order(m);
+    for (size_type i = 0; i < m; ++i) order[i] = i;
+    switch (which) {
+        case eigen_which::largest_magnitude:
+            std::sort(order.begin(), order.end(),
+                      [&](size_type a2, size_type b2){ return std::abs(mu(a2)) > std::abs(mu(b2)); });
+            break;
+        case eigen_which::smallest_magnitude:
+            std::sort(order.begin(), order.end(),
+                      [&](size_type a2, size_type b2){ return std::abs(mu(a2)) < std::abs(mu(b2)); });
+            break;
+        case eigen_which::largest_algebraic:
+            std::sort(order.begin(), order.end(),
+                      [&](size_type a2, size_type b2){ return mu(a2).real() > mu(b2).real(); });
+            break;
+        case eigen_which::smallest_algebraic:
+            std::sort(order.begin(), order.end(),
+                      [&](size_type a2, size_type b2){ return mu(a2).real() < mu(b2).real(); });
+            break;
+    }
+
+    out.values.change_dim(k);
+    out.vectors = mat::dense2D<complex_type>(n, k);
+    out.subspace = static_cast<int>(m);
+    bool all_conv = true;
+    for (size_type w2 = 0; w2 < k; ++w2) {
+        size_type c = order[w2];
+        out.values(w2) = mu(c);
+        // Ritz vector y = V(:,0..m-1) * S(:,c)  (real V times complex S).
+        for (size_type i = 0; i < n; ++i) {
+            complex_type acc(0);
+            for (size_type r = 0; r < m; ++r) acc += complex_type(V(i, r)) * S(r, c);
+            out.vectors(i, w2) = acc;
+        }
+        // Ritz residual estimate: |h_next| * |last component of S(:,c)|.
+        T rest = abs(h_next) * std::abs(S(m - 1, c));
+        if (rest > tol * (std::abs(mu(c)) + tol)) all_conv = false;
+    }
+    out.converged = all_conv;
+    return out;
+}
+
+} // namespace mtl::itl

--- a/include/mtl/itl/eigen/eigen_common.hpp
+++ b/include/mtl/itl/eigen/eigen_common.hpp
@@ -1,0 +1,40 @@
+#pragma once
+// MTL5 -- Shared types/utilities for the iterative (Krylov) eigensolvers.
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/mat/dense2D.hpp>
+
+namespace mtl::itl {
+
+/// Which end of the spectrum a Krylov eigensolver should return.
+/// Algebraic selectors apply to real (symmetric) spectra; magnitude selectors
+/// apply to any spectrum (including complex Arnoldi Ritz values).
+enum class eigen_which {
+    largest_magnitude,
+    smallest_magnitude,
+    largest_algebraic,
+    smallest_algebraic
+};
+
+/// A set of computed Ritz pairs (approximate eigenpairs from a Krylov subspace).
+/// `Value` is real for symmetric (Lanczos) solvers and std::complex for general
+/// (Arnoldi) solvers.
+template <typename Value>
+struct ritz_pairs {
+    vec::dense_vector<Value> values;   ///< k wanted Ritz values
+    mat::dense2D<Value> vectors;       ///< n x k, column i is the Ritz vector for values(i)
+    int subspace = 0;                  ///< Krylov subspace dimension actually built
+    bool converged = false;            ///< all wanted pairs met the residual tolerance
+};
+
+/// Apply a LinearOperator and materialize the result as a dense_vector.
+template <typename LinearOp, typename T>
+vec::dense_vector<T> ev_matvec(const LinearOp& A, const vec::dense_vector<T>& x) {
+    auto w = A * x;
+    const auto n = x.size();
+    vec::dense_vector<T> y(n);
+    for (typename vec::dense_vector<T>::size_type i = 0; i < n; ++i)
+        y(i) = w(i);
+    return y;
+}
+
+} // namespace mtl::itl

--- a/include/mtl/itl/eigen/eigensolvers.hpp
+++ b/include/mtl/itl/eigen/eigensolvers.hpp
@@ -1,0 +1,10 @@
+#pragma once
+// MTL5 -- Iterative (Krylov) eigensolvers umbrella.
+// Matrix-free eigenvalue methods that operate through the LinearOperator
+// concept (A * x), so they apply to dense2D, compressed2D, and user-supplied
+// matrix-free operators alike. Each projects onto a Krylov subspace and solves
+// the small projected problem with the dense eigensolvers in namespace mtl.
+#include <mtl/itl/eigen/eigen_common.hpp>
+#include <mtl/itl/eigen/power_iteration.hpp>
+#include <mtl/itl/eigen/lanczos.hpp>
+#include <mtl/itl/eigen/arnoldi.hpp>

--- a/include/mtl/itl/eigen/lanczos.hpp
+++ b/include/mtl/itl/eigen/lanczos.hpp
@@ -1,0 +1,146 @@
+#pragma once
+// MTL5 -- Lanczos iteration for a few extremal eigenpairs of a SYMMETRIC
+// linear operator. Matrix-free (only needs A * x). Builds an orthonormal Krylov
+// basis and a symmetric tridiagonal projection, whose eigenpairs (via the dense
+// eigen_symmetric) give the Ritz pairs. Full reorthogonalization keeps the basis
+// orthogonal for a robust reference implementation.
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <vector>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/operation/dot.hpp>
+#include <mtl/operation/norms.hpp>
+#include <mtl/operation/eigenvalue_symmetric.hpp>
+#include <mtl/itl/eigen/eigen_common.hpp>
+
+namespace mtl::itl {
+
+/// Compute `k` extremal eigenpairs of a symmetric operator `A` by the Lanczos
+/// method. `v0` is the starting vector; `which` selects the end of the spectrum;
+/// `subspace` is the Krylov dimension to build (default: a modest multiple of k,
+/// capped at n -- larger is more accurate); `tol` is the Ritz residual
+/// tolerance used to flag convergence.
+///
+/// Returns k Ritz values (ordered per `which`) and their Ritz vectors (columns).
+/// A is any LinearOperator; it MUST be symmetric for the tridiagonal projection
+/// to be meaningful.
+template <typename LinearOp, typename T>
+ritz_pairs<T> lanczos(const LinearOp& A, vec::dense_vector<T> v0, std::size_t k,
+                      eigen_which which = eigen_which::largest_algebraic,
+                      std::size_t subspace = 0, T tol = T(1e-8)) {
+    using std::abs;
+    using size_type = typename vec::dense_vector<T>::size_type;
+    const size_type n = v0.size();
+
+    ritz_pairs<T> out;
+    if (n == 0 || k == 0) return out;
+
+    size_type m = subspace ? subspace
+                           : std::max<size_type>(2 * k + 20, 20);
+    if (m > n) m = n;
+    if (k > m) k = m;
+
+    const T breakdown = std::sqrt(std::numeric_limits<T>::epsilon());
+
+    // Orthonormal Lanczos basis (columns) and tridiagonal entries.
+    mat::dense2D<T> V(n, m);
+    std::vector<T> alpha(m, T(0));
+    std::vector<T> beta(m, T(0));   // beta[j] links columns j-1 and j; beta[0] unused
+
+    T nv = mtl::two_norm(v0);
+    if (nv == T(0)) { v0(0) = T(1); nv = T(1); }
+    vec::dense_vector<T> q(n), q_prev(n, T(0)), w(n);
+    for (size_type i = 0; i < n; ++i) q(i) = v0(i) / nv;
+
+    size_type built = 0;
+    T beta_next = T(0);   // ||r_m||: residual norm past the last built column
+    for (size_type j = 0; j < m; ++j) {
+        for (size_type i = 0; i < n; ++i) V(i, j) = q(i);
+
+        w = ev_matvec(A, q);
+        if (j > 0)
+            for (size_type i = 0; i < n; ++i) w(i) -= beta[j] * q_prev(i);
+
+        T a = mtl::dot(q, w);
+        alpha[j] = a;
+        for (size_type i = 0; i < n; ++i) w(i) -= a * q(i);
+
+        // Full reorthogonalization (two passes) against all built columns.
+        for (int pass = 0; pass < 2; ++pass)
+            for (size_type c = 0; c <= j; ++c) {
+                T s = T(0);
+                for (size_type i = 0; i < n; ++i) s += V(i, c) * w(i);
+                for (size_type i = 0; i < n; ++i) w(i) -= s * V(i, c);
+            }
+
+        built = j + 1;
+        T bn = mtl::two_norm(w);
+        beta_next = bn;
+        if (bn <= breakdown) break;         // invariant subspace found
+        if (j + 1 < m) beta[j + 1] = bn;
+        for (size_type i = 0; i < n; ++i) { q_prev(i) = q(i); q(i) = w(i) / bn; }
+    }
+    m = built;
+
+    // Symmetric tridiagonal projection T_m.
+    mat::dense2D<T> Tm(m, m);
+    for (size_type i = 0; i < m; ++i)
+        for (size_type j = 0; j < m; ++j)
+            Tm(i, j) = T(0);
+    for (size_type j = 0; j < m; ++j) Tm(j, j) = alpha[j];
+    for (size_type j = 1; j < m; ++j) { Tm(j, j - 1) = beta[j]; Tm(j - 1, j) = beta[j]; }
+
+    // Dense symmetric eigensolve of the small tridiagonal (theta ascending).
+    auto es = mtl::eigen_symmetric(Tm);
+    const auto& theta = es.eigenvalues;    // size m, ascending
+    const auto& S     = es.eigenvectors;   // m x m, column i = eigvec of Tm
+
+    // Order the m Ritz values per `which`, then take the first k.
+    std::vector<size_type> order(m);
+    for (size_type i = 0; i < m; ++i) order[i] = i;
+    auto by = [&](eigen_which w2) {
+        switch (w2) {
+            case eigen_which::largest_algebraic:
+                std::sort(order.begin(), order.end(),
+                          [&](size_type a2, size_type b2){ return theta(a2) > theta(b2); });
+                break;
+            case eigen_which::smallest_algebraic:
+                std::sort(order.begin(), order.end(),
+                          [&](size_type a2, size_type b2){ return theta(a2) < theta(b2); });
+                break;
+            case eigen_which::largest_magnitude:
+                std::sort(order.begin(), order.end(),
+                          [&](size_type a2, size_type b2){ return abs(theta(a2)) > abs(theta(b2)); });
+                break;
+            case eigen_which::smallest_magnitude:
+                std::sort(order.begin(), order.end(),
+                          [&](size_type a2, size_type b2){ return abs(theta(a2)) < abs(theta(b2)); });
+                break;
+        }
+    };
+    by(which);
+
+    out.values.change_dim(k);
+    out.vectors = mat::dense2D<T>(n, k);
+    out.subspace = static_cast<int>(m);
+    bool all_conv = true;
+    for (size_type w2 = 0; w2 < k; ++w2) {
+        size_type c = order[w2];
+        out.values(w2) = theta(c);
+        // Ritz vector y = V(:,0..m-1) * S(:,c).
+        for (size_type i = 0; i < n; ++i) {
+            T acc = T(0);
+            for (size_type r = 0; r < m; ++r) acc += V(i, r) * S(r, c);
+            out.vectors(i, w2) = acc;
+        }
+        // Ritz residual estimate: |beta_next| * |last component of S(:,c)|.
+        T rest = abs(beta_next) * abs(S(m - 1, c));
+        if (rest > tol * (abs(theta(c)) + tol)) all_conv = false;
+    }
+    out.converged = all_conv;
+    return out;
+}
+
+} // namespace mtl::itl

--- a/include/mtl/itl/eigen/power_iteration.hpp
+++ b/include/mtl/itl/eigen/power_iteration.hpp
@@ -1,0 +1,79 @@
+#pragma once
+// MTL5 -- Power iteration for the dominant eigenpair of a linear operator.
+// Matrix-free: only needs A * x (the LinearOperator concept), so it applies to
+// dense2D, compressed2D, and user-supplied matrix-free operators alike.
+#include <cmath>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/operation/dot.hpp>
+#include <mtl/operation/norms.hpp>
+#include <mtl/itl/eigen/eigen_common.hpp>
+
+namespace mtl::itl {
+
+/// A single computed eigenpair.
+template <typename T>
+struct eigenpair {
+    T value;                       ///< eigenvalue estimate (Rayleigh quotient)
+    vec::dense_vector<T> vector;   ///< unit-norm eigenvector estimate
+    int iterations = 0;
+    bool converged = false;
+};
+
+/// Power iteration for the eigenvalue of largest magnitude (assumed real and
+/// dominant, as for symmetric / SPD operators or any operator with a real
+/// dominant eigenvalue). Returns the Rayleigh-quotient eigenvalue and unit
+/// eigenvector. Converges when the Ritz residual ||A v - lambda v|| <= tol.
+///
+/// `A` is any LinearOperator (A * v yields a vector); `v0` is the starting
+/// vector (need not be normalized). O(1) vectors of storage; one matvec/iter.
+template <typename LinearOp, typename T>
+eigenpair<T> power_iteration(const LinearOp& A, vec::dense_vector<T> v0,
+                             int max_iter = 1000, T tol = T(1e-10)) {
+    using std::abs;
+    using size_type = typename vec::dense_vector<T>::size_type;
+    const size_type n = v0.size();
+
+    eigenpair<T> result;
+    result.vector = v0;
+    if (n == 0) return result;
+
+    // Normalize the start vector.
+    T nv = mtl::two_norm(v0);
+    if (nv == T(0)) { v0(0) = T(1); nv = T(1); }
+    for (size_type i = 0; i < n; ++i) v0(i) /= nv;
+
+    T lambda = T(0);
+    int it = 0;
+    for (; it < max_iter; ++it) {
+        vec::dense_vector<T> w = ev_matvec(A, v0);
+
+        // Rayleigh quotient (v is unit norm): lambda = v^T A v.
+        lambda = mtl::dot(v0, w);
+
+        // Ritz residual r = A v - lambda v.
+        T res = T(0);
+        for (size_type i = 0; i < n; ++i) {
+            T ri = w(i) - lambda * v0(i);
+            res += ri * ri;
+        }
+        res = std::sqrt(res);
+
+        // Normalize w to become the next iterate.
+        T nw = mtl::two_norm(w);
+        if (nw == T(0)) break;               // A v = 0: v spans a null vector
+        for (size_type i = 0; i < n; ++i) v0(i) = w(i) / nw;
+
+        if (res <= tol * (abs(lambda) + tol)) {
+            result.converged = true;
+            ++it;
+            break;
+        }
+    }
+
+    result.value = lambda;
+    result.vector = v0;
+    result.iterations = it;
+    return result;
+}
+
+} // namespace mtl::itl

--- a/include/mtl/itl/itl.hpp
+++ b/include/mtl/itl/itl.hpp
@@ -30,6 +30,9 @@
 #include <mtl/itl/pc/ssor.hpp>
 #include <mtl/itl/pc/solver.hpp>
 
+// Iterative (Krylov) eigensolvers
+#include <mtl/itl/eigen/eigensolvers.hpp>
+
 // Smoothers
 #include <mtl/itl/smoother/gauss_seidel.hpp>
 #include <mtl/itl/smoother/jacobi.hpp>

--- a/tests/unit/itl/test_eigensolvers.cpp
+++ b/tests/unit/itl/test_eigensolvers.cpp
@@ -1,0 +1,210 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/operation/operators.hpp>
+#include <mtl/itl/eigen/eigensolvers.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <vector>
+
+using namespace mtl;
+using cplx = std::complex<double>;
+
+namespace {
+
+// 1D Laplacian (SPD tridiagonal), eigenvalues 2-2cos(k*pi/(n+1)).
+mat::dense2D<double> laplacian1d(std::size_t n) {
+    mat::dense2D<double> A(n, n);
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j) A(i, j) = 0.0;
+    for (std::size_t i = 0; i < n; ++i) {
+        A(i, i) = 2.0;
+        if (i > 0)     A(i, i - 1) = -1.0;
+        if (i + 1 < n) A(i, i + 1) = -1.0;
+    }
+    return A;
+}
+
+std::vector<double> laplacian1d_eigs(std::size_t n) {
+    std::vector<double> e(n);
+    for (std::size_t k = 1; k <= n; ++k)
+        e[k - 1] = 2.0 - 2.0 * std::cos(k * 3.14159265358979323846 / (n + 1));
+    std::sort(e.begin(), e.end());
+    return e;
+}
+
+// A matrix-free operator: y = A * x for a fixed dense A, to exercise the
+// LinearOperator path with a user type rather than dense2D directly.
+struct MatFreeOp {
+    const mat::dense2D<double>& A;
+    vec::dense_vector<double> operator*(const vec::dense_vector<double>& x) const {
+        const std::size_t n = A.num_rows();
+        vec::dense_vector<double> y(n, 0.0);
+        for (std::size_t i = 0; i < n; ++i) {
+            double s = 0.0;
+            for (std::size_t j = 0; j < n; ++j) s += A(i, j) * x(j);
+            y(i) = s;
+        }
+        return y;
+    }
+};
+
+} // namespace
+
+TEST_CASE("power_iteration: dominant eigenpair of SPD Laplacian", "[itl][eigen][power]") {
+    const std::size_t n = 20;
+    auto A = laplacian1d(n);
+    auto expected = laplacian1d_eigs(n);
+    double lambda_max = expected.back();
+
+    vec::dense_vector<double> v0(n, 1.0);
+    v0(0) = 1.7;  // break symmetry with the null-ish modes
+    auto pair = itl::power_iteration(A, v0, 5000, 1e-11);
+
+    REQUIRE(pair.converged);
+    REQUIRE_THAT(pair.value, Catch::Matchers::WithinAbs(lambda_max, 1e-6));
+
+    // Residual A v - lambda v is small.
+    auto Av = A * pair.vector;
+    double res = 0.0;
+    for (std::size_t i = 0; i < n; ++i) {
+        double r = Av(i) - pair.value * pair.vector(i);
+        res += r * r;
+    }
+    REQUIRE(std::sqrt(res) < 1e-6);
+}
+
+TEST_CASE("lanczos: largest and smallest eigenvalues of SPD Laplacian", "[itl][eigen][lanczos]") {
+    const std::size_t n = 30;
+    auto A = laplacian1d(n);
+    auto expected = laplacian1d_eigs(n);
+
+    vec::dense_vector<double> v0(n);
+    for (std::size_t i = 0; i < n; ++i) v0(i) = 1.0 + 0.1 * static_cast<double>(i);
+
+    // Use a full subspace so the extremal Ritz pairs converge deterministically
+    // (the default subspace still recovers the values, just not to 1e-8 residual).
+    SECTION("largest algebraic") {
+        auto r = itl::lanczos(A, v0, 3, itl::eigen_which::largest_algebraic, n);
+        REQUIRE(r.values.size() == 3);
+        REQUIRE(r.converged);
+        // values are ordered largest-first
+        REQUIRE_THAT(r.values(0), Catch::Matchers::WithinAbs(expected[n-1], 1e-7));
+        REQUIRE_THAT(r.values(1), Catch::Matchers::WithinAbs(expected[n-2], 1e-7));
+        REQUIRE_THAT(r.values(2), Catch::Matchers::WithinAbs(expected[n-3], 1e-7));
+    }
+    SECTION("smallest algebraic") {
+        auto r = itl::lanczos(A, v0, 3, itl::eigen_which::smallest_algebraic, n);
+        REQUIRE(r.converged);
+        REQUIRE_THAT(r.values(0), Catch::Matchers::WithinAbs(expected[0], 1e-7));
+        REQUIRE_THAT(r.values(1), Catch::Matchers::WithinAbs(expected[1], 1e-7));
+        REQUIRE_THAT(r.values(2), Catch::Matchers::WithinAbs(expected[2], 1e-7));
+    }
+}
+
+TEST_CASE("lanczos: Ritz vectors satisfy the eigen relation", "[itl][eigen][lanczos]") {
+    const std::size_t n = 25;
+    auto A = laplacian1d(n);
+    vec::dense_vector<double> v0(n, 1.0);
+    v0(1) = 2.0;
+
+    auto r = itl::lanczos(A, v0, 4, itl::eigen_which::largest_algebraic);
+    REQUIRE(r.values.size() == 4);
+    for (std::size_t c = 0; c < 4; ++c) {
+        // extract column c
+        vec::dense_vector<double> y(n);
+        for (std::size_t i = 0; i < n; ++i) y(i) = r.vectors(i, c);
+        auto Ay = A * y;
+        double res = 0.0, nrm = 0.0;
+        for (std::size_t i = 0; i < n; ++i) {
+            double ri = Ay(i) - r.values(c) * y(i);
+            res += ri * ri; nrm += y(i) * y(i);
+        }
+        REQUIRE_THAT(std::sqrt(nrm), Catch::Matchers::WithinAbs(1.0, 1e-8));
+        REQUIRE(std::sqrt(res) < 1e-6);
+    }
+}
+
+TEST_CASE("lanczos: works through a matrix-free operator", "[itl][eigen][lanczos]") {
+    const std::size_t n = 20;
+    auto A = laplacian1d(n);
+    auto expected = laplacian1d_eigs(n);
+    MatFreeOp op{A};
+
+    vec::dense_vector<double> v0(n, 1.0);
+    v0(0) = 1.3;
+    auto r = itl::lanczos(op, v0, 2, itl::eigen_which::largest_algebraic);
+    REQUIRE(r.converged);
+    REQUIRE_THAT(r.values(0), Catch::Matchers::WithinAbs(expected[n-1], 1e-7));
+    REQUIRE_THAT(r.values(1), Catch::Matchers::WithinAbs(expected[n-2], 1e-7));
+}
+
+TEST_CASE("arnoldi: eigenpairs of a nonsymmetric operator", "[itl][eigen][arnoldi]") {
+    // Block-diagonal-ish nonsymmetric matrix with a known real dominant
+    // eigenvalue 10 and a complex pair 2 +/- i.
+    const std::size_t n = 6;
+    mat::dense2D<double> A(n, n);
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j) A(i, j) = 0.0;
+    A(0,0) = 10.0;                       // dominant real
+    A(1,1) = 2.0; A(1,2) = -1.0;         // 2 +/- i block
+    A(2,1) = 1.0; A(2,2) = 2.0;
+    A(3,3) = 4.0;
+    A(4,4) = -3.0;
+    A(5,5) = 1.0;
+
+    vec::dense_vector<double> v0(n, 1.0);
+    v0(2) = 0.5;
+    auto r = itl::arnoldi(A, v0, 3, itl::eigen_which::largest_magnitude);
+    REQUIRE(r.values.size() == 3);
+    REQUIRE(r.converged);
+
+    // Dominant Ritz value is 10.
+    REQUIRE_THAT(r.values(0).real(), Catch::Matchers::WithinAbs(10.0, 1e-7));
+    REQUIRE_THAT(r.values(0).imag(), Catch::Matchers::WithinAbs(0.0, 1e-8));
+
+    // Each Ritz pair satisfies A y = mu y (complex).
+    for (std::size_t c = 0; c < 3; ++c) {
+        double res = 0.0;
+        for (std::size_t i = 0; i < n; ++i) {
+            cplx Ay(0.0, 0.0);
+            for (std::size_t j = 0; j < n; ++j)
+                Ay += cplx(A(i, j), 0.0) * r.vectors(j, c);
+            Ay -= r.values(c) * r.vectors(i, c);
+            res += std::norm(Ay);
+        }
+        REQUIRE(std::sqrt(res) < 1e-6);
+    }
+}
+
+TEST_CASE("arnoldi: recovers a complex-conjugate pair", "[itl][eigen][arnoldi]") {
+    const std::size_t n = 5;
+    mat::dense2D<double> A(n, n);
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j) A(i, j) = 0.0;
+    // 3 +/- 2i block plus real eigenvalues 1, -1, 5.
+    A(0,0) = 3.0; A(0,1) = -2.0;
+    A(1,0) = 2.0; A(1,1) = 3.0;
+    A(2,2) = 5.0;
+    A(3,3) = 1.0;
+    A(4,4) = -1.0;
+
+    vec::dense_vector<double> v0(n, 1.0);
+    v0(1) = 0.7;
+    auto r = itl::arnoldi(A, v0, 5, itl::eigen_which::largest_magnitude, n);
+
+    // The full spectrum (subspace = n) must contain 3 +/- 2i.
+    std::vector<cplx> got(r.values.size());
+    for (std::size_t i = 0; i < r.values.size(); ++i) got[i] = r.values(i);
+    auto has = [&](cplx target) {
+        return std::any_of(got.begin(), got.end(),
+                           [&](cplx z){ return std::abs(z - target) < 1e-6; });
+    };
+    REQUIRE(has(cplx(3, 2)));
+    REQUIRE(has(cplx(3, -2)));
+    REQUIRE(has(cplx(5, 0)));
+}


### PR DESCRIPTION
Closes #205. Part of epic #202.

## What

Adds matrix-free Krylov eigensolvers under `include/mtl/itl/eigen/`
(namespace `mtl::itl`). They operate through the `LinearOperator` concept — only
`A * x` is needed — so they work for `dense2D`, `compressed2D`, and
user-supplied matrix-free operators alike.

| Function | Operator | Method | Returns |
|---|---|---|---|
| `power_iteration(A, v0)` | any (real dominant) | power + Rayleigh quotient | dominant `eigenpair<T>` |
| `lanczos(A, v0, k, which)` | **symmetric** | Lanczos → tridiagonal | k `ritz_pairs<T>` |
| `arnoldi(A, v0, k, which)` | general | Arnoldi → Hessenberg | k `ritz_pairs<complex<T>>` |

Each projects onto a Krylov subspace and solves the small projected problem with
the **dense eigensolvers from #203/#204/#209** (`eigen_symmetric` for Lanczos,
`eigen` for Arnoldi) — nice reuse, and the projected-solve accuracy rides on
already-tested code.

## API

- `eigen_which` selector: `largest_magnitude`, `smallest_magnitude`,
  `largest_algebraic`, `smallest_algebraic`.
- Optional `subspace` (Krylov dimension; default a modest multiple of `k`, capped
  at `n`) and `tol`. Results carry a per-run `converged` flag from the standard
  Ritz residual estimate (`|beta_next| * |last eigvec component|`).
- Full reorthogonalization (two passes) for a robust reference implementation.

## Tests (`tests/unit/itl/test_eigensolvers.cpp`, GCC + Clang)

- SPD 1D Laplacian with closed-form spectrum: `power_iteration` (dominant),
  `lanczos` (largest/smallest algebraic, Ritz-vector residuals), and a
  **matrix-free operator** struct to exercise the `LinearOperator` path.
- `arnoldi` on nonsymmetric operators: real dominant + complex-conjugate blocks;
  checks complex Ritz residuals `A y = mu y` and recovery of a `3 ± 2i` pair.
- Full suite (132 tests) green on GCC and Clang; existing ITL solvers unaffected.

## Scope note

These are single-shot (non-restarted) builds. Implicit/thick restarting and
**shift-invert for interior/smallest eigenvalues** (turning "smallest" into
"largest of `(A - sigma I)^{-1}`" via the sparse direct solvers) are the natural
content of the sparse eigensolver (#206), which builds on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
