### PR TITLE
feat(sparse): sparse eigensolver with shift-invert (#206)

### DIFF
--- a/docs/algorithms/eigenvalues.md
+++ b/docs/algorithms/eigenvalues.md
@@ -120,6 +120,38 @@ auto g = mtl::itl::arnoldi(A, v0, 4, mtl::itl::eigen_which::largest_magnitude);
 ```
 
 These are single-shot (non-restarted) builds with full reorthogonalization —
-robust and simple. Implicit/thick restarting and shift-invert for interior
-eigenvalues (which turns "smallest" into "largest of `(A - sigma I)^{-1}`" using
-the sparse direct solvers) are planned follow-ups for the sparse eigensolver.
+robust and simple. Implicit/thick restarting is a planned follow-up.
+
+## Sparse eigensolver (shift-invert)
+
+For sparse matrices (`compressed2D`), `mtl::sparse` builds on the iterative
+solvers above:
+
+| Function | Returns |
+|---|---|
+| `sparse::sparse_eigs(A, k, which)` | k eigenpairs by Arnoldi applied directly to the sparse operator (best for largest-magnitude) |
+| `sparse::sparse_eigs_shift_invert(A, sigma, k)` | k eigenpairs **nearest `sigma`** (interior / smallest) |
+
+Largest-magnitude eigenvalues come from running Arnoldi directly on `A` (a sparse
+matrix is already a `LinearOperator`). Interior or smallest eigenvalues use
+**shift-invert**: `(A - sigma*I)` is factored once with the sparse LU direct
+solver, and its inverse is applied inside Arnoldi. An eigenpair `(theta, y)` of
+`(A - sigma*I)^{-1}` maps to `(lambda, y)` of `A` with `lambda = sigma + 1/theta`
+and the *same* eigenvector, so "nearest `sigma`" becomes "largest `|theta|`" —
+which Arnoldi converges to quickly.
+
+```cpp
+#include <mtl/sparse/eigen/shift_invert.hpp>
+
+// The 4 eigenvalues of A closest to sigma = 2.5, with eigenvectors.
+auto near = mtl::sparse::sparse_eigs_shift_invert(A, 2.5, 4);
+// near.values (complex, = sigma + 1/theta), near.vectors, near.converged
+
+// The reusable operator, if you want to drive the Krylov solver yourself:
+mtl::sparse::shift_invert_operator<double> op(A, 2.5);   // factor once
+auto y = op * x;                                         // apply (A - 2.5 I)^{-1}
+```
+
+The factorization is computed once and applied on every Arnoldi step; tiny
+pivots are perturbed so a shift landing (near-)exactly on an eigenvalue stays
+solvable. Generalized problems `A x = lambda B x` are a future extension.

--- a/include/mtl/sparse/eigen/shift_invert.hpp
+++ b/include/mtl/sparse/eigen/shift_invert.hpp
@@ -1,0 +1,145 @@
+#pragma once
+// MTL5 -- Sparse eigenvalue computation.
+//
+// Two modes, both matrix-free at the Krylov level (see include/mtl/itl/eigen):
+//   * Largest-magnitude eigenvalues: run the iterative eigensolvers directly on
+//     the sparse operator (compressed2D is already a LinearOperator, A * x).
+//   * Interior / smallest / nearest-sigma eigenvalues: SHIFT-INVERT. Factor
+//     (A - sigma*I) once with the sparse LU direct solver, then apply its
+//     inverse inside Arnoldi. An eigenpair (theta, y) of (A - sigma*I)^{-1}
+//     corresponds to an eigenpair (lambda, y) of A with lambda = sigma + 1/theta
+//     and the SAME eigenvector, and "nearest sigma" becomes "largest |theta|".
+#include <cmath>
+#include <complex>
+#include <cstddef>
+#include <limits>
+#include <map>
+#include <vector>
+#include <mtl/mat/compressed2D.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/sparse/factorization/sparse_lu.hpp>
+#include <mtl/itl/eigen/arnoldi.hpp>
+
+namespace mtl::sparse {
+
+/// Build B = A - sigma*I as a new CSR sparse matrix. The diagonal entry is
+/// created if A has no stored element there.
+template <typename Value, typename Parameters>
+mat::compressed2D<Value> shift_diagonal(const mat::compressed2D<Value, Parameters>& A,
+                                        Value sigma) {
+    using size_type = std::size_t;
+    const size_type n = A.num_rows();
+    const auto& rp = A.ref_major();
+    const auto& ci = A.ref_minor();
+    const auto& dat = A.ref_data();
+
+    std::vector<size_type> starts(n + 1, 0);
+    std::vector<size_type> indices;
+    std::vector<Value> data;
+    for (size_type r = 0; r < n; ++r) {
+        starts[r] = indices.size();
+        std::map<size_type, Value> row;               // keeps columns sorted
+        for (size_type k = rp[r]; k < rp[r + 1]; ++k)
+            row[ci[k]] += dat[k];
+        row[r] -= sigma;                              // subtract on the diagonal
+        for (const auto& [c, v] : row) { indices.push_back(c); data.push_back(v); }
+    }
+    starts[n] = indices.size();
+    return mat::compressed2D<Value>(n, n, static_cast<size_type>(data.size()),
+                                    starts.data(), indices.data(), data.data());
+}
+
+/// LinearOperator applying (A - sigma*I)^{-1} via a cached sparse LU
+/// factorization: factor once, apply many. Plug into the iterative eigensolvers.
+template <typename Value>
+class shift_invert_operator {
+public:
+    template <typename Parameters>
+    shift_invert_operator(const mat::compressed2D<Value, Parameters>& A, Value sigma)
+        : n_(A.num_rows()) {
+        auto B = shift_diagonal(A, sigma);
+
+        // Guard against an (near-)exactly singular shift: perturb tiny pivots
+        // rather than throwing, scaled to the magnitude of B.
+        Value maxabs = Value(0);
+        for (Value v : B.ref_data()) { Value a = std::abs(v); if (a > maxabs) maxabs = a; }
+        if (maxabs == Value(0)) maxabs = Value(1);
+        const Value perturb =
+            std::sqrt(std::numeric_limits<Value>::epsilon()) * maxabs;
+
+        auto sym = factorization::sparse_lu_symbolic(B);
+        num_ = factorization::sparse_lu_numeric(B, sym, Value(1), perturb);
+    }
+
+    /// y = (A - sigma*I)^{-1} x
+    template <typename Vec>
+    vec::dense_vector<Value> operator*(const Vec& x) const {
+        vec::dense_vector<Value> y(n_);
+        num_.solve(y, x);
+        return y;
+    }
+
+    std::size_t num_rows() const { return n_; }
+    std::size_t num_cols() const { return n_; }
+
+private:
+    std::size_t n_;
+    factorization::lu_numeric<Value> num_;
+};
+
+/// Compute the `k` eigenvalues of a sparse matrix `A` nearest the shift `sigma`,
+/// with their eigenvectors, by Arnoldi on the shift-invert operator
+/// (A - sigma*I)^{-1}. Returns complex Ritz pairs: values are the eigenvalues of
+/// A (lambda = sigma + 1/theta), vectors are the corresponding eigenvectors.
+///
+/// `subspace` is the Krylov dimension (default: modest multiple of k, capped at
+/// n); `tol` flags convergence via the Arnoldi Ritz residual.
+template <typename Value, typename Parameters>
+itl::ritz_pairs<std::complex<Value>>
+sparse_eigs_shift_invert(const mat::compressed2D<Value, Parameters>& A, Value sigma,
+                         std::size_t k, std::size_t subspace = 0,
+                         Value tol = Value(1e-8)) {
+    using complex_type = std::complex<Value>;
+    const std::size_t n = A.num_rows();
+
+    shift_invert_operator<Value> op(A, sigma);
+
+    // Start vector: index-varied to break symmetry.
+    vec::dense_vector<Value> v0(n);
+    for (std::size_t i = 0; i < n; ++i)
+        v0(i) = Value(1) + Value(i) / Value(n == 0 ? 1 : n);
+
+    // Nearest sigma  <=>  largest |theta| of the shift-inverted operator.
+    auto r = itl::arnoldi(op, v0, k, itl::eigen_which::largest_magnitude, subspace, tol);
+
+    // Map Ritz values back: lambda = sigma + 1/theta. Eigenvectors are unchanged.
+    itl::ritz_pairs<complex_type> out;
+    out.values = r.values;
+    out.vectors = r.vectors;
+    out.subspace = r.subspace;
+    out.converged = r.converged;
+    for (std::size_t i = 0; i < r.values.size(); ++i) {
+        complex_type theta = r.values(i);
+        out.values(i) = (std::abs(theta) == Value(0))
+                            ? complex_type(std::numeric_limits<Value>::infinity())
+                            : complex_type(sigma) + complex_type(Value(1)) / theta;
+    }
+    return out;
+}
+
+/// Compute the `k` eigenvalues of a sparse matrix `A` of largest magnitude (or
+/// per `which`) with eigenvectors, by Arnoldi applied directly to the sparse
+/// operator -- no factorization. A thin convenience over itl::arnoldi.
+template <typename Value, typename Parameters>
+itl::ritz_pairs<std::complex<Value>>
+sparse_eigs(const mat::compressed2D<Value, Parameters>& A, std::size_t k,
+            itl::eigen_which which = itl::eigen_which::largest_magnitude,
+            std::size_t subspace = 0, Value tol = Value(1e-8)) {
+    const std::size_t n = A.num_rows();
+    vec::dense_vector<Value> v0(n);
+    for (std::size_t i = 0; i < n; ++i)
+        v0(i) = Value(1) + Value(i) / Value(n == 0 ? 1 : n);
+    return itl::arnoldi(A, v0, k, which, subspace, tol);
+}
+
+} // namespace mtl::sparse

--- a/include/mtl/sparse/sparse.hpp
+++ b/include/mtl/sparse/sparse.hpp
@@ -33,3 +33,6 @@
 #include <mtl/sparse/ordering/amd.hpp>
 #include <mtl/sparse/ordering/colamd.hpp>
 #include <mtl/sparse/ordering/dulmage_mendelsohn.hpp>
+
+// Sparse eigensolver (shift-invert on top of the direct solvers + Krylov)
+#include <mtl/sparse/eigen/shift_invert.hpp>

--- a/tests/unit/sparse/test_sparse_eigensolver.cpp
+++ b/tests/unit/sparse/test_sparse_eigensolver.cpp
@@ -1,0 +1,152 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <mtl/mat/compressed2D.hpp>
+#include <mtl/mat/inserter.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/operation/operators.hpp>
+#include <mtl/sparse/eigen/shift_invert.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <vector>
+
+using namespace mtl;
+using cplx = std::complex<double>;
+
+namespace {
+
+// 1D Laplacian as a sparse CSR matrix (SPD tridiagonal).
+mat::compressed2D<double> laplacian1d(std::size_t n) {
+    mat::compressed2D<double> A(n, n);
+    mat::inserter<mat::compressed2D<double>> ins(A);
+    for (std::size_t i = 0; i < n; ++i) {
+        if (i > 0)     ins[i][i - 1] << -1.0;
+        ins[i][i] << 2.0;
+        if (i + 1 < n) ins[i][i + 1] << -1.0;
+    }
+    return A;
+}
+
+std::vector<double> laplacian1d_eigs(std::size_t n) {
+    std::vector<double> e(n);
+    for (std::size_t k = 1; k <= n; ++k)
+        e[k - 1] = 2.0 - 2.0 * std::cos(k * 3.14159265358979323846 / (n + 1));
+    std::sort(e.begin(), e.end());
+    return e;
+}
+
+// Max residual ||A y - lambda y|| over the returned (complex) eigenpairs.
+double max_residual(const mat::compressed2D<double>& A,
+                    const itl::ritz_pairs<cplx>& r) {
+    const std::size_t n = A.num_rows();
+    const auto& rp = A.ref_major();
+    const auto& ci = A.ref_minor();
+    const auto& dat = A.ref_data();
+    double worst = 0.0;
+    for (std::size_t c = 0; c < r.values.size(); ++c) {
+        for (std::size_t i = 0; i < n; ++i) {
+            cplx Ay(0.0, 0.0);
+            for (std::size_t k = rp[i]; k < rp[i + 1]; ++k)
+                Ay += cplx(dat[k], 0.0) * r.vectors(ci[k], c);
+            Ay -= r.values(c) * r.vectors(i, c);
+            worst = std::max(worst, std::abs(Ay));
+        }
+    }
+    return worst;
+}
+
+} // namespace
+
+TEST_CASE("sparse_eigs: largest-magnitude eigenvalues (direct Arnoldi)", "[sparse][eigen]") {
+    const std::size_t n = 40;
+    auto A = laplacian1d(n);
+    auto expected = laplacian1d_eigs(n);
+
+    // The Laplacian spectrum clusters near its ends, so the extreme top
+    // eigenvalue converges slowly for a small Krylov subspace; use a full
+    // subspace here to validate the sparse_eigs path deterministically.
+    auto r = sparse::sparse_eigs(A, 3, itl::eigen_which::largest_magnitude, n);
+    REQUIRE(r.values.size() == 3);
+    REQUIRE(r.converged);
+
+    // For the SPD Laplacian, largest magnitude == largest algebraic.
+    REQUIRE_THAT(r.values(0).real(), Catch::Matchers::WithinAbs(expected[n-1], 1e-7));
+    REQUIRE_THAT(r.values(0).imag(), Catch::Matchers::WithinAbs(0.0, 1e-9));
+    REQUIRE(max_residual(A, r) < 1e-6);
+}
+
+TEST_CASE("sparse shift-invert: smallest eigenvalues near sigma=0", "[sparse][eigen][shift-invert]") {
+    const std::size_t n = 40;
+    auto A = laplacian1d(n);
+    auto expected = laplacian1d_eigs(n);  // ascending; smallest are expected[0..]
+
+    // sigma slightly below the smallest eigenvalue -> the k nearest are the
+    // k smallest eigenvalues of A.
+    auto r = sparse::sparse_eigs_shift_invert(A, 0.0, 3);
+    REQUIRE(r.values.size() == 3);
+    REQUIRE(r.converged);
+
+    std::vector<double> got(3);
+    for (std::size_t i = 0; i < 3; ++i) {
+        REQUIRE_THAT(r.values(i).imag(), Catch::Matchers::WithinAbs(0.0, 1e-8));
+        got[i] = r.values(i).real();
+    }
+    std::sort(got.begin(), got.end());
+    REQUIRE_THAT(got[0], Catch::Matchers::WithinAbs(expected[0], 1e-7));
+    REQUIRE_THAT(got[1], Catch::Matchers::WithinAbs(expected[1], 1e-7));
+    REQUIRE_THAT(got[2], Catch::Matchers::WithinAbs(expected[2], 1e-7));
+
+    // Eigenvectors (unchanged by shift-invert) satisfy A y = lambda y.
+    REQUIRE(max_residual(A, r) < 1e-6);
+}
+
+TEST_CASE("sparse shift-invert: interior eigenvalues near a target", "[sparse][eigen][shift-invert]") {
+    const std::size_t n = 50;
+    auto A = laplacian1d(n);
+    auto expected = laplacian1d_eigs(n);
+
+    // Pick an interior target (off the midpoint between two eigenvalues, so the
+    // nearest eigenvalue is unambiguous) and find the eigenvalue closest to it.
+    const double sigma = 2.05;   // interior of the [0,4] Laplacian spectrum
+    auto r = sparse::sparse_eigs_shift_invert(A, sigma, 4);
+    REQUIRE(r.values.size() == 4);
+
+    // The closest returned eigenvalue must match the closest true eigenvalue.
+    double best_true = expected[0];
+    for (double e : expected)
+        if (std::abs(e - sigma) < std::abs(best_true - sigma)) best_true = e;
+
+    double best_got = r.values(0).real();
+    for (std::size_t i = 0; i < r.values.size(); ++i)
+        if (std::abs(r.values(i).real() - sigma) < std::abs(best_got - sigma))
+            best_got = r.values(i).real();
+
+    REQUIRE_THAT(best_got, Catch::Matchers::WithinAbs(best_true, 1e-7));
+    REQUIRE(max_residual(A, r) < 1e-6);
+}
+
+TEST_CASE("sparse shift-invert: nonsymmetric matrix", "[sparse][eigen][shift-invert]") {
+    // Nonsymmetric sparse matrix with known real eigenvalues 1..n on the diagonal
+    // plus a subdiagonal (upper/lower triangular -> eigenvalues are the diagonal).
+    const std::size_t n = 8;
+    mat::compressed2D<double> A(n, n);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        for (std::size_t i = 0; i < n; ++i) {
+            ins[i][i] << static_cast<double>(i + 1);       // eigenvalues 1..n
+            if (i + 1 < n) ins[i][i + 1] << 0.5;           // upper triangular perturbation
+        }
+    }
+
+    // Find eigenvalues nearest sigma = 3.2 -> should include 3.
+    auto r = sparse::sparse_eigs_shift_invert(A, 3.2, 2);
+    REQUIRE(r.values.size() == 2);
+
+    bool found3 = false;
+    for (std::size_t i = 0; i < r.values.size(); ++i)
+        if (std::abs(r.values(i) - cplx(3.0, 0.0)) < 1e-6) found3 = true;
+    REQUIRE(found3);
+    REQUIRE(max_residual(A, r) < 1e-6);
+}


### PR DESCRIPTION
Closes #206. Completes the eigen epic #202.

## What

A sparse eigenvalue capability in `mtl::sparse` that composes the sparse LU
direct solver with the Arnoldi eigensolver (#205):

| Function | Returns |
|---|---|
| `sparse_eigs(A, k, which)` | k eigenpairs by Arnoldi applied directly to the sparse operator (best for largest-magnitude) |
| `sparse_eigs_shift_invert(A, sigma, k)` | k eigenpairs **nearest `sigma`** (interior / smallest) |
| `shift_invert_operator<Value>` | reusable `LinearOperator` applying `(A - sigma*I)^{-1}` (factor once, apply many) |

## How shift-invert works

`(A - sigma*I)` is factored **once** with sparse LU; its inverse is applied on
every Arnoldi step. An eigenpair `(theta, y)` of `(A - sigma*I)^{-1}` maps to
`(lambda, y)` of `A` with `lambda = sigma + 1/theta` and the **same
eigenvector** — so "nearest sigma" becomes "largest `|theta|`", which is
well-separated and converges fast. Tiny pivots are perturbed so a shift landing
(near-)exactly on an eigenvalue stays solvable.

This is the capstone of the epic: it reuses the sparse direct solvers **and** the
iterative Arnoldi (#205), which in turn uses the dense eigensolvers
(#203/#204/#209) on the projected Hessenberg. Largest-magnitude needs no
factorization at all — a `compressed2D` is already a `LinearOperator`.

## Tests (`tests/unit/sparse/test_sparse_eigensolver.cpp`, GCC + Clang)

SPD 1D Laplacian (closed-form spectrum): largest, smallest (`sigma=0`), and
interior (`sigma=2.05`, chosen off the midpoint so the nearest eigenvalue is
unambiguous) eigenvalues; plus a nonsymmetric matrix, eigenvalues nearest a
target. Each checks the actual eigenpair residual `A y = lambda y`. Full suite
(133 tests) green on GCC and Clang.

## Scope note

Standard (non-generalized) problems. Generalized `A x = lambda B x` (shift-invert
with `B`) is noted as a future extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
