### PR TITLE
perf(benchmarks): add BLIS backend + expand core BLAS routine coverage (#227)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -17,7 +17,15 @@ backend:
 | `native`   | *(none)* | generic C++ |
 | `native-fast` | `-DMTL5_NATIVE_FAST_GEMM=ON -DMTL5_WITH_HIGHWAY=ON -DMTL5_NATIVE_ARCH=ON` | MTL5's own SIMD GEMM/GEMV (no external BLAS) |
 | `openblas` | `-DMTL5_WITH_BLAS=ON -DMTL5_WITH_LAPACK=ON` | system BLAS/LAPACK (OpenBLAS) |
+| `blis`     | `-DMTL5_WITH_BLAS=ON -DBLA_VENDOR=FLAME` | BLIS (BLAS-only; `libblis`) |
 | `mkl`      | `… -DBLA_VENDOR=Intel10_64lp` (oneAPI sourced) | Intel MKL |
+
+BLIS is selected through CMake's `FindBLAS` `BLA_VENDOR=FLAME` and requires a
+BLIS BLAS on the system (e.g. `apt install libblis-dev`, or build BLIS and point
+CMake at it). It is a **BLAS-only** library, so the `blis` variant runs the BLAS
+L1/L2/L3 suites (LAPACK factorizations would need libFLAME, not wired here). Set
+thread count with `BLIS_NUM_THREADS`. Both `run_sweeps.sh` and `run_scaling.sh`
+skip the `blis` variant automatically if a BLIS BLAS cannot be located.
 
 `native-fast` is the epic #82 path: `mult()` routes through the blocked GEMM
 (`detail/gemm_blocked.hpp`) and SIMD GEMV (`detail/gemv.hpp`), built over Google
@@ -40,9 +48,9 @@ the numbers are what a real app compiled that way would get.
 ```
 benchmarks/
   bench_all.cpp          CLI driver (sizes/sweeps/suites + --label)
-  run_sweeps.sh          builds native/native-fast/openblas/mkl variants and runs the sweeps
+  run_sweeps.sh          builds native/native-fast/openblas/blis/mkl variants and runs the sweeps
   plot_results.py        GFLOP/s-vs-N plots from the CSVs
-  analyze_gate.py        % of OpenBLAS / % of FMA peak + the pass/fail perf gate
+  analyze_gate.py        % of a reference backend (--reference, default openblas) / % of FMA peak + the pass/fail perf gate
   harness/
     timer.hpp            high-resolution timing + statistics
     reporter.hpp         console table + CSV output
@@ -98,9 +106,18 @@ to `native` or `blas`; `run_sweeps.sh` passes `native`/`openblas`/`mkl`).
 
 ### Suites
 
-`all`, `blas` (= l1 + l2 + l3), `lapack`, the level groups `l1` (dot + nrm2),
-`l2` (gemv), `l3` (gemm), and the individual ops `dot`, `nrm2`, `gemv`, `gemm`,
+`all`, `blas` (= l1 + l2 + l3), `lapack`, the level groups `l1` (dot + nrm2 +
+axpy + scal), `l2` (gemv), `l3` (gemm), and the individual ops `dot`, `nrm2`,
+`axpy`, `scal`, `gemv`, `gemm`,
 `lu`, `qr`, `cholesky`, `eig`.
+
+### BLAS routine coverage
+
+Benchmarked (the core BLAS routines MTL5 implements): **L1** `dot`, `nrm2`,
+`axpy`, `scal`; **L2** `gemv`; **L3** `gemm`. Standard BLAS routines MTL5 does
+**not** implement yet — and therefore cannot benchmark — are, for reference:
+L1 `asum`, `iamax`, `copy`, `swap`, `rot`; L2 `ger`, `symv`, `trmv`, `trsv`;
+L3 `symm`, `syrk`, `syr2k`, `trmm`, `trsm` (tracked in #227).
 
 ### Sweeping size N (padding / odd-size overhead)
 

--- a/benchmarks/analyze_gate.py
+++ b/benchmarks/analyze_gate.py
@@ -23,6 +23,9 @@ Examples:
     ./analyze_gate.py data/blas_sweep_native-fast.csv data/blas_sweep_openblas.csv \\
         --gate --op gemm --threshold 0.80 --min-size 256
 
+    # Compare against BLIS instead of OpenBLAS (table or gate)
+    ./analyze_gate.py data/blas_sweep_*.csv --reference blis
+
 Standard library only (no pandas). Benchmark tooling, not part of the library.
 """
 
@@ -63,59 +66,61 @@ def pick(backends, *candidates):
     return None
 
 
-def print_table(data, peak):
+def print_table(data, peak, reference):
     for op in sorted(data):
         backends = data[op]
         nf = pick(backends, "native-fast", "native_fast")
-        ob = pick(backends, "openblas", "blas")
+        ref = pick(backends, reference, "openblas", "blas")
+        ref_name = ref if ref else reference
         if nf is None:
             continue
         print(f"\n== {op} ==")
         hdr = f"{'N':>6} {'native-fast':>12}"
-        if ob:
-            hdr += f" {'openblas':>12} {'% OpenBLAS':>11}"
+        if ref:
+            hdr += f" {ref_name:>12} {('% ' + ref_name):>11}"
         if peak:
             hdr += f" {'% FMA peak':>11}"
         print(hdr)
         for n in sorted(backends[nf]):
             g = backends[nf][n]
             line = f"{n:>6} {g:>12.2f}"
-            if ob and n in backends[ob] and backends[ob][n] > 0:
-                line += f" {backends[ob][n]:>12.2f} {100.0 * g / backends[ob][n]:>10.1f}%"
-            elif ob:
+            if ref and n in backends[ref] and backends[ref][n] > 0:
+                line += f" {backends[ref][n]:>12.2f} {100.0 * g / backends[ref][n]:>10.1f}%"
+            elif ref:
                 line += f" {'--':>12} {'--':>11}"
             if peak:
                 line += f" {100.0 * g / peak:>10.1f}%"
             print(line)
 
 
-def run_gate(data, op, threshold, min_size):
+def run_gate(data, op, threshold, min_size, reference):
     backends = data.get(op, {})
     nf = pick(backends, "native-fast", "native_fast")
-    ob = pick(backends, "openblas", "blas")
-    if nf is None or ob is None:
-        sys.exit(f"gate: need both native-fast and openblas data for '{op}' "
+    ref = pick(backends, reference, "openblas", "blas")
+    ref_name = ref if ref else reference
+    if nf is None or ref is None:
+        sys.exit(f"gate: need both native-fast and {reference} data for '{op}' "
                  f"(have: {sorted(backends)})")
     failures = []
     checked = 0
     for n in sorted(backends[nf]):
-        if n < min_size or n not in backends[ob] or backends[ob][n] <= 0:
+        if n < min_size or n not in backends[ref] or backends[ref][n] <= 0:
             continue
         checked += 1
-        frac = backends[nf][n] / backends[ob][n]
+        frac = backends[nf][n] / backends[ref][n]
         status = "ok" if frac >= threshold else "LOW"
         print(f"  N={n:>5}  native-fast={backends[nf][n]:8.2f}  "
-              f"openblas={backends[ob][n]:8.2f}  {100*frac:5.1f}%  [{status}]")
+              f"{ref_name}={backends[ref][n]:8.2f}  {100*frac:5.1f}%  [{status}]")
         if frac < threshold:
             failures.append((n, frac))
     if checked == 0:
         sys.exit(f"gate: no comparable sizes >= {min_size} for '{op}'")
     if failures:
         worst = min(f for _, f in failures)
-        print(f"\nGATE FAIL: {op} below {threshold*100:.0f}% of OpenBLAS at "
+        print(f"\nGATE FAIL: {op} below {threshold*100:.0f}% of {ref_name} at "
               f"{len(failures)}/{checked} sizes (worst {worst*100:.1f}%).")
         return 1
-    print(f"\nGATE PASS: {op} >= {threshold*100:.0f}% of OpenBLAS at all "
+    print(f"\nGATE PASS: {op} >= {threshold*100:.0f}% of {ref_name} at all "
           f"{checked} sizes (N >= {min_size}).")
     return 0
 
@@ -127,8 +132,11 @@ def main():
                     help="machine FMA peak (GFLOP/s) for the %% FMA peak column")
     ap.add_argument("--gate", action="store_true", help="run the pass/fail perf gate")
     ap.add_argument("--op", default="gemm", help="operation to gate (default: gemm)")
+    ap.add_argument("--reference", default="openblas",
+                    help="reference backend to compare against (default: openblas; "
+                         "e.g. blis, mkl)")
     ap.add_argument("--threshold", type=float, default=0.80,
-                    help="min native-fast/openblas fraction (default: 0.80)")
+                    help="min native-fast/reference fraction (default: 0.80)")
     ap.add_argument("--min-size", type=int, default=256,
                     help="only gate sizes >= this (default: 256)")
     args = ap.parse_args()
@@ -138,9 +146,9 @@ def main():
     data = load(args.csv)
     if args.gate:
         print(f"Gate: {args.op} native-fast >= {args.threshold*100:.0f}% of "
-              f"OpenBLAS for N >= {args.min_size}")
-        sys.exit(run_gate(data, args.op, args.threshold, args.min_size))
-    print_table(data, args.peak_gflops)
+              f"{args.reference} for N >= {args.min_size}")
+        sys.exit(run_gate(data, args.op, args.threshold, args.min_size, args.reference))
+    print_table(data, args.peak_gflops, args.reference)
 
 
 if __name__ == "__main__":

--- a/benchmarks/bench_all.cpp
+++ b/benchmarks/bench_all.cpp
@@ -129,8 +129,8 @@ static void print_usage() {
         "    250:1030:x1.01   -> dense sweep bracketing the 256/512/1024 cliffs\n"
         "\n"
         "Suites: all, blas (=l1+l2+l3), lapack,\n"
-        "        l1 (dot+nrm2), l2 (gemv), l3 (gemm),\n"
-        "        dot, nrm2, gemv, gemm, lu, qr, cholesky, eig\n";
+        "        l1 (dot+nrm2+axpy+scal), l2 (gemv), l3 (gemm),\n"
+        "        dot, nrm2, axpy, scal, gemv, gemm, lu, qr, cholesky, eig\n";
 }
 
 int main(int argc, char* argv[]) {
@@ -188,6 +188,8 @@ int main(int argc, char* argv[]) {
         std::cout << "=== BLAS Level 1 ===" << std::endl;
         b::bench_dot(rep, label, blas_sizes);
         b::bench_nrm2(rep, label, blas_sizes);
+        b::bench_axpy(rep, label, blas_sizes);
+        b::bench_scal(rep, label, blas_sizes);
         std::cout << "=== BLAS Level 2 ===" << std::endl;
         b::bench_gemv(rep, label, blas_sizes);
         std::cout << "=== BLAS Level 3 ===" << std::endl;
@@ -196,6 +198,8 @@ int main(int argc, char* argv[]) {
         std::cout << "=== BLAS Level 1 ===" << std::endl;
         b::bench_dot(rep, label, blas_sizes);
         b::bench_nrm2(rep, label, blas_sizes);
+        b::bench_axpy(rep, label, blas_sizes);
+        b::bench_scal(rep, label, blas_sizes);
     } else if (suite == "l2") {
         std::cout << "=== BLAS Level 2 ===" << std::endl;
         b::bench_gemv(rep, label, blas_sizes);
@@ -212,6 +216,10 @@ int main(int argc, char* argv[]) {
         b::bench_dot(rep, label, blas_sizes);
     } else if (suite == "nrm2") {
         b::bench_nrm2(rep, label, blas_sizes);
+    } else if (suite == "axpy") {
+        b::bench_axpy(rep, label, blas_sizes);
+    } else if (suite == "scal") {
+        b::bench_scal(rep, label, blas_sizes);
     } else if (suite == "gemv") {
         b::bench_gemv(rep, label, blas_sizes);
     } else if (suite == "gemm") {

--- a/benchmarks/harness/runner.hpp
+++ b/benchmarks/harness/runner.hpp
@@ -22,6 +22,8 @@
 #include <mtl/operation/mult.hpp>
 #include <mtl/operation/dot.hpp>
 #include <mtl/operation/norms.hpp>
+#include <mtl/operation/axpy.hpp>
+#include <mtl/operation/scale.hpp>
 #include <mtl/operation/lu.hpp>
 #include <mtl/operation/qr.hpp>
 #include <mtl/operation/cholesky.hpp>
@@ -56,6 +58,33 @@ inline void bench_nrm2(reporter& rep, const std::string& label,
         auto t = measure([&]{ sink = mtl::two_norm(v); },
                          "nrm2", label, n, flops, warmup, iterations);
         (void)sink;
+        rep.add(t);
+    }
+}
+
+inline void bench_axpy(reporter& rep, const std::string& label,
+                       const std::vector<std::size_t>& sizes,
+                       std::size_t warmup = 3, std::size_t iterations = 20) {
+    for (auto n : sizes) {
+        auto x = make_random_vector<double>(n);
+        auto y = make_random_vector<double>(n, 456);
+        const double alpha = 1.0000001;   // near 1 so repeated y += alpha*x stays bounded
+        double flops = static_cast<double>(2 * n);
+        auto t = measure([&]{ mtl::axpy(alpha, x, y); },
+                         "axpy", label, n, flops, warmup, iterations);
+        rep.add(t);
+    }
+}
+
+inline void bench_scal(reporter& rep, const std::string& label,
+                       const std::vector<std::size_t>& sizes,
+                       std::size_t warmup = 3, std::size_t iterations = 20) {
+    for (auto n : sizes) {
+        auto x = make_random_vector<double>(n);
+        const double alpha = 1.0000001;   // near 1 so repeated x *= alpha stays bounded
+        double flops = static_cast<double>(n);
+        auto t = measure([&]{ mtl::scale(alpha, x); },
+                         "scal", label, n, flops, warmup, iterations);
         rep.add(t);
     }
 }
@@ -160,6 +189,8 @@ inline void run_all(reporter& rep, const std::string& label,
     std::cout << "=== BLAS Level 1 ===" << std::endl;
     bench_dot(rep, label, blas_sizes);
     bench_nrm2(rep, label, blas_sizes);
+    bench_axpy(rep, label, blas_sizes);
+    bench_scal(rep, label, blas_sizes);
 
     std::cout << "=== BLAS Level 2 ===" << std::endl;
     bench_gemv(rep, label, blas_sizes);

--- a/benchmarks/run_scaling.sh
+++ b/benchmarks/run_scaling.sh
@@ -5,6 +5,7 @@
 # Threading is a RUNTIME axis of the same per-backend binary:
 #   native-fast : MTL5_NUM_THREADS=T
 #   openblas    : OPENBLAS_NUM_THREADS=T
+#   blis        : BLIS_NUM_THREADS=T   (if a BLIS BLAS is found)
 #   mkl         : MKL_NUM_THREADS=T
 # For T threads we pin to the first T physical performance cores (one logical id
 # per core -- HT siblings excluded) so scaling reflects cores, not SMT.
@@ -85,6 +86,18 @@ run_scaling_for build-scaling-native-fast native-fast MTL5_NUM_THREADS
 echo "=== openblas (OPENBLAS_NUM_THREADS) ==="
 configure_build build-scaling-openblas -DMTL5_WITH_BLAS=ON -DMTL5_WITH_LAPACK=ON
 run_scaling_for build-scaling-openblas openblas OPENBLAS_NUM_THREADS
+
+# BLIS (BLA_VENDOR=FLAME, BLIS_NUM_THREADS); skipped if not found at configure.
+if cmake -B build-scaling-blis-probe -DMTL5_BUILD_BENCHMARKS=ON -DCMAKE_BUILD_TYPE=Release \
+        -DMTL5_WITH_BLAS=ON -DBLA_VENDOR=FLAME >/dev/null 2>&1; then
+    rm -rf build-scaling-blis-probe
+    echo "=== blis (BLIS_NUM_THREADS) ==="
+    configure_build build-scaling-blis -DMTL5_WITH_BLAS=ON -DBLA_VENDOR=FLAME
+    run_scaling_for build-scaling-blis blis BLIS_NUM_THREADS
+else
+    rm -rf build-scaling-blis-probe
+    echo "=== blis: SKIPPED (no FLAME/BLIS BLAS found) ==="
+fi
 
 if [[ -f "$MKL_SETVARS" ]]; then
     echo "=== mkl (MKL_NUM_THREADS) ==="

--- a/benchmarks/run_sweeps.sh
+++ b/benchmarks/run_sweeps.sh
@@ -21,7 +21,8 @@
 #
 # Variants: native (generic-only), native-fast (the blocked GEMM / SIMD GEMV
 # path: -DMTL5_NATIVE_FAST_GEMM + Highway + -march=native, no external BLAS),
-# openblas, and mkl (if oneAPI is present).
+# openblas, blis (BLA_VENDOR=FLAME, if a BLIS BLAS is found), and mkl (if oneAPI
+# is present).
 #
 # Example (P-core 4, GEMM/GEMV/L1 gate only):
 #   BENCH_CPU=4 BENCH_SUITES=blas benchmarks/run_sweeps.sh
@@ -66,12 +67,12 @@ run_variant() {
         case "$s" in
             blas)
                 echo ">> $label: BLAS L1/L2/L3 sweep"
-                OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+                OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 BLIS_NUM_THREADS=1 \
                     "${PIN[@]}" "$bin" --suite blas --blas-sweep "$SWEEP" \
                     --label "$label" --csv "$DATA/blas_sweep_${label}.csv" ;;
             lapack)
                 echo ">> $label: LAPACK factorization sweep"
-                OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+                OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 BLIS_NUM_THREADS=1 \
                     "${PIN[@]}" "$bin" --suite lapack --lapack-sweep "$SWEEP" \
                     --label "$label" --csv "$DATA/lapack_sweep_${label}.csv" ;;
             *) echo "  (unknown suite '$s' in BENCH_SUITES, skipping)" ;;
@@ -91,6 +92,22 @@ run_variant build-native-fast native-fast
 echo "=== openblas ==="
 configure_build build-openblas -DMTL5_WITH_BLAS=ON -DMTL5_WITH_LAPACK=ON
 run_variant build-openblas openblas
+
+# BLIS (BLAS-compatible; selected via CMake FindBLAS BLA_VENDOR=FLAME). BLIS is a
+# BLAS-only library (LAPACK would come from libflame, not wired here), so it is
+# configured with BLAS only -- the BLAS L1/L2/L3 suites are the point of the
+# comparison. Threads via BLIS_NUM_THREADS (pinned to 1 in run_variant's env).
+# Skipped if a FLAME/BLIS BLAS cannot be located at configure time.
+echo "=== blis ==="
+if cmake -B build-blis-probe -DMTL5_BUILD_BENCHMARKS=ON -DCMAKE_BUILD_TYPE=Release \
+        -DMTL5_WITH_BLAS=ON -DBLA_VENDOR=FLAME >/dev/null 2>&1; then
+    rm -rf build-blis-probe
+    configure_build build-blis -DMTL5_WITH_BLAS=ON -DBLA_VENDOR=FLAME
+    run_variant build-blis blis
+else
+    rm -rf build-blis-probe
+    echo "=== blis: SKIPPED (no FLAME/BLIS BLAS found; install libblis-dev or set BLA_VENDOR) ==="
+fi
 
 if [[ -f "$MKL_SETVARS" ]]; then
     echo "=== mkl ==="


### PR DESCRIPTION
Closes #227.

## What

Extends the benchmark harness to compare MTL5's core BLAS routines against
**OpenBLAS and BLIS** (keeping native / native-fast / MKL).

### 1. BLIS backend
- `run_sweeps.sh` and `run_scaling.sh` gain a `blis` variant, selected via CMake
  `FindBLAS` `-DBLA_VENDOR=FLAME`. BLIS is BLAS-only, so it runs the BLAS
  L1/L2/L3 suites (threads via `BLIS_NUM_THREADS`). Both scripts **skip it
  automatically** if a BLIS BLAS isn't found, mirroring the MKL guard.

### 2. Expanded routine coverage
- Added `bench_axpy` and `bench_scal` (L1) to `runner.hpp`, wired into the
  `all` / `blas` / `l1` groups and as individual `--suite axpy|scal` targets.
- The core BLAS set MTL5 implements is now covered: **L1** dot/nrm2/axpy/scal,
  **L2** gemv, **L3** gemm.

### 3. Analysis
- `analyze_gate.py` gains `--reference` (default `openblas`) so the comparison
  table and pass/fail gate can measure against **BLIS** (or MKL) as the baseline.

### 4. Docs
- `benchmarks/README.md`: BLIS backend row + setup, expanded suites, and a
  **BLAS routine coverage** note listing the standard routines MTL5 doesn't
  implement yet (`asum`, `iamax`, `copy`, `swap`, `rot`, `ger`, `symv`, `trmv`,
  `trsv`, `symm`, `syrk`, `syr2k`, `trmm`, `trsm`) as follow-up candidates.

## Validation (real OpenBLAS + BLIS locally)

Installed `libblis`, confirmed CMake `BLA_VENDOR=FLAME` finds it and `bench_all`
links `libblis.so.4`. Ran all six routines across native-fast / openblas / blis;
`analyze_gate.py --reference blis` produces the table and a passing gate;
`plot_results.py` renders the new ops. `bash -n` clean on both scripts.

## Notes

- The perf sweeps are intentionally **not** in CI (shared-runner clocks are
  unstable) — this runs on pinned hardware, like the existing GEMM sweeps. So CI
  here only compiles `bench_all` (the harness change); the multi-backend
  comparison + committed CSVs/plots are a separate run on dedicated hardware.
- Complements the scale-out roadmap (#220); gives the threading work (#221) a
  multi-backend baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
