### PR TITLE
feat(operation): BLAS Level-2 operators — ger, symv, trmv, trsv (#229, batch 1/3)

### DIFF
--- a/benchmarks/bench_all.cpp
+++ b/benchmarks/bench_all.cpp
@@ -129,8 +129,9 @@ static void print_usage() {
         "    250:1030:x1.01   -> dense sweep bracketing the 256/512/1024 cliffs\n"
         "\n"
         "Suites: all, blas (=l1+l2+l3), lapack,\n"
-        "        l1 (dot+nrm2+axpy+scal), l2 (gemv), l3 (gemm),\n"
-        "        dot, nrm2, axpy, scal, gemv, gemm, lu, qr, cholesky, eig\n";
+        "        l1 (dot+nrm2+axpy+scal), l2 (gemv+ger+symv+trmv+trsv), l3 (gemm),\n"
+        "        dot, nrm2, axpy, scal, gemv, ger, symv, trmv, trsv, gemm,\n"
+        "        lu, qr, cholesky, eig\n";
 }
 
 int main(int argc, char* argv[]) {
@@ -192,6 +193,10 @@ int main(int argc, char* argv[]) {
         b::bench_scal(rep, label, blas_sizes);
         std::cout << "=== BLAS Level 2 ===" << std::endl;
         b::bench_gemv(rep, label, blas_sizes);
+        b::bench_ger(rep, label, blas_sizes);
+        b::bench_symv(rep, label, blas_sizes);
+        b::bench_trmv(rep, label, blas_sizes);
+        b::bench_trsv(rep, label, blas_sizes);
         std::cout << "=== BLAS Level 3 ===" << std::endl;
         b::bench_gemm(rep, label, blas_sizes);
     } else if (suite == "l1") {
@@ -203,6 +208,10 @@ int main(int argc, char* argv[]) {
     } else if (suite == "l2") {
         std::cout << "=== BLAS Level 2 ===" << std::endl;
         b::bench_gemv(rep, label, blas_sizes);
+        b::bench_ger(rep, label, blas_sizes);
+        b::bench_symv(rep, label, blas_sizes);
+        b::bench_trmv(rep, label, blas_sizes);
+        b::bench_trsv(rep, label, blas_sizes);
     } else if (suite == "l3") {
         std::cout << "=== BLAS Level 3 ===" << std::endl;
         b::bench_gemm(rep, label, blas_sizes);
@@ -222,6 +231,14 @@ int main(int argc, char* argv[]) {
         b::bench_scal(rep, label, blas_sizes);
     } else if (suite == "gemv") {
         b::bench_gemv(rep, label, blas_sizes);
+    } else if (suite == "ger") {
+        b::bench_ger(rep, label, blas_sizes);
+    } else if (suite == "symv") {
+        b::bench_symv(rep, label, blas_sizes);
+    } else if (suite == "trmv") {
+        b::bench_trmv(rep, label, blas_sizes);
+    } else if (suite == "trsv") {
+        b::bench_trsv(rep, label, blas_sizes);
     } else if (suite == "gemm") {
         b::bench_gemm(rep, label, blas_sizes);
     } else if (suite == "lu") {

--- a/benchmarks/harness/runner.hpp
+++ b/benchmarks/harness/runner.hpp
@@ -24,6 +24,10 @@
 #include <mtl/operation/norms.hpp>
 #include <mtl/operation/axpy.hpp>
 #include <mtl/operation/scale.hpp>
+#include <mtl/operation/ger.hpp>
+#include <mtl/operation/symv.hpp>
+#include <mtl/operation/trmv.hpp>
+#include <mtl/operation/trsv.hpp>
 #include <mtl/operation/lu.hpp>
 #include <mtl/operation/qr.hpp>
 #include <mtl/operation/cholesky.hpp>
@@ -99,6 +103,64 @@ inline void bench_gemv(reporter& rep, const std::string& label,
         double flops = static_cast<double>(2 * n * n);
         auto t = measure([&]{ mtl::mult(A, x, y); },
                          "gemv", label, n, flops, warmup, iterations);
+        rep.add(t);
+    }
+}
+
+inline void bench_ger(reporter& rep, const std::string& label,
+                      const std::vector<std::size_t>& sizes,
+                      std::size_t warmup = 3, std::size_t iterations = 10) {
+    for (auto n : sizes) {
+        auto A = make_random_matrix<double>(n, n);
+        auto x = make_random_vector<double>(n);
+        auto y = make_random_vector<double>(n, 77);
+        const double alpha = 1.0000001;
+        double flops = static_cast<double>(2 * n * n);
+        auto t = measure([&]{ mtl::ger(alpha, x, y, A); },
+                         "ger", label, n, flops, warmup, iterations);
+        rep.add(t);
+    }
+}
+
+inline void bench_symv(reporter& rep, const std::string& label,
+                       const std::vector<std::size_t>& sizes,
+                       std::size_t warmup = 3, std::size_t iterations = 10) {
+    for (auto n : sizes) {
+        auto A = make_random_matrix<double>(n, n);   // treated as symmetric
+        auto x = make_random_vector<double>(n);
+        vec::dense_vector<double> y(n, 0.0);
+        double flops = static_cast<double>(2 * n * n);
+        auto t = measure([&]{ mtl::symv(1.0, A, x, 0.0, y); },
+                         "symv", label, n, flops, warmup, iterations);
+        rep.add(t);
+    }
+}
+
+inline void bench_trmv(reporter& rep, const std::string& label,
+                       const std::vector<std::size_t>& sizes,
+                       std::size_t warmup = 3, std::size_t iterations = 10) {
+    for (auto n : sizes) {
+        auto A = make_random_matrix<double>(n, n);   // upper triangle used
+        auto x = make_random_vector<double>(n);
+        double flops = static_cast<double>(n * n);
+        auto t = measure([&]{ mtl::trmv(A, x, /*upper=*/true); },
+                         "trmv", label, n, flops, warmup, iterations);
+        rep.add(t);
+    }
+}
+
+inline void bench_trsv(reporter& rep, const std::string& label,
+                       const std::vector<std::size_t>& sizes,
+                       std::size_t warmup = 3, std::size_t iterations = 10) {
+    for (auto n : sizes) {
+        auto A = make_random_matrix<double>(n, n);
+        for (std::size_t i = 0; i < n; ++i)     // strengthen the diagonal for a stable solve
+            A(i, i) += static_cast<double>(n);
+        auto b = make_random_vector<double>(n);
+        vec::dense_vector<double> x(n);
+        double flops = static_cast<double>(n * n);
+        auto t = measure([&]{ mtl::trsv(A, x, b, /*upper=*/true); },
+                         "trsv", label, n, flops, warmup, iterations);
         rep.add(t);
     }
 }
@@ -194,6 +256,10 @@ inline void run_all(reporter& rep, const std::string& label,
 
     std::cout << "=== BLAS Level 2 ===" << std::endl;
     bench_gemv(rep, label, blas_sizes);
+    bench_ger(rep, label, blas_sizes);
+    bench_symv(rep, label, blas_sizes);
+    bench_trmv(rep, label, blas_sizes);
+    bench_trsv(rep, label, blas_sizes);
 
     std::cout << "=== BLAS Level 3 ===" << std::endl;
     bench_gemm(rep, label, blas_sizes);

--- a/include/mtl/interface/blas.hpp
+++ b/include/mtl/interface/blas.hpp
@@ -55,6 +55,27 @@ void dtrsv_(const char* uplo, const char* trans, const char* diag,
             const int* n, const double* A, const int* lda,
             double* x, const int* incx);
 
+void sger_(const int* m, const int* n, const float* alpha,
+           const float* x, const int* incx, const float* y, const int* incy,
+           float* A, const int* lda);
+void dger_(const int* m, const int* n, const double* alpha,
+           const double* x, const int* incx, const double* y, const int* incy,
+           double* A, const int* lda);
+
+void ssymv_(const char* uplo, const int* n, const float* alpha,
+            const float* A, const int* lda, const float* x, const int* incx,
+            const float* beta, float* y, const int* incy);
+void dsymv_(const char* uplo, const int* n, const double* alpha,
+            const double* A, const int* lda, const double* x, const int* incx,
+            const double* beta, double* y, const int* incy);
+
+void strmv_(const char* uplo, const char* trans, const char* diag,
+            const int* n, const float* A, const int* lda,
+            float* x, const int* incx);
+void dtrmv_(const char* uplo, const char* trans, const char* diag,
+            const int* n, const double* A, const int* lda,
+            double* x, const int* incx);
+
 // Level 3 -- matrix-matrix operations
 void sgemm_(const char* transa, const char* transb,
             const int* m, const int* n, const int* k,
@@ -130,6 +151,33 @@ inline void trsv(char uplo, char trans, char diag, int n,
 inline void trsv(char uplo, char trans, char diag, int n,
                  const double* A, int lda, double* x, int incx) {
     dtrsv_(&uplo, &trans, &diag, &n, A, &lda, x, &incx);
+}
+
+inline void ger(int m, int n, float alpha, const float* x, int incx,
+                const float* y, int incy, float* A, int lda) {
+    sger_(&m, &n, &alpha, x, &incx, y, &incy, A, &lda);
+}
+inline void ger(int m, int n, double alpha, const double* x, int incx,
+                const double* y, int incy, double* A, int lda) {
+    dger_(&m, &n, &alpha, x, &incx, y, &incy, A, &lda);
+}
+
+inline void symv(char uplo, int n, float alpha, const float* A, int lda,
+                 const float* x, int incx, float beta, float* y, int incy) {
+    ssymv_(&uplo, &n, &alpha, A, &lda, x, &incx, &beta, y, &incy);
+}
+inline void symv(char uplo, int n, double alpha, const double* A, int lda,
+                 const double* x, int incx, double beta, double* y, int incy) {
+    dsymv_(&uplo, &n, &alpha, A, &lda, x, &incx, &beta, y, &incy);
+}
+
+inline void trmv(char uplo, char trans, char diag, int n,
+                 const float* A, int lda, float* x, int incx) {
+    strmv_(&uplo, &trans, &diag, &n, A, &lda, x, &incx);
+}
+inline void trmv(char uplo, char trans, char diag, int n,
+                 const double* A, int lda, double* x, int incx) {
+    dtrmv_(&uplo, &trans, &diag, &n, A, &lda, x, &incx);
 }
 
 // -- Level 3 ------------------------------------------------------------

--- a/include/mtl/mtl.hpp
+++ b/include/mtl/mtl.hpp
@@ -168,6 +168,10 @@
 #include <mtl/operation/random.hpp>
 #include <mtl/operation/lower_trisolve.hpp>
 #include <mtl/operation/upper_trisolve.hpp>
+#include <mtl/operation/ger.hpp>
+#include <mtl/operation/symv.hpp>
+#include <mtl/operation/trmv.hpp>
+#include <mtl/operation/trsv.hpp>
 #include <mtl/operation/lu.hpp>
 #include <mtl/operation/householder.hpp>
 #include <mtl/operation/qr.hpp>

--- a/include/mtl/operation/ger.hpp
+++ b/include/mtl/operation/ger.hpp
@@ -1,0 +1,49 @@
+#pragma once
+// MTL5 -- ger: A <- alpha*x*y^T + A  (BLAS level-2 general rank-1 update)
+// Generic path for any Matrix/Vector; BLAS dispatch for column-major dense
+// float/double when available.
+#include <cassert>
+#include <cstddef>
+#include <limits>
+#include <type_traits>
+
+#include <mtl/concepts/scalar.hpp>
+#include <mtl/concepts/vector.hpp>
+#include <mtl/concepts/matrix.hpp>
+#include <mtl/interface/dispatch_traits.hpp>
+#ifdef MTL5_HAS_BLAS
+#include <mtl/interface/blas.hpp>
+#endif
+
+namespace mtl {
+
+/// Rank-1 update: A(i,j) += alpha * x(i) * y(j).
+template <Scalar S, Vector VX, Vector VY, Matrix M>
+void ger(const S& alpha, const VX& x, const VY& y, M& A) {
+    using size_type = typename M::size_type;
+    const size_type m = A.num_rows();
+    const size_type n = A.num_cols();
+    assert(x.size() == m && y.size() == n);
+
+#ifdef MTL5_HAS_BLAS
+    if constexpr (interface::BlasDenseMatrix<M> && interface::BlasDenseVector<VX> &&
+                  interface::BlasDenseVector<VY> && !interface::is_row_major_v<M> &&
+                  std::is_same_v<typename M::value_type, typename VX::value_type> &&
+                  std::is_same_v<typename M::value_type, typename VY::value_type>) {
+        using T = typename M::value_type;
+        const auto imax = static_cast<size_type>(std::numeric_limits<int>::max());
+        if (m <= imax && n <= imax) {
+            // Column-major storage: leading dimension is the row count.
+            interface::blas::ger(static_cast<int>(m), static_cast<int>(n),
+                                 static_cast<T>(alpha), x.data(), 1, y.data(), 1,
+                                 A.data(), static_cast<int>(m));
+            return;
+        }
+    }
+#endif
+    for (size_type i = 0; i < m; ++i)
+        for (size_type j = 0; j < n; ++j)
+            A(i, j) += alpha * x(i) * y(j);
+}
+
+} // namespace mtl

--- a/include/mtl/operation/symv.hpp
+++ b/include/mtl/operation/symv.hpp
@@ -1,0 +1,53 @@
+#pragma once
+// MTL5 -- symv: y <- alpha*A*x + beta*y  for symmetric A  (BLAS level-2)
+// The generic path reads the full matrix (correct for any symmetric A); the
+// BLAS path reads a single triangle. BLAS dispatch for column-major dense
+// float/double when available.
+#include <cassert>
+#include <cstddef>
+#include <limits>
+#include <type_traits>
+
+#include <mtl/concepts/scalar.hpp>
+#include <mtl/concepts/vector.hpp>
+#include <mtl/concepts/matrix.hpp>
+#include <mtl/math/identity.hpp>
+#include <mtl/interface/dispatch_traits.hpp>
+#ifdef MTL5_HAS_BLAS
+#include <mtl/interface/blas.hpp>
+#endif
+
+namespace mtl {
+
+/// Symmetric matrix-vector product: y = alpha*A*x + beta*y, A assumed symmetric.
+template <Scalar S, Matrix M, Vector VX, Vector VY>
+void symv(const S& alpha, const M& A, const VX& x, const S& beta, VY& y) {
+    using value_type = typename VY::value_type;
+    using size_type  = typename M::size_type;
+    const size_type n = A.num_rows();
+    assert(A.num_cols() == n && x.size() == n && y.size() == n);
+
+#ifdef MTL5_HAS_BLAS
+    if constexpr (interface::BlasDenseMatrix<M> && interface::BlasDenseVector<VX> &&
+                  interface::BlasDenseVector<VY> && !interface::is_row_major_v<M> &&
+                  std::is_same_v<value_type, typename M::value_type> &&
+                  std::is_same_v<value_type, typename VX::value_type>) {
+        using T = value_type;
+        if (n <= static_cast<size_type>(std::numeric_limits<int>::max())) {
+            // Symmetric: 'L' reads the lower triangle (== upper for symmetric A).
+            interface::blas::symv('L', static_cast<int>(n), static_cast<T>(alpha),
+                                  A.data(), static_cast<int>(n), x.data(), 1,
+                                  static_cast<T>(beta), y.data(), 1);
+            return;
+        }
+    }
+#endif
+    for (size_type i = 0; i < n; ++i) {
+        auto acc = math::zero<value_type>();
+        for (size_type j = 0; j < n; ++j)
+            acc += A(i, j) * x(j);
+        y(i) = alpha * acc + beta * y(i);
+    }
+}
+
+} // namespace mtl

--- a/include/mtl/operation/trmv.hpp
+++ b/include/mtl/operation/trmv.hpp
@@ -1,0 +1,61 @@
+#pragma once
+// MTL5 -- trmv: x <- A*x  for triangular A  (BLAS level-2)
+// A is upper (upper=true) or lower triangular; the opposite triangle is ignored.
+// unit_diag treats the diagonal as all ones. No transpose in this variant.
+// BLAS dispatch for column-major dense float/double when available.
+#include <cassert>
+#include <cstddef>
+#include <limits>
+#include <type_traits>
+
+#include <mtl/concepts/vector.hpp>
+#include <mtl/concepts/matrix.hpp>
+#include <mtl/math/identity.hpp>
+#include <mtl/interface/dispatch_traits.hpp>
+#ifdef MTL5_HAS_BLAS
+#include <mtl/interface/blas.hpp>
+#endif
+
+namespace mtl {
+
+/// Triangular matrix-vector product: x = A*x, A upper/lower triangular.
+template <Matrix M, Vector VX>
+void trmv(const M& A, VX& x, bool upper, bool unit_diag = false) {
+    using value_type = typename VX::value_type;
+    using size_type  = typename M::size_type;
+    const size_type n = A.num_rows();
+    assert(A.num_cols() == n && x.size() == n);
+
+#ifdef MTL5_HAS_BLAS
+    if constexpr (interface::BlasDenseMatrix<M> && interface::BlasDenseVector<VX> &&
+                  !interface::is_row_major_v<M> &&
+                  std::is_same_v<value_type, typename M::value_type>) {
+        using T = value_type;
+        if (n <= static_cast<size_type>(std::numeric_limits<int>::max())) {
+            interface::blas::trmv(upper ? 'U' : 'L', 'N', unit_diag ? 'U' : 'N',
+                                  static_cast<int>(n), A.data(), static_cast<int>(n),
+                                  x.data(), 1);
+            return;
+        }
+    }
+#endif
+    if (upper) {
+        // x_i depends on x_j for j >= i; forward order is safe.
+        for (size_type i = 0; i < n; ++i) {
+            auto acc = unit_diag ? x(i) : A(i, i) * x(i);
+            for (size_type j = i + 1; j < n; ++j)
+                acc += A(i, j) * x(j);
+            x(i) = acc;
+        }
+    } else {
+        // x_i depends on x_j for j <= i; reverse order is safe.
+        for (size_type ii = n; ii-- > 0; ) {
+            auto acc = unit_diag ? x(ii) : A(ii, ii) * x(ii);
+            for (size_type j = 0; j < ii; ++j)
+                acc += A(ii, j) * x(j);
+            x(ii) = acc;
+        }
+    }
+}
+
+} // namespace mtl

--- a/include/mtl/operation/trsv.hpp
+++ b/include/mtl/operation/trsv.hpp
@@ -1,0 +1,58 @@
+#pragma once
+// MTL5 -- trsv: solve A*x = b for triangular A  (BLAS level-2)
+// A BLAS-style facade over the forward/back-substitution solvers, with an
+// in-place (solve A*x = x) form. A is upper (upper=true) or lower triangular;
+// unit_diag treats the diagonal as all ones. No transpose in this variant.
+// BLAS dispatch for column-major dense float/double when available.
+#include <cassert>
+#include <cstddef>
+#include <limits>
+#include <type_traits>
+
+#include <mtl/concepts/vector.hpp>
+#include <mtl/concepts/matrix.hpp>
+#include <mtl/operation/lower_trisolve.hpp>
+#include <mtl/operation/upper_trisolve.hpp>
+#include <mtl/interface/dispatch_traits.hpp>
+#ifdef MTL5_HAS_BLAS
+#include <mtl/interface/blas.hpp>
+#endif
+
+namespace mtl {
+
+/// Solve A*x = x in place, A upper/lower triangular.
+template <Matrix M, Vector VX>
+void trsv(const M& A, VX& x, bool upper, bool unit_diag = false) {
+    using value_type = typename VX::value_type;
+    using size_type  = typename M::size_type;
+    const size_type n = A.num_rows();
+    assert(A.num_cols() == n && x.size() == n);
+
+#ifdef MTL5_HAS_BLAS
+    if constexpr (interface::BlasDenseMatrix<M> && interface::BlasDenseVector<VX> &&
+                  !interface::is_row_major_v<M> &&
+                  std::is_same_v<value_type, typename M::value_type>) {
+        using T = value_type;
+        if (n <= static_cast<size_type>(std::numeric_limits<int>::max())) {
+            interface::blas::trsv(upper ? 'U' : 'L', 'N', unit_diag ? 'U' : 'N',
+                                  static_cast<int>(n), A.data(), static_cast<int>(n),
+                                  x.data(), 1);
+            return;
+        }
+    }
+#endif
+    if (upper)
+        upper_trisolve(A, x, unit_diag);
+    else
+        lower_trisolve(A, x, unit_diag);
+}
+
+/// Solve A*x = b, writing the solution into x (b unchanged).
+template <Matrix M, Vector VX, Vector VB>
+void trsv(const M& A, VX& x, const VB& b, bool upper, bool unit_diag = false) {
+    using size_type = typename M::size_type;
+    for (size_type i = 0; i < b.size(); ++i) x(i) = b(i);
+    trsv(A, x, upper, unit_diag);
+}
+
+} // namespace mtl

--- a/tests/unit/operation/test_blas_l2.cpp
+++ b/tests/unit/operation/test_blas_l2.cpp
@@ -1,0 +1,133 @@
+// Tests for the BLAS Level-2 operators: ger, symv, trmv, trsv (#229).
+// Exercise the generic (non-column-major / non-BLAS) path with row-major
+// dense2D; a LAPACK/BLAS build additionally routes column-major inputs through
+// the external BLAS, validated by the same reference checks.
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/mat/parameter.hpp>
+#include <mtl/tag/orientation.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/operation/ger.hpp>
+#include <mtl/operation/symv.hpp>
+#include <mtl/operation/trmv.hpp>
+#include <mtl/operation/trsv.hpp>
+
+#include <cmath>
+
+using namespace mtl;
+using colmat = mat::dense2D<double, mat::parameters<tag::col_major>>;
+
+TEST_CASE("ger: rank-1 update A += alpha x y^T", "[operation][blas][ger]") {
+    mat::dense2D<double> A(2, 3);
+    for (std::size_t i = 0; i < 2; ++i)
+        for (std::size_t j = 0; j < 3; ++j) A(i, j) = 1.0;
+    vec::dense_vector<double> x = {2.0, 3.0};
+    vec::dense_vector<double> y = {1.0, 0.5, -1.0};
+
+    ger(2.0, x, y, A);   // A(i,j) += 2*x(i)*y(j)
+    for (std::size_t i = 0; i < 2; ++i)
+        for (std::size_t j = 0; j < 3; ++j)
+            REQUIRE_THAT(A(i, j), Catch::Matchers::WithinAbs(1.0 + 2.0 * x(i) * y(j), 1e-12));
+}
+
+TEST_CASE("ger: column-major (BLAS-eligible) path matches reference", "[operation][blas][ger]") {
+    colmat A(3, 3);
+    for (std::size_t i = 0; i < 3; ++i)
+        for (std::size_t j = 0; j < 3; ++j) A(i, j) = static_cast<double>(i + j);
+    vec::dense_vector<double> x = {1.0, -2.0, 0.5};
+    vec::dense_vector<double> y = {2.0, 1.0, -1.0};
+
+    ger(1.5, x, y, A);
+    for (std::size_t i = 0; i < 3; ++i)
+        for (std::size_t j = 0; j < 3; ++j)
+            REQUIRE_THAT(A(i, j),
+                Catch::Matchers::WithinAbs(static_cast<double>(i + j) + 1.5 * x(i) * y(j), 1e-12));
+}
+
+TEST_CASE("symv: symmetric matrix-vector y = alpha A x + beta y", "[operation][blas][symv]") {
+    // A = [[2,1,0],[1,3,1],[0,1,2]] symmetric.
+    mat::dense2D<double> A(3, 3);
+    double v[3][3] = {{2,1,0},{1,3,1},{0,1,2}};
+    for (std::size_t i = 0; i < 3; ++i)
+        for (std::size_t j = 0; j < 3; ++j) A(i, j) = v[i][j];
+    vec::dense_vector<double> x = {1.0, 2.0, 3.0};
+    vec::dense_vector<double> y = {1.0, 1.0, 1.0};
+
+    symv(2.0, A, x, 0.5, y);   // y = 2*A*x + 0.5*y
+    // A*x = [4, 10, 8]; 2*A*x + 0.5*[1,1,1] = [8.5, 20.5, 16.5]
+    REQUIRE_THAT(y(0), Catch::Matchers::WithinAbs(8.5, 1e-12));
+    REQUIRE_THAT(y(1), Catch::Matchers::WithinAbs(20.5, 1e-12));
+    REQUIRE_THAT(y(2), Catch::Matchers::WithinAbs(16.5, 1e-12));
+}
+
+TEST_CASE("symv: column-major path matches reference", "[operation][blas][symv]") {
+    colmat A(3, 3);
+    double v[3][3] = {{4,1,2},{1,5,3},{2,3,6}};   // symmetric
+    for (std::size_t i = 0; i < 3; ++i)
+        for (std::size_t j = 0; j < 3; ++j) A(i, j) = v[i][j];
+    vec::dense_vector<double> x = {1.0, -1.0, 2.0};
+    vec::dense_vector<double> y = {0.0, 0.0, 0.0};
+
+    symv(1.0, A, x, 0.0, y);   // y = A*x
+    // A*x = [4-1+4, 1-5+6, 2-3+12] = [7, 2, 11]
+    REQUIRE_THAT(y(0), Catch::Matchers::WithinAbs(7.0, 1e-12));
+    REQUIRE_THAT(y(1), Catch::Matchers::WithinAbs(2.0, 1e-12));
+    REQUIRE_THAT(y(2), Catch::Matchers::WithinAbs(11.0, 1e-12));
+}
+
+TEST_CASE("trmv: triangular matrix-vector x = A x", "[operation][blas][trmv]") {
+    // Upper triangular U = [[2,1,3],[0,4,1],[0,0,5]].
+    mat::dense2D<double> U(3, 3);
+    double u[3][3] = {{2,1,3},{0,4,1},{0,0,5}};
+    for (std::size_t i = 0; i < 3; ++i)
+        for (std::size_t j = 0; j < 3; ++j) U(i, j) = u[i][j];
+    vec::dense_vector<double> x = {1.0, 2.0, 3.0};
+    trmv(U, x, /*upper=*/true);
+    // U*x = [2+2+9, 8+3, 15] = [13, 11, 15]
+    REQUIRE_THAT(x(0), Catch::Matchers::WithinAbs(13.0, 1e-12));
+    REQUIRE_THAT(x(1), Catch::Matchers::WithinAbs(11.0, 1e-12));
+    REQUIRE_THAT(x(2), Catch::Matchers::WithinAbs(15.0, 1e-12));
+
+    // Lower triangular L = [[2,0,0],[1,3,0],[4,1,5]].
+    mat::dense2D<double> L(3, 3);
+    double l[3][3] = {{2,0,0},{1,3,0},{4,1,5}};
+    for (std::size_t i = 0; i < 3; ++i)
+        for (std::size_t j = 0; j < 3; ++j) L(i, j) = l[i][j];
+    vec::dense_vector<double> z = {1.0, 2.0, 3.0};
+    trmv(L, z, /*upper=*/false);
+    // L*z = [2, 1+6, 4+2+15] = [2, 7, 21]
+    REQUIRE_THAT(z(0), Catch::Matchers::WithinAbs(2.0, 1e-12));
+    REQUIRE_THAT(z(1), Catch::Matchers::WithinAbs(7.0, 1e-12));
+    REQUIRE_THAT(z(2), Catch::Matchers::WithinAbs(21.0, 1e-12));
+}
+
+TEST_CASE("trsv: triangular solve A x = b inverts trmv", "[operation][blas][trsv]") {
+    // Upper triangular; solve U y = (U x) recovers x.
+    colmat U(4, 4);
+    for (std::size_t i = 0; i < 4; ++i)
+        for (std::size_t j = 0; j < 4; ++j)
+            U(i, j) = (j >= i) ? static_cast<double>(i + j + 1) : 0.0;
+    vec::dense_vector<double> x = {1.0, -2.0, 3.0, 0.5};
+
+    vec::dense_vector<double> b(4);
+    for (std::size_t i = 0; i < 4; ++i) b(i) = x(i);
+    trmv(U, b, /*upper=*/true);          // b = U x
+
+    vec::dense_vector<double> sol(4);
+    trsv(U, sol, b, /*upper=*/true);     // solve U sol = b
+    for (std::size_t i = 0; i < 4; ++i)
+        REQUIRE_THAT(sol(i), Catch::Matchers::WithinAbs(x(i), 1e-10));
+
+    // Lower triangular, in-place form.
+    mat::dense2D<double> Lm(3, 3);
+    double l[3][3] = {{2,0,0},{1,3,0},{4,1,5}};
+    for (std::size_t i = 0; i < 3; ++i)
+        for (std::size_t j = 0; j < 3; ++j) Lm(i, j) = l[i][j];
+    vec::dense_vector<double> rhs = {2.0, 7.0, 21.0};   // = L * [1,2,3]
+    trsv(Lm, rhs, /*upper=*/false);
+    REQUIRE_THAT(rhs(0), Catch::Matchers::WithinAbs(1.0, 1e-12));
+    REQUIRE_THAT(rhs(1), Catch::Matchers::WithinAbs(2.0, 1e-12));
+    REQUIRE_THAT(rhs(2), Catch::Matchers::WithinAbs(3.0, 1e-12));
+}


### PR DESCRIPTION
Batch 1 of 3 for #229 (complete BLAS L2/L3 coverage). Adds the four missing core
**Level-2** operators.

## What

| Op | Semantics | BLAS |
|---|---|---|
| `ger(alpha, x, y, A)` | `A += alpha * x * y^T` | `sger`/`dger` |
| `symv(alpha, A, x, beta, y)` | `y = alpha*A*x + beta*y`, A symmetric | `ssymv`/`dsymv` |
| `trmv(A, x, upper, unit)` | `x = A*x`, triangular | `strmv`/`dtrmv` |
| `trsv(A, x[, b], upper, unit)` | solve `A*x = b`, triangular | `strsv`/`dtrsv` |

Each is a generic templated function that works for **any** Matrix/Vector type
and orientation (and custom number types), with optional external-BLAS dispatch
for **column-major dense float/double** — the same gating style as `gemv`/`axpy`.
`trsv` is a BLAS-style facade over the existing `lower/upper_trisolve`. New BLAS
bindings (`sger/dger`, `ssymv/dsymv`, `strmv/dtrmv`) added to `interface/blas.hpp`
(trsv bindings already existed).

## Verification

- `tests/unit/operation/test_blas_l2.cpp`: reference-value checks for each op on
  **row-major (generic)** and **column-major (BLAS)** inputs, plus a trmv/trsv
  round-trip (`trsv(U, trmv(U, x)) == x`).
- Confirmed the BLAS path is genuinely taken: `dger_`/`dsymv_`/`dtrmv_`/`dtrsv_`
  are undefined symbols in the BLAS-built test binary.
- Full suite **134/134 green with and without BLAS, on GCC and Clang.**
- Benchmarks: `bench_ger/symv/trmv/trsv` wired into the `l2` group and individual
  suites, so they're covered by the OpenBLAS/BLIS comparison (#227).

## Scope notes

- **No transpose** variant for `trmv`/`trsv` in this batch (matches the existing
  `trisolve`); `symv` reads the full symmetric matrix on the generic path.
- **Accumulator-policy-awareness** for the reduction ops (symv/trmv) is deferred
  — plain `value_type` accumulation for now.
- Follow-ups on #229: **batch 2** L3 triangular (`trmm`, `trsm`), **batch 3** L3
  symmetric (`symm`, `syrk`, `syr2k`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
