### PR TITLE
feat(operation): BLAS Level-3 triangular operators — trmm, trsm (#229, batch 2/3)

### DIFF
--- a/benchmarks/bench_all.cpp
+++ b/benchmarks/bench_all.cpp
@@ -129,8 +129,8 @@ static void print_usage() {
         "    250:1030:x1.01   -> dense sweep bracketing the 256/512/1024 cliffs\n"
         "\n"
         "Suites: all, blas (=l1+l2+l3), lapack,\n"
-        "        l1 (dot+nrm2+axpy+scal), l2 (gemv+ger+symv+trmv+trsv), l3 (gemm),\n"
-        "        dot, nrm2, axpy, scal, gemv, ger, symv, trmv, trsv, gemm,\n"
+        "        l1 (dot+nrm2+axpy+scal), l2 (gemv+ger+symv+trmv+trsv), l3 (gemm+trmm+trsm),\n"
+        "        dot, nrm2, axpy, scal, gemv, ger, symv, trmv, trsv, gemm, trmm, trsm,\n"
         "        lu, qr, cholesky, eig\n";
 }
 
@@ -199,6 +199,8 @@ int main(int argc, char* argv[]) {
         b::bench_trsv(rep, label, blas_sizes);
         std::cout << "=== BLAS Level 3 ===" << std::endl;
         b::bench_gemm(rep, label, blas_sizes);
+        b::bench_trmm(rep, label, blas_sizes);
+        b::bench_trsm(rep, label, blas_sizes);
     } else if (suite == "l1") {
         std::cout << "=== BLAS Level 1 ===" << std::endl;
         b::bench_dot(rep, label, blas_sizes);
@@ -215,6 +217,8 @@ int main(int argc, char* argv[]) {
     } else if (suite == "l3") {
         std::cout << "=== BLAS Level 3 ===" << std::endl;
         b::bench_gemm(rep, label, blas_sizes);
+        b::bench_trmm(rep, label, blas_sizes);
+        b::bench_trsm(rep, label, blas_sizes);
     } else if (suite == "lapack") {
         std::cout << "=== LAPACK Factorizations ===" << std::endl;
         b::bench_lu(rep, label, lapack_sizes);
@@ -241,6 +245,10 @@ int main(int argc, char* argv[]) {
         b::bench_trsv(rep, label, blas_sizes);
     } else if (suite == "gemm") {
         b::bench_gemm(rep, label, blas_sizes);
+    } else if (suite == "trmm") {
+        b::bench_trmm(rep, label, blas_sizes);
+    } else if (suite == "trsm") {
+        b::bench_trsm(rep, label, blas_sizes);
     } else if (suite == "lu") {
         b::bench_lu(rep, label, lapack_sizes);
     } else if (suite == "qr") {

--- a/benchmarks/harness/runner.hpp
+++ b/benchmarks/harness/runner.hpp
@@ -28,6 +28,8 @@
 #include <mtl/operation/symv.hpp>
 #include <mtl/operation/trmv.hpp>
 #include <mtl/operation/trsv.hpp>
+#include <mtl/operation/trmm.hpp>
+#include <mtl/operation/trsm.hpp>
 #include <mtl/operation/lu.hpp>
 #include <mtl/operation/qr.hpp>
 #include <mtl/operation/cholesky.hpp>
@@ -179,6 +181,36 @@ inline void bench_gemm(reporter& rep, const std::string& label,
     }
 }
 
+inline void bench_trmm(reporter& rep, const std::string& label,
+                       const std::vector<std::size_t>& sizes,
+                       std::size_t warmup = 3, std::size_t iterations = 10) {
+    for (auto n : sizes) {
+        auto A = make_random_matrix<double>(n, n);   // upper triangle used
+        auto B = make_random_matrix<double>(n, n, 99);
+        double flops = static_cast<double>(n) * n * n;   // ~n^3 for square triangular*full
+        auto t = measure([&]{ mtl::trmm(1.0, A, B, /*upper=*/true); },
+                         "trmm", label, n, flops, warmup, iterations);
+        rep.add(t);
+    }
+}
+
+inline void bench_trsm(reporter& rep, const std::string& label,
+                       const std::vector<std::size_t>& sizes,
+                       std::size_t warmup = 3, std::size_t iterations = 10) {
+    for (auto n : sizes) {
+        auto A = make_random_matrix<double>(n, n);
+        for (std::size_t i = 0; i < n; ++i)     // strengthen diagonal for stability
+            A(i, i) += static_cast<double>(n);
+        auto B_template = make_random_matrix<double>(n, n, 99);
+        double flops = static_cast<double>(n) * n * n;
+        auto t = measure([&]{
+                    auto B = B_template;
+                    mtl::trsm(1.0, A, B, /*upper=*/true);
+                 }, "trsm", label, n, flops, warmup, iterations);
+        rep.add(t);
+    }
+}
+
 // ── LAPACK-level suites ─────────────────────────────────────────────────────
 // Column-major inputs so the BLAS/LAPACK dispatch is eligible (matches a
 // real app that stores factorization operands column-major).
@@ -263,6 +295,8 @@ inline void run_all(reporter& rep, const std::string& label,
 
     std::cout << "=== BLAS Level 3 ===" << std::endl;
     bench_gemm(rep, label, blas_sizes);
+    bench_trmm(rep, label, blas_sizes);
+    bench_trsm(rep, label, blas_sizes);
 
     std::cout << "=== LAPACK Factorizations ===" << std::endl;
     bench_lu(rep, label, lapack_sizes);

--- a/include/mtl/interface/blas.hpp
+++ b/include/mtl/interface/blas.hpp
@@ -88,6 +88,24 @@ void dgemm_(const char* transa, const char* transb,
             const double* B, const int* ldb,
             const double* beta, double* C, const int* ldc);
 
+void strmm_(const char* side, const char* uplo, const char* transa,
+            const char* diag, const int* m, const int* n,
+            const float* alpha, const float* A, const int* lda,
+            float* B, const int* ldb);
+void dtrmm_(const char* side, const char* uplo, const char* transa,
+            const char* diag, const int* m, const int* n,
+            const double* alpha, const double* A, const int* lda,
+            double* B, const int* ldb);
+
+void strsm_(const char* side, const char* uplo, const char* transa,
+            const char* diag, const int* m, const int* n,
+            const float* alpha, const float* A, const int* lda,
+            float* B, const int* ldb);
+void dtrsm_(const char* side, const char* uplo, const char* transa,
+            const char* diag, const int* m, const int* n,
+            const double* alpha, const double* A, const int* lda,
+            double* B, const int* ldb);
+
 } // extern "C"
 
 // -- C++ wrapper functions ----------------------------------------------
@@ -193,6 +211,24 @@ inline void gemm(char transa, char transb, int m, int n, int k,
                  const double* B, int ldb,
                  double beta, double* C, int ldc) {
     dgemm_(&transa, &transb, &m, &n, &k, &alpha, A, &lda, B, &ldb, &beta, C, &ldc);
+}
+
+inline void trmm(char side, char uplo, char transa, char diag, int m, int n,
+                 float alpha, const float* A, int lda, float* B, int ldb) {
+    strmm_(&side, &uplo, &transa, &diag, &m, &n, &alpha, A, &lda, B, &ldb);
+}
+inline void trmm(char side, char uplo, char transa, char diag, int m, int n,
+                 double alpha, const double* A, int lda, double* B, int ldb) {
+    dtrmm_(&side, &uplo, &transa, &diag, &m, &n, &alpha, A, &lda, B, &ldb);
+}
+
+inline void trsm(char side, char uplo, char transa, char diag, int m, int n,
+                 float alpha, const float* A, int lda, float* B, int ldb) {
+    strsm_(&side, &uplo, &transa, &diag, &m, &n, &alpha, A, &lda, B, &ldb);
+}
+inline void trsm(char side, char uplo, char transa, char diag, int m, int n,
+                 double alpha, const double* A, int lda, double* B, int ldb) {
+    dtrsm_(&side, &uplo, &transa, &diag, &m, &n, &alpha, A, &lda, B, &ldb);
 }
 
 } // namespace mtl::interface::blas

--- a/include/mtl/mtl.hpp
+++ b/include/mtl/mtl.hpp
@@ -172,6 +172,8 @@
 #include <mtl/operation/symv.hpp>
 #include <mtl/operation/trmv.hpp>
 #include <mtl/operation/trsv.hpp>
+#include <mtl/operation/trmm.hpp>
+#include <mtl/operation/trsm.hpp>
 #include <mtl/operation/lu.hpp>
 #include <mtl/operation/householder.hpp>
 #include <mtl/operation/qr.hpp>

--- a/include/mtl/operation/trmm.hpp
+++ b/include/mtl/operation/trmm.hpp
@@ -1,0 +1,63 @@
+#pragma once
+// MTL5 -- trmm: B <- alpha * A * B  for triangular A  (BLAS level-3, left side)
+// A is m x m upper (upper=true) or lower triangular; B is m x n. unit_diag treats
+// A's diagonal as all ones. Left side, no transpose in this variant. BLAS
+// dispatch for column-major dense float/double when available.
+#include <cassert>
+#include <cstddef>
+#include <limits>
+#include <type_traits>
+
+#include <mtl/concepts/scalar.hpp>
+#include <mtl/concepts/matrix.hpp>
+#include <mtl/interface/dispatch_traits.hpp>
+#ifdef MTL5_HAS_BLAS
+#include <mtl/interface/blas.hpp>
+#endif
+
+namespace mtl {
+
+/// Triangular matrix-matrix product: B = alpha * A * B, A upper/lower triangular.
+template <Scalar S, Matrix MA, Matrix MB>
+void trmm(const S& alpha, const MA& A, MB& B, bool upper, bool unit_diag = false) {
+    using value_type = typename MB::value_type;
+    using size_type  = typename MA::size_type;
+    const size_type m = A.num_rows();
+    const size_type n = B.num_cols();
+    assert(A.num_cols() == m && B.num_rows() == m);
+
+#ifdef MTL5_HAS_BLAS
+    if constexpr (interface::BlasDenseMatrix<MA> && interface::BlasDenseMatrix<MB> &&
+                  !interface::is_row_major_v<MA> && !interface::is_row_major_v<MB> &&
+                  std::is_same_v<value_type, typename MA::value_type>) {
+        using T = value_type;
+        const auto imax = static_cast<size_type>(std::numeric_limits<int>::max());
+        if (m <= imax && n <= imax) {
+            interface::blas::trmm('L', upper ? 'U' : 'L', 'N', unit_diag ? 'U' : 'N',
+                                  static_cast<int>(m), static_cast<int>(n),
+                                  static_cast<T>(alpha), A.data(), static_cast<int>(m),
+                                  B.data(), static_cast<int>(m));
+            return;
+        }
+    }
+#endif
+    for (size_type c = 0; c < n; ++c) {
+        if (upper) {
+            for (size_type i = 0; i < m; ++i) {
+                auto acc = unit_diag ? B(i, c) : A(i, i) * B(i, c);
+                for (size_type j = i + 1; j < m; ++j)
+                    acc += A(i, j) * B(j, c);
+                B(i, c) = alpha * acc;
+            }
+        } else {
+            for (size_type ii = m; ii-- > 0; ) {
+                auto acc = unit_diag ? B(ii, c) : A(ii, ii) * B(ii, c);
+                for (size_type j = 0; j < ii; ++j)
+                    acc += A(ii, j) * B(j, c);
+                B(ii, c) = alpha * acc;
+            }
+        }
+    }
+}
+
+} // namespace mtl

--- a/include/mtl/operation/trmm.hpp
+++ b/include/mtl/operation/trmm.hpp
@@ -3,6 +3,7 @@
 // A is m x m upper (upper=true) or lower triangular; B is m x n. unit_diag treats
 // A's diagonal as all ones. Left side, no transpose in this variant. BLAS
 // dispatch for column-major dense float/double when available.
+#include <algorithm>
 #include <cassert>
 #include <cstddef>
 #include <limits>
@@ -33,10 +34,11 @@ void trmm(const S& alpha, const MA& A, MB& B, bool upper, bool unit_diag = false
         using T = value_type;
         const auto imax = static_cast<size_type>(std::numeric_limits<int>::max());
         if (m <= imax && n <= imax) {
+            // BLAS requires lda,ldb >= max(1,m) even for empty (m==0) matrices.
+            const int ld = std::max(1, static_cast<int>(m));
             interface::blas::trmm('L', upper ? 'U' : 'L', 'N', unit_diag ? 'U' : 'N',
                                   static_cast<int>(m), static_cast<int>(n),
-                                  static_cast<T>(alpha), A.data(), static_cast<int>(m),
-                                  B.data(), static_cast<int>(m));
+                                  static_cast<T>(alpha), A.data(), ld, B.data(), ld);
             return;
         }
     }

--- a/include/mtl/operation/trsm.hpp
+++ b/include/mtl/operation/trsm.hpp
@@ -4,6 +4,7 @@
 // overwritten with the solution X. unit_diag treats A's diagonal as all ones.
 // Left side, no transpose in this variant. BLAS dispatch for column-major dense
 // float/double when available.
+#include <algorithm>
 #include <cassert>
 #include <cstddef>
 #include <limits>
@@ -34,10 +35,11 @@ void trsm(const S& alpha, const MA& A, MB& B, bool upper, bool unit_diag = false
         using T = value_type;
         const auto imax = static_cast<size_type>(std::numeric_limits<int>::max());
         if (m <= imax && n <= imax) {
+            // BLAS requires lda,ldb >= max(1,m) even for empty (m==0) matrices.
+            const int ld = std::max(1, static_cast<int>(m));
             interface::blas::trsm('L', upper ? 'U' : 'L', 'N', unit_diag ? 'U' : 'N',
                                   static_cast<int>(m), static_cast<int>(n),
-                                  static_cast<T>(alpha), A.data(), static_cast<int>(m),
-                                  B.data(), static_cast<int>(m));
+                                  static_cast<T>(alpha), A.data(), ld, B.data(), ld);
             return;
         }
     }

--- a/include/mtl/operation/trsm.hpp
+++ b/include/mtl/operation/trsm.hpp
@@ -1,0 +1,66 @@
+#pragma once
+// MTL5 -- trsm: solve A * X = alpha * B for triangular A  (BLAS level-3, left side)
+// A is m x m upper (upper=true) or lower triangular; B is m x n and is
+// overwritten with the solution X. unit_diag treats A's diagonal as all ones.
+// Left side, no transpose in this variant. BLAS dispatch for column-major dense
+// float/double when available.
+#include <cassert>
+#include <cstddef>
+#include <limits>
+#include <type_traits>
+
+#include <mtl/concepts/scalar.hpp>
+#include <mtl/concepts/matrix.hpp>
+#include <mtl/interface/dispatch_traits.hpp>
+#ifdef MTL5_HAS_BLAS
+#include <mtl/interface/blas.hpp>
+#endif
+
+namespace mtl {
+
+/// Triangular solve with multiple RHS: solve A * X = alpha * B, B := X.
+template <Scalar S, Matrix MA, Matrix MB>
+void trsm(const S& alpha, const MA& A, MB& B, bool upper, bool unit_diag = false) {
+    using value_type = typename MB::value_type;
+    using size_type  = typename MA::size_type;
+    const size_type m = A.num_rows();
+    const size_type n = B.num_cols();
+    assert(A.num_cols() == m && B.num_rows() == m);
+
+#ifdef MTL5_HAS_BLAS
+    if constexpr (interface::BlasDenseMatrix<MA> && interface::BlasDenseMatrix<MB> &&
+                  !interface::is_row_major_v<MA> && !interface::is_row_major_v<MB> &&
+                  std::is_same_v<value_type, typename MA::value_type>) {
+        using T = value_type;
+        const auto imax = static_cast<size_type>(std::numeric_limits<int>::max());
+        if (m <= imax && n <= imax) {
+            interface::blas::trsm('L', upper ? 'U' : 'L', 'N', unit_diag ? 'U' : 'N',
+                                  static_cast<int>(m), static_cast<int>(n),
+                                  static_cast<T>(alpha), A.data(), static_cast<int>(m),
+                                  B.data(), static_cast<int>(m));
+            return;
+        }
+    }
+#endif
+    for (size_type c = 0; c < n; ++c) {
+        if (upper) {
+            // Back substitution.
+            for (size_type ii = m; ii-- > 0; ) {
+                auto s = alpha * B(ii, c);
+                for (size_type j = ii + 1; j < m; ++j)
+                    s -= A(ii, j) * B(j, c);
+                B(ii, c) = unit_diag ? s : s / A(ii, ii);
+            }
+        } else {
+            // Forward substitution.
+            for (size_type i = 0; i < m; ++i) {
+                auto s = alpha * B(i, c);
+                for (size_type j = 0; j < i; ++j)
+                    s -= A(i, j) * B(j, c);
+                B(i, c) = unit_diag ? s : s / A(i, i);
+            }
+        }
+    }
+}
+
+} // namespace mtl

--- a/tests/unit/operation/test_blas_l3_triangular.cpp
+++ b/tests/unit/operation/test_blas_l3_triangular.cpp
@@ -1,0 +1,125 @@
+// Tests for the BLAS Level-3 triangular operators: trmm, trsm (#229, batch 2).
+// Exercises the generic (row-major) path and the column-major (BLAS-dispatch)
+// path with the same reference checks; trsm inverts trmm as a round-trip.
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/mat/parameter.hpp>
+#include <mtl/tag/orientation.hpp>
+#include <mtl/operation/trmm.hpp>
+#include <mtl/operation/trsm.hpp>
+
+#include <cmath>
+
+using namespace mtl;
+template <typename Params = mat::parameters<>>
+using dmat = mat::dense2D<double, Params>;
+using colmat = mat::dense2D<double, mat::parameters<tag::col_major>>;
+
+namespace {
+
+template <typename MA, typename MB>
+double max_abs_diff(const MA& A, const MB& B, std::size_t m, std::size_t n) {
+    double d = 0.0;
+    for (std::size_t i = 0; i < m; ++i)
+        for (std::size_t j = 0; j < n; ++j)
+            d = std::max(d, std::abs(A(i, j) - B(i, j)));
+    return d;
+}
+
+} // namespace
+
+TEST_CASE("trmm: B = alpha * A * B, upper triangular", "[operation][blas][trmm]") {
+    // U = [[2,1,3],[0,4,1],[0,0,5]], B = 3x2.
+    dmat<> U(3, 3);
+    double u[3][3] = {{2,1,3},{0,4,1},{0,0,5}};
+    for (std::size_t i = 0; i < 3; ++i)
+        for (std::size_t j = 0; j < 3; ++j) U(i, j) = u[i][j];
+    dmat<> B(3, 2);
+    double b[3][2] = {{1,0},{2,1},{3,2}};
+    for (std::size_t i = 0; i < 3; ++i)
+        for (std::size_t j = 0; j < 2; ++j) B(i, j) = b[i][j];
+
+    trmm(1.0, U, B, /*upper=*/true);
+    // col0: U*[1,2,3] = [13,11,15]; col1: U*[0,1,2] = [7,6,10]
+    double exp[3][2] = {{13,7},{11,6},{15,10}};
+    for (std::size_t i = 0; i < 3; ++i)
+        for (std::size_t j = 0; j < 2; ++j)
+            REQUIRE_THAT(B(i, j), Catch::Matchers::WithinAbs(exp[i][j], 1e-12));
+}
+
+TEST_CASE("trmm: lower triangular with alpha (column-major/BLAS path)", "[operation][blas][trmm]") {
+    colmat L(3, 3);
+    double l[3][3] = {{2,0,0},{1,3,0},{4,1,5}};
+    for (std::size_t i = 0; i < 3; ++i)
+        for (std::size_t j = 0; j < 3; ++j) L(i, j) = l[i][j];
+    colmat B(3, 1);
+    B(0,0) = 1; B(1,0) = 2; B(2,0) = 3;
+
+    trmm(2.0, L, B, /*upper=*/false);   // 2 * L * [1,2,3]
+    // L*[1,2,3] = [2,7,21] -> *2 = [4,14,42]
+    REQUIRE_THAT(B(0,0), Catch::Matchers::WithinAbs(4.0, 1e-12));
+    REQUIRE_THAT(B(1,0), Catch::Matchers::WithinAbs(14.0, 1e-12));
+    REQUIRE_THAT(B(2,0), Catch::Matchers::WithinAbs(42.0, 1e-12));
+}
+
+TEST_CASE("trsm: solves A X = alpha B (upper, generic + BLAS)", "[operation][blas][trsm]") {
+    // Build a well-conditioned upper-triangular A, a known X, form B = A*X,
+    // then trsm must recover X (up to the alpha scaling).
+    const std::size_t m = 5, n = 3;
+    colmat A(m, m), X(m, n), B(m, n);
+    for (std::size_t i = 0; i < m; ++i)
+        for (std::size_t j = 0; j < m; ++j)
+            A(i, j) = (j >= i) ? static_cast<double>(i + j + 1) : 0.0;
+    for (std::size_t i = 0; i < m; ++i)
+        for (std::size_t j = 0; j < n; ++j)
+            X(i, j) = static_cast<double>((i + 1) * (j + 2)) - 3.0;
+
+    // B = A * X
+    for (std::size_t i = 0; i < m; ++i)
+        for (std::size_t j = 0; j < n; ++j) {
+            double s = 0.0;
+            for (std::size_t k = 0; k < m; ++k) s += A(i, k) * X(k, j);
+            B(i, j) = s;
+        }
+
+    trsm(1.0, A, B, /*upper=*/true);    // solve A * Xr = B, B := Xr
+    REQUIRE(max_abs_diff(B, X, m, n) < 1e-9);
+}
+
+TEST_CASE("trsm inverts trmm (lower, round-trip)", "[operation][blas][trsm]") {
+    const std::size_t m = 4, n = 2;
+    dmat<> A(m, m), B0(m, n), B(m, n);
+    for (std::size_t i = 0; i < m; ++i)
+        for (std::size_t j = 0; j < m; ++j)
+            A(i, j) = (j <= i) ? static_cast<double>(i + j + 2) : 0.0;   // lower, nonzero diag
+    for (std::size_t i = 0; i < m; ++i)
+        for (std::size_t j = 0; j < n; ++j) {
+            B0(i, j) = static_cast<double>(i) - 2.0 * static_cast<double>(j) + 1.0;
+            B(i, j)  = B0(i, j);
+        }
+
+    trmm(1.0, A, B, /*upper=*/false);   // B = A * B0
+    trsm(1.0, A, B, /*upper=*/false);   // solve A * X = B  ->  X == B0
+    REQUIRE(max_abs_diff(B, B0, m, n) < 1e-10);
+}
+
+TEST_CASE("trmm/trsm: unit diagonal", "[operation][blas][trmm][trsm]") {
+    // Unit-diagonal lower triangular (diagonal ignored, treated as 1).
+    dmat<> A(3, 3);
+    double a[3][3] = {{9,0,0},{2,9,0},{3,4,9}};   // off-diagonals used; diag ignored
+    for (std::size_t i = 0; i < 3; ++i)
+        for (std::size_t j = 0; j < 3; ++j) A(i, j) = a[i][j];
+    dmat<> B(3, 1), B0(3, 1);
+    B(0,0) = B0(0,0) = 1; B(1,0) = B0(1,0) = 2; B(2,0) = B0(2,0) = 3;
+
+    trmm(1.0, A, B, /*upper=*/false, /*unit_diag=*/true);
+    // unit-diag L*[1,2,3]: [1, 2+2*1, 3+3*1+4*2] = [1, 4, 14]
+    REQUIRE_THAT(B(0,0), Catch::Matchers::WithinAbs(1.0, 1e-12));
+    REQUIRE_THAT(B(1,0), Catch::Matchers::WithinAbs(4.0, 1e-12));
+    REQUIRE_THAT(B(2,0), Catch::Matchers::WithinAbs(14.0, 1e-12));
+
+    trsm(1.0, A, B, /*upper=*/false, /*unit_diag=*/true);   // recover B0
+    REQUIRE(max_abs_diff(B, B0, 3, 1) < 1e-12);
+}

--- a/tests/unit/operation/test_blas_l3_triangular.cpp
+++ b/tests/unit/operation/test_blas_l3_triangular.cpp
@@ -105,6 +105,16 @@ TEST_CASE("trsm inverts trmm (lower, round-trip)", "[operation][blas][trsm]") {
     REQUIRE(max_abs_diff(B, B0, m, n) < 1e-10);
 }
 
+TEST_CASE("trmm/trsm: empty matrices (BLAS leading-dimension edge)", "[operation][blas][trmm][trsm]") {
+    // Column-major 0x0 is BLAS-eligible; the BLAS path must pass lda,ldb >= 1
+    // (max(1,m)) rather than 0. Both ops are a no-op and must not crash.
+    colmat A0(0, 0), B0(0, 0);
+    REQUIRE_NOTHROW(trmm(1.0, A0, B0, /*upper=*/true));
+    REQUIRE_NOTHROW(trsm(1.0, A0, B0, /*upper=*/true));
+    REQUIRE(B0.num_rows() == 0);
+    REQUIRE(B0.num_cols() == 0);
+}
+
 TEST_CASE("trmm/trsm: unit diagonal", "[operation][blas][trmm][trsm]") {
     // Unit-diagonal lower triangular (diagonal ignored, treated as 1).
     dmat<> A(3, 3);


### PR DESCRIPTION
Batch 2 of 3 for #229. Adds the **Level-3 triangular** operators (left side, no
transpose).

## What

| Op | Semantics | BLAS |
|---|---|---|
| `trmm(alpha, A, B, upper, unit)` | `B = alpha * A * B`, A triangular | `strmm`/`dtrmm` |
| `trsm(alpha, A, B, upper, unit)` | solve `A*X = alpha*B`, `B := X` | `strsm`/`dtrsm` |

Generic templated functions (any Matrix type/orientation, custom number types) —
the generic path applies the triangular kernel per column, with correct
forward/back ordering — and optional external-BLAS dispatch for **column-major
dense float/double** (same gating as gemm/trmv). New `strmm/dtrmm`, `strsm/dtrsm`
bindings added to `interface/blas.hpp`.

## Verification

- `tests/unit/operation/test_blas_l3_triangular.cpp`: upper/lower, `alpha`, and
  **unit-diagonal** cases on row-major (generic) and column-major (BLAS) inputs;
  a `trsm`-solves-`A*X=A*X0` recovery and a **`trsm` inverts `trmm`** round-trip.
- Confirmed the BLAS path is genuinely taken (`dtrmm_`/`dtrsm_` linked).
- Full suite **135/135 green with and without BLAS, on GCC and Clang.**
- Benchmarks: `bench_trmm/trsm` wired into the `l3` group + individual suites.

## Scope

- **Left side, no transpose** in this batch (the common factorization case);
  right-side/transpose variants are a possible extension.
- Follow-up on #229: **batch 3** L3 symmetric (`symm`, `syrk`, `syr2k`) — which
  will complete the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added triangular matrix–matrix multiplication (`trmm`) and triangular system solving (`trsm`).
  - Supports upper/lower triangular and unit-diagonal matrices, with optimized BLAS execution where available and a fallback implementation otherwise.
  - Added support for running and benchmarking these operations through dedicated and Level 3 benchmark suites.

- **Tests**
  - Added coverage for multiplication, solving, BLAS dispatch, scaling, round trips, and unit-diagonal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->