### PR TITLE
feat(operation): BLAS Level-3 symmetric operators — symm, syrk, syr2k (#229, batch 3/3)

### DIFF
--- a/benchmarks/bench_all.cpp
+++ b/benchmarks/bench_all.cpp
@@ -129,8 +129,8 @@ static void print_usage() {
         "    250:1030:x1.01   -> dense sweep bracketing the 256/512/1024 cliffs\n"
         "\n"
         "Suites: all, blas (=l1+l2+l3), lapack,\n"
-        "        l1 (dot+nrm2+axpy+scal), l2 (gemv+ger+symv+trmv+trsv), l3 (gemm+trmm+trsm),\n"
-        "        dot, nrm2, axpy, scal, gemv, ger, symv, trmv, trsv, gemm, trmm, trsm,\n"
+        "        l1 (dot+nrm2+axpy+scal), l2 (gemv+ger+symv+trmv+trsv), l3 (gemm+trmm+trsm+symm+syrk+syr2k),\n"
+        "        dot, nrm2, axpy, scal, gemv, ger, symv, trmv, trsv,\n        gemm, trmm, trsm, symm, syrk, syr2k,\n"
         "        lu, qr, cholesky, eig\n";
 }
 
@@ -201,6 +201,9 @@ int main(int argc, char* argv[]) {
         b::bench_gemm(rep, label, blas_sizes);
         b::bench_trmm(rep, label, blas_sizes);
         b::bench_trsm(rep, label, blas_sizes);
+        b::bench_symm(rep, label, blas_sizes);
+        b::bench_syrk(rep, label, blas_sizes);
+        b::bench_syr2k(rep, label, blas_sizes);
     } else if (suite == "l1") {
         std::cout << "=== BLAS Level 1 ===" << std::endl;
         b::bench_dot(rep, label, blas_sizes);
@@ -219,6 +222,9 @@ int main(int argc, char* argv[]) {
         b::bench_gemm(rep, label, blas_sizes);
         b::bench_trmm(rep, label, blas_sizes);
         b::bench_trsm(rep, label, blas_sizes);
+        b::bench_symm(rep, label, blas_sizes);
+        b::bench_syrk(rep, label, blas_sizes);
+        b::bench_syr2k(rep, label, blas_sizes);
     } else if (suite == "lapack") {
         std::cout << "=== LAPACK Factorizations ===" << std::endl;
         b::bench_lu(rep, label, lapack_sizes);
@@ -249,6 +255,12 @@ int main(int argc, char* argv[]) {
         b::bench_trmm(rep, label, blas_sizes);
     } else if (suite == "trsm") {
         b::bench_trsm(rep, label, blas_sizes);
+    } else if (suite == "symm") {
+        b::bench_symm(rep, label, blas_sizes);
+    } else if (suite == "syrk") {
+        b::bench_syrk(rep, label, blas_sizes);
+    } else if (suite == "syr2k") {
+        b::bench_syr2k(rep, label, blas_sizes);
     } else if (suite == "lu") {
         b::bench_lu(rep, label, lapack_sizes);
     } else if (suite == "qr") {

--- a/benchmarks/harness/runner.hpp
+++ b/benchmarks/harness/runner.hpp
@@ -30,6 +30,9 @@
 #include <mtl/operation/trsv.hpp>
 #include <mtl/operation/trmm.hpp>
 #include <mtl/operation/trsm.hpp>
+#include <mtl/operation/symm.hpp>
+#include <mtl/operation/syrk.hpp>
+#include <mtl/operation/syr2k.hpp>
 #include <mtl/operation/lu.hpp>
 #include <mtl/operation/qr.hpp>
 #include <mtl/operation/cholesky.hpp>
@@ -211,6 +214,47 @@ inline void bench_trsm(reporter& rep, const std::string& label,
     }
 }
 
+inline void bench_symm(reporter& rep, const std::string& label,
+                       const std::vector<std::size_t>& sizes,
+                       std::size_t warmup = 3, std::size_t iterations = 10) {
+    for (auto n : sizes) {
+        auto A = make_random_matrix<double>(n, n);   // treated as symmetric
+        auto B = make_random_matrix<double>(n, n, 99);
+        mat::dense2D<double> C(n, n);
+        double flops = static_cast<double>(2 * n) * n * n;
+        auto t = measure([&]{ mtl::symm(1.0, A, B, 0.0, C); },
+                         "symm", label, n, flops, warmup, iterations);
+        rep.add(t);
+    }
+}
+
+inline void bench_syrk(reporter& rep, const std::string& label,
+                       const std::vector<std::size_t>& sizes,
+                       std::size_t warmup = 3, std::size_t iterations = 10) {
+    for (auto n : sizes) {
+        auto A = make_random_matrix<double>(n, n);
+        mat::dense2D<double> C(n, n);
+        double flops = static_cast<double>(n) * n * n;   // ~n^3 (half of a full gemm)
+        auto t = measure([&]{ mtl::syrk(1.0, A, 0.0, C); },
+                         "syrk", label, n, flops, warmup, iterations);
+        rep.add(t);
+    }
+}
+
+inline void bench_syr2k(reporter& rep, const std::string& label,
+                        const std::vector<std::size_t>& sizes,
+                        std::size_t warmup = 3, std::size_t iterations = 10) {
+    for (auto n : sizes) {
+        auto A = make_random_matrix<double>(n, n);
+        auto B = make_random_matrix<double>(n, n, 99);
+        mat::dense2D<double> C(n, n);
+        double flops = static_cast<double>(2 * n) * n * n;
+        auto t = measure([&]{ mtl::syr2k(1.0, A, B, 0.0, C); },
+                         "syr2k", label, n, flops, warmup, iterations);
+        rep.add(t);
+    }
+}
+
 // ── LAPACK-level suites ─────────────────────────────────────────────────────
 // Column-major inputs so the BLAS/LAPACK dispatch is eligible (matches a
 // real app that stores factorization operands column-major).
@@ -297,6 +341,9 @@ inline void run_all(reporter& rep, const std::string& label,
     bench_gemm(rep, label, blas_sizes);
     bench_trmm(rep, label, blas_sizes);
     bench_trsm(rep, label, blas_sizes);
+    bench_symm(rep, label, blas_sizes);
+    bench_syrk(rep, label, blas_sizes);
+    bench_syr2k(rep, label, blas_sizes);
 
     std::cout << "=== LAPACK Factorizations ===" << std::endl;
     bench_lu(rep, label, lapack_sizes);

--- a/include/mtl/interface/blas.hpp
+++ b/include/mtl/interface/blas.hpp
@@ -106,6 +106,31 @@ void dtrsm_(const char* side, const char* uplo, const char* transa,
             const double* alpha, const double* A, const int* lda,
             double* B, const int* ldb);
 
+void ssymm_(const char* side, const char* uplo, const int* m, const int* n,
+            const float* alpha, const float* A, const int* lda,
+            const float* B, const int* ldb,
+            const float* beta, float* C, const int* ldc);
+void dsymm_(const char* side, const char* uplo, const int* m, const int* n,
+            const double* alpha, const double* A, const int* lda,
+            const double* B, const int* ldb,
+            const double* beta, double* C, const int* ldc);
+
+void ssyrk_(const char* uplo, const char* trans, const int* n, const int* k,
+            const float* alpha, const float* A, const int* lda,
+            const float* beta, float* C, const int* ldc);
+void dsyrk_(const char* uplo, const char* trans, const int* n, const int* k,
+            const double* alpha, const double* A, const int* lda,
+            const double* beta, double* C, const int* ldc);
+
+void ssyr2k_(const char* uplo, const char* trans, const int* n, const int* k,
+             const float* alpha, const float* A, const int* lda,
+             const float* B, const int* ldb,
+             const float* beta, float* C, const int* ldc);
+void dsyr2k_(const char* uplo, const char* trans, const int* n, const int* k,
+             const double* alpha, const double* A, const int* lda,
+             const double* B, const int* ldb,
+             const double* beta, double* C, const int* ldc);
+
 } // extern "C"
 
 // -- C++ wrapper functions ----------------------------------------------
@@ -229,6 +254,37 @@ inline void trsm(char side, char uplo, char transa, char diag, int m, int n,
 inline void trsm(char side, char uplo, char transa, char diag, int m, int n,
                  double alpha, const double* A, int lda, double* B, int ldb) {
     dtrsm_(&side, &uplo, &transa, &diag, &m, &n, &alpha, A, &lda, B, &ldb);
+}
+
+inline void symm(char side, char uplo, int m, int n, float alpha,
+                 const float* A, int lda, const float* B, int ldb,
+                 float beta, float* C, int ldc) {
+    ssymm_(&side, &uplo, &m, &n, &alpha, A, &lda, B, &ldb, &beta, C, &ldc);
+}
+inline void symm(char side, char uplo, int m, int n, double alpha,
+                 const double* A, int lda, const double* B, int ldb,
+                 double beta, double* C, int ldc) {
+    dsymm_(&side, &uplo, &m, &n, &alpha, A, &lda, B, &ldb, &beta, C, &ldc);
+}
+
+inline void syrk(char uplo, char trans, int n, int k, float alpha,
+                 const float* A, int lda, float beta, float* C, int ldc) {
+    ssyrk_(&uplo, &trans, &n, &k, &alpha, A, &lda, &beta, C, &ldc);
+}
+inline void syrk(char uplo, char trans, int n, int k, double alpha,
+                 const double* A, int lda, double beta, double* C, int ldc) {
+    dsyrk_(&uplo, &trans, &n, &k, &alpha, A, &lda, &beta, C, &ldc);
+}
+
+inline void syr2k(char uplo, char trans, int n, int k, float alpha,
+                  const float* A, int lda, const float* B, int ldb,
+                  float beta, float* C, int ldc) {
+    ssyr2k_(&uplo, &trans, &n, &k, &alpha, A, &lda, B, &ldb, &beta, C, &ldc);
+}
+inline void syr2k(char uplo, char trans, int n, int k, double alpha,
+                  const double* A, int lda, const double* B, int ldb,
+                  double beta, double* C, int ldc) {
+    dsyr2k_(&uplo, &trans, &n, &k, &alpha, A, &lda, B, &ldb, &beta, C, &ldc);
 }
 
 } // namespace mtl::interface::blas

--- a/include/mtl/mtl.hpp
+++ b/include/mtl/mtl.hpp
@@ -174,6 +174,9 @@
 #include <mtl/operation/trsv.hpp>
 #include <mtl/operation/trmm.hpp>
 #include <mtl/operation/trsm.hpp>
+#include <mtl/operation/symm.hpp>
+#include <mtl/operation/syrk.hpp>
+#include <mtl/operation/syr2k.hpp>
 #include <mtl/operation/lu.hpp>
 #include <mtl/operation/householder.hpp>
 #include <mtl/operation/qr.hpp>

--- a/include/mtl/operation/symm.hpp
+++ b/include/mtl/operation/symm.hpp
@@ -1,0 +1,57 @@
+#pragma once
+// MTL5 -- symm: C <- alpha*A*B + beta*C  for symmetric A  (BLAS level-3, left side)
+// A is m x m symmetric (generic path reads the full matrix); B, C are m x n.
+// Left side, uplo lower for the BLAS path. BLAS dispatch for column-major dense
+// float/double when available.
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <limits>
+#include <type_traits>
+
+#include <mtl/concepts/scalar.hpp>
+#include <mtl/concepts/matrix.hpp>
+#include <mtl/math/identity.hpp>
+#include <mtl/interface/dispatch_traits.hpp>
+#ifdef MTL5_HAS_BLAS
+#include <mtl/interface/blas.hpp>
+#endif
+
+namespace mtl {
+
+/// Symmetric matrix-matrix product: C = alpha*A*B + beta*C, A assumed symmetric.
+template <Scalar S, Matrix MA, Matrix MB, Matrix MC>
+void symm(const S& alpha, const MA& A, const MB& B, const S& beta, MC& C) {
+    using value_type = typename MC::value_type;
+    using size_type  = typename MA::size_type;
+    const size_type m = A.num_rows();
+    const size_type n = B.num_cols();
+    assert(A.num_cols() == m && B.num_rows() == m && C.num_rows() == m && C.num_cols() == n);
+
+#ifdef MTL5_HAS_BLAS
+    if constexpr (interface::BlasDenseMatrix<MA> && interface::BlasDenseMatrix<MB> &&
+                  interface::BlasDenseMatrix<MC> && !interface::is_row_major_v<MA> &&
+                  !interface::is_row_major_v<MB> && !interface::is_row_major_v<MC> &&
+                  std::is_same_v<value_type, typename MA::value_type> &&
+                  std::is_same_v<value_type, typename MB::value_type>) {
+        using T = value_type;
+        const auto imax = static_cast<size_type>(std::numeric_limits<int>::max());
+        if (m <= imax && n <= imax) {
+            const int ld = std::max(1, static_cast<int>(m));
+            interface::blas::symm('L', 'L', static_cast<int>(m), static_cast<int>(n),
+                                  static_cast<T>(alpha), A.data(), ld, B.data(), ld,
+                                  static_cast<T>(beta), C.data(), ld);
+            return;
+        }
+    }
+#endif
+    for (size_type i = 0; i < m; ++i)
+        for (size_type j = 0; j < n; ++j) {
+            auto acc = math::zero<value_type>();
+            for (size_type k = 0; k < m; ++k)
+                acc += A(i, k) * B(k, j);
+            C(i, j) = alpha * acc + beta * C(i, j);
+        }
+}
+
+} // namespace mtl

--- a/include/mtl/operation/syr2k.hpp
+++ b/include/mtl/operation/syr2k.hpp
@@ -1,0 +1,63 @@
+#pragma once
+// MTL5 -- syr2k: C <- alpha*(A*B^T + B*A^T) + beta*C  (BLAS level-3 symmetric
+// rank-2k). C is m x m and treated as symmetric; the full symmetric result is
+// produced (both triangles set). A, B are m x k. BLAS dispatch for column-major
+// dense float/double when available (writes the lower triangle, then mirrored).
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <limits>
+#include <type_traits>
+
+#include <mtl/concepts/scalar.hpp>
+#include <mtl/concepts/matrix.hpp>
+#include <mtl/math/identity.hpp>
+#include <mtl/interface/dispatch_traits.hpp>
+#ifdef MTL5_HAS_BLAS
+#include <mtl/interface/blas.hpp>
+#endif
+
+namespace mtl {
+
+/// Symmetric rank-2k update: C = alpha*(A*B^T + B*A^T) + beta*C, C symmetric.
+template <Scalar S, Matrix MA, Matrix MB, Matrix MC>
+void syr2k(const S& alpha, const MA& A, const MB& B, const S& beta, MC& C) {
+    using value_type = typename MC::value_type;
+    using size_type  = typename MA::size_type;
+    const size_type m = A.num_rows();
+    const size_type k = A.num_cols();
+    assert(B.num_rows() == m && B.num_cols() == k && C.num_rows() == m && C.num_cols() == m);
+
+#ifdef MTL5_HAS_BLAS
+    if constexpr (interface::BlasDenseMatrix<MA> && interface::BlasDenseMatrix<MB> &&
+                  interface::BlasDenseMatrix<MC> && !interface::is_row_major_v<MA> &&
+                  !interface::is_row_major_v<MB> && !interface::is_row_major_v<MC> &&
+                  std::is_same_v<value_type, typename MA::value_type> &&
+                  std::is_same_v<value_type, typename MB::value_type>) {
+        using T = value_type;
+        const auto imax = static_cast<size_type>(std::numeric_limits<int>::max());
+        if (m <= imax && k <= imax) {
+            const int ld = std::max(1, static_cast<int>(m));
+            interface::blas::syr2k('L', 'N', static_cast<int>(m), static_cast<int>(k),
+                                   static_cast<T>(alpha), A.data(), ld, B.data(), ld,
+                                   static_cast<T>(beta), C.data(), ld);
+            for (size_type i = 0; i < m; ++i)
+                for (size_type j = 0; j < i; ++j)
+                    C(j, i) = C(i, j);
+            return;
+        }
+    }
+#endif
+    for (size_type i = 0; i < m; ++i)
+        for (size_type j = 0; j <= i; ++j) {
+            auto acc = math::zero<value_type>();
+            for (size_type l = 0; l < k; ++l)
+                acc += A(i, l) * B(j, l) + B(i, l) * A(j, l);
+            C(i, j) = alpha * acc + beta * C(i, j);
+        }
+    for (size_type i = 0; i < m; ++i)
+        for (size_type j = 0; j < i; ++j)
+            C(j, i) = C(i, j);
+}
+
+} // namespace mtl

--- a/include/mtl/operation/syrk.hpp
+++ b/include/mtl/operation/syrk.hpp
@@ -1,0 +1,63 @@
+#pragma once
+// MTL5 -- syrk: C <- alpha*A*A^T + beta*C  (BLAS level-3 symmetric rank-k)
+// C is m x m and treated as symmetric; the full symmetric result is produced
+// (both triangles set). A is m x k. BLAS dispatch for column-major dense
+// float/double when available (writes the lower triangle, then mirrored).
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <limits>
+#include <type_traits>
+
+#include <mtl/concepts/scalar.hpp>
+#include <mtl/concepts/matrix.hpp>
+#include <mtl/math/identity.hpp>
+#include <mtl/interface/dispatch_traits.hpp>
+#ifdef MTL5_HAS_BLAS
+#include <mtl/interface/blas.hpp>
+#endif
+
+namespace mtl {
+
+/// Symmetric rank-k update: C = alpha*A*A^T + beta*C, C symmetric (full result).
+template <Scalar S, Matrix MA, Matrix MC>
+void syrk(const S& alpha, const MA& A, const S& beta, MC& C) {
+    using value_type = typename MC::value_type;
+    using size_type  = typename MA::size_type;
+    const size_type m = A.num_rows();
+    const size_type k = A.num_cols();
+    assert(C.num_rows() == m && C.num_cols() == m);
+
+#ifdef MTL5_HAS_BLAS
+    if constexpr (interface::BlasDenseMatrix<MA> && interface::BlasDenseMatrix<MC> &&
+                  !interface::is_row_major_v<MA> && !interface::is_row_major_v<MC> &&
+                  std::is_same_v<value_type, typename MA::value_type>) {
+        using T = value_type;
+        const auto imax = static_cast<size_type>(std::numeric_limits<int>::max());
+        if (m <= imax && k <= imax) {
+            const int lda = std::max(1, static_cast<int>(m));
+            interface::blas::syrk('L', 'N', static_cast<int>(m), static_cast<int>(k),
+                                  static_cast<T>(alpha), A.data(), lda,
+                                  static_cast<T>(beta), C.data(), lda);
+            // BLAS wrote the lower triangle; mirror to the upper for a full result.
+            for (size_type i = 0; i < m; ++i)
+                for (size_type j = 0; j < i; ++j)
+                    C(j, i) = C(i, j);
+            return;
+        }
+    }
+#endif
+    // Compute the lower triangle, then mirror.
+    for (size_type i = 0; i < m; ++i)
+        for (size_type j = 0; j <= i; ++j) {
+            auto acc = math::zero<value_type>();
+            for (size_type l = 0; l < k; ++l)
+                acc += A(i, l) * A(j, l);
+            C(i, j) = alpha * acc + beta * C(i, j);
+        }
+    for (size_type i = 0; i < m; ++i)
+        for (size_type j = 0; j < i; ++j)
+            C(j, i) = C(i, j);
+}
+
+} // namespace mtl

--- a/tests/unit/operation/test_blas_l3_symmetric.cpp
+++ b/tests/unit/operation/test_blas_l3_symmetric.cpp
@@ -1,0 +1,121 @@
+// Tests for the BLAS Level-3 symmetric operators: symm, syrk, syr2k
+// (#229, batch 3). Exercises the generic (row-major) path and the column-major
+// (BLAS-dispatch) path against a plain reference; syrk/syr2k results are checked
+// to be full symmetric matrices.
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/mat/parameter.hpp>
+#include <mtl/tag/orientation.hpp>
+#include <mtl/operation/symm.hpp>
+#include <mtl/operation/syrk.hpp>
+#include <mtl/operation/syr2k.hpp>
+
+#include <cmath>
+#include <vector>
+
+using namespace mtl;
+template <typename Params = mat::parameters<>>
+using dmat = mat::dense2D<double, Params>;
+using colmat = mat::dense2D<double, mat::parameters<tag::col_major>>;
+
+namespace {
+
+// C(i,j) = alpha * sum_k A(i,k) B(k,j) + beta * C(i,j), A treated symmetric/full.
+double sym_symm_ref(const std::vector<std::vector<double>>& A,
+                    const std::vector<std::vector<double>>& B,
+                    double alpha, double beta, double c0,
+                    std::size_t i, std::size_t j, std::size_t m) {
+    double acc = 0.0;
+    for (std::size_t k = 0; k < m; ++k) acc += A[i][k] * B[k][j];
+    return alpha * acc + beta * c0;
+}
+
+template <typename M>
+bool is_symmetric(const M& C, std::size_t n, double tol) {
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j)
+            if (std::abs(C(i, j) - C(j, i)) > tol) return false;
+    return true;
+}
+
+} // namespace
+
+TEST_CASE("symm: C = alpha A B + beta C, A symmetric", "[operation][blas][symm]") {
+    // A symmetric 3x3, B 3x2.
+    std::vector<std::vector<double>> Av = {{2,1,0},{1,3,1},{0,1,2}};
+    std::vector<std::vector<double>> Bv = {{1,4},{2,5},{3,6}};
+    for (auto orient : {0, 1}) {   // 0 = row-major (generic), 1 = col-major (BLAS)
+        auto run = [&](auto& A, auto& B, auto& C) {
+            for (std::size_t i = 0; i < 3; ++i)
+                for (std::size_t j = 0; j < 3; ++j) A(i, j) = Av[i][j];
+            for (std::size_t i = 0; i < 3; ++i)
+                for (std::size_t j = 0; j < 2; ++j) { B(i, j) = Bv[i][j]; }
+            for (std::size_t i = 0; i < 3; ++i)
+                for (std::size_t j = 0; j < 2; ++j) C(i, j) = 1.0;
+            symm(2.0, A, B, 0.5, C);
+            for (std::size_t i = 0; i < 3; ++i)
+                for (std::size_t j = 0; j < 2; ++j)
+                    REQUIRE_THAT(C(i, j),
+                        Catch::Matchers::WithinAbs(sym_symm_ref(Av, Bv, 2.0, 0.5, 1.0, i, j, 3), 1e-12));
+        };
+        if (orient == 0) { dmat<> A(3,3), B(3,2), C(3,2); run(A, B, C); }
+        else             { colmat A(3,3), B(3,2), C(3,2); run(A, B, C); }
+    }
+}
+
+TEST_CASE("syrk: C = alpha A A^T + beta C is full symmetric", "[operation][blas][syrk]") {
+    // A is 3x2.
+    std::vector<std::vector<double>> Av = {{1,2},{3,4},{5,6}};
+    auto run = [&](auto& A, auto& C) {
+        for (std::size_t i = 0; i < 3; ++i)
+            for (std::size_t j = 0; j < 2; ++j) A(i, j) = Av[i][j];
+        for (std::size_t i = 0; i < 3; ++i)
+            for (std::size_t j = 0; j < 3; ++j) C(i, j) = 0.0;
+        syrk(1.0, A, 0.0, C);
+        // reference (A A^T)
+        for (std::size_t i = 0; i < 3; ++i)
+            for (std::size_t j = 0; j < 3; ++j) {
+                double acc = 0.0;
+                for (std::size_t l = 0; l < 2; ++l) acc += Av[i][l] * Av[j][l];
+                REQUIRE_THAT(C(i, j), Catch::Matchers::WithinAbs(acc, 1e-12));
+            }
+        REQUIRE(is_symmetric(C, 3, 1e-12));
+    };
+    { dmat<> A(3,2), C(3,3); run(A, C); }        // generic
+    { colmat A(3,2), C(3,3); run(A, C); }        // BLAS
+}
+
+TEST_CASE("syrk: alpha/beta accumulation", "[operation][blas][syrk]") {
+    colmat A(2, 2), C(2, 2);
+    A(0,0)=1; A(0,1)=2; A(1,0)=3; A(1,1)=4;
+    C(0,0)=10; C(0,1)=20; C(1,0)=20; C(1,1)=30;   // symmetric input
+    syrk(2.0, A, 0.5, C);
+    // A A^T = [[5,11],[11,25]]; 2*that + 0.5*C = [[10+5, 22+10],[22+10, 50+15]] = [[15,32],[32,65]]
+    REQUIRE_THAT(C(0,0), Catch::Matchers::WithinAbs(15.0, 1e-12));
+    REQUIRE_THAT(C(0,1), Catch::Matchers::WithinAbs(32.0, 1e-12));
+    REQUIRE_THAT(C(1,0), Catch::Matchers::WithinAbs(32.0, 1e-12));
+    REQUIRE_THAT(C(1,1), Catch::Matchers::WithinAbs(65.0, 1e-12));
+}
+
+TEST_CASE("syr2k: C = alpha(A B^T + B A^T) + beta C is full symmetric", "[operation][blas][syr2k]") {
+    std::vector<std::vector<double>> Av = {{1,0},{2,1},{0,3}};
+    std::vector<std::vector<double>> Bv = {{2,1},{1,0},{1,1}};
+    auto run = [&](auto& A, auto& B, auto& C) {
+        for (std::size_t i = 0; i < 3; ++i)
+            for (std::size_t j = 0; j < 2; ++j) { A(i,j)=Av[i][j]; B(i,j)=Bv[i][j]; }
+        for (std::size_t i = 0; i < 3; ++i)
+            for (std::size_t j = 0; j < 3; ++j) C(i, j) = 0.0;
+        syr2k(1.0, A, B, 0.0, C);
+        for (std::size_t i = 0; i < 3; ++i)
+            for (std::size_t j = 0; j < 3; ++j) {
+                double acc = 0.0;
+                for (std::size_t l = 0; l < 2; ++l) acc += Av[i][l]*Bv[j][l] + Bv[i][l]*Av[j][l];
+                REQUIRE_THAT(C(i, j), Catch::Matchers::WithinAbs(acc, 1e-12));
+            }
+        REQUIRE(is_symmetric(C, 3, 1e-12));
+    };
+    { dmat<> A(3,2), B(3,2), C(3,3); run(A, B, C); }   // generic
+    { colmat A(3,2), B(3,2), C(3,3); run(A, B, C); }   // BLAS
+}


### PR DESCRIPTION
**Closes #229** — the final batch. Adds the **Level-3 symmetric** operators,
completing MTL5's core BLAS L1/L2/L3 coverage.

## What

| Op | Semantics | BLAS |
|---|---|---|
| `symm(alpha, A, B, beta, C)` | `C = alpha*A*B + beta*C`, A symmetric | `ssymm`/`dsymm` |
| `syrk(alpha, A, beta, C)` | `C = alpha*A*A^T + beta*C`, C symmetric | `ssyrk`/`dsyrk` |
| `syr2k(alpha, A, B, beta, C)` | `C = alpha*(A*B^T + B*A^T) + beta*C` | `ssyr2k`/`dsyr2k` |

Generic templated functions (any type/orientation, custom number types) + BLAS
dispatch for column-major float/double. `symm`'s generic path reads the full
symmetric A. `syrk`/`syr2k` produce the **full symmetric C** (both triangles):
the generic path computes the lower triangle and mirrors it; the BLAS path calls
the one-triangle kernel then mirrors lower→upper, so both paths agree. Leading
dimensions clamped to `max(1, m)` (the empty-matrix fix from batch 2, applied
up front). New `ssymm/dsymm`, `ssyrk/dsyrk`, `ssyr2k/dsyr2k` bindings.

## Verification

- `tests/unit/operation/test_blas_l3_symmetric.cpp`: reference-value checks with
  `alpha`/`beta` on row-major (generic) and column-major (BLAS) inputs;
  `syrk`/`syr2k` results verified **full symmetric**.
- Confirmed BLAS path taken (`dsymm_`/`dsyrk_`/`dsyr2k_` linked).
- Full suite **136/136 green with and without BLAS, on GCC and Clang**.
- Benchmarks: `bench_symm/syrk/syr2k` wired into the `l3` group.

## #229 complete

MTL5 now covers the core BLAS surface:
- **L1**: dot, nrm2, axpy, scal
- **L2**: gemv, ger, symv, trmv, trsv
- **L3**: gemm, trmm, trsm, symm, syrk, syr2k

(Scope notes carried across the batches: left-side/no-transpose triangular
variants, and accumulator-policy-awareness for the reductions, remain possible
future extensions.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
