### PR TITLE
docs: changelog + session log — BLAS coverage & expansion roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,10 @@ Format follows [Conventional Commits](https://www.conventionalcommits.org/).
 - **Size-N sweep** (`--sweep START:STOP:STEP` and `:xFACTOR`) plus BLAS-level suite groups `l1`/`l2`/`l3`/`blas`; default sizes now bracket powers of two with odd/1.5x neighbours to expose padding overhead (#77)
 - **GFLOP/s-vs-N plotting** (`benchmarks/plot_results.py`, matplotlib) and committed example data + rendered plots under `benchmarks/data/` with provenance (#78, #79, #80)
 - **One-executable-per-backend methodology** — `bench_all` calls only the public `mtl::` API; the build flags choose the backend (native / OpenBLAS / MKL); `run_sweeps.sh` builds all variants, pins to a P-core, and emits one CSV per backend (#81)
+- **BLIS backend + expanded BLAS routine coverage** — `run_sweeps.sh`/`run_scaling.sh` gain a `blis` variant (CMake `BLA_VENDOR=FLAME`, auto-skipped if absent); the harness now benchmarks all core BLAS routines MTL5 implements (adds `axpy`/`scal` at L1, and L2/L3 as they land); `analyze_gate.py --reference` baselines against OpenBLAS, BLIS, or MKL (#227, #228)
 
 #### Documentation & API
+- **Capability assessment & expansion analysis** — `docs/design/capability-assessment-and-expansion.md`: a source-grounded assessment across functionality, performance (single/multi-thread), distributed-memory and hardware-accelerator readiness, with a maturity scorecard and a prioritized expansion roadmap (seeded the roadmap epic #220 and issues #221–#227) (#219)
 - **Doxygen C++ API reference** generated into the docs site (`docs-site/Doxyfile`, `npm run api`, sidebar link, CI step) (#73)
 - Public `eigenvalue_symmetric_generic()` — the generic (LAPACK-free) symmetric eigensolver, extracted so it can be called regardless of `MTL5_HAS_LAPACK` (#78)
 
@@ -50,6 +52,13 @@ Format follows [Conventional Commits](https://www.conventionalcommits.org/).
 - **Matrix-free iterative eigensolvers** in `mtl::itl` (`include/mtl/itl/eigen/`), operating through the `LinearOperator` concept (`A * x`) so they apply to `dense2D`, `compressed2D`, and user matrix-free operators: `power_iteration` (dominant pair), `lanczos` (symmetric, k extremal Ritz pairs via a tridiagonal projection), `arnoldi` (general, k Ritz pairs via a Hessenberg projection). Each solves the small projected problem with the dense eigensolvers; an `eigen_which` selector picks the wanted end of the spectrum (#205)
 - **Sparse eigensolver with shift-invert** in `mtl::sparse` — `sparse_eigs` (largest-magnitude, Arnoldi directly on the sparse operator), `sparse_eigs_shift_invert` (k eigenpairs nearest `sigma` via `(A - sigma*I)^{-1}` applied inside Arnoldi, mapping `lambda = sigma + 1/theta`), and the reusable `shift_invert_operator` (factor once with sparse LU, apply many; tiny pivots perturbed so a shift on an eigenvalue stays solvable) (#206)
 - **Eigenvalue/eigenvector solver guide** — `docs/algorithms/eigenvalues.md`: a decision guide plus a runnable snippet for every public eigen API across dense/iterative/sparse, the LAPACK dispatch conditions, and the custom-number-type story (#203, #207)
+
+#### Core BLAS Level-2 / Level-3 operators (#229)
+- **Level 2**: `ger` (rank-1 update), `symv` (symmetric matrix-vector), `trmv` (triangular matrix-vector), `trsv` (triangular solve) (#230)
+- **Level 3 triangular**: `trmm` (`B = alpha*A*B`), `trsm` (solve `A*X = alpha*B`) — left side, no transpose (#231)
+- **Level 3 symmetric**: `symm` (`C = alpha*A*B + beta*C`, A symmetric), `syrk` (`C = alpha*A*Aᵀ + beta*C`), `syr2k` (`C = alpha*(A*Bᵀ + B*Aᵀ) + beta*C`); `syrk`/`syr2k` produce the full symmetric result (both triangles) (#232)
+- Each is a generic templated function (any Matrix/Vector type and orientation, and custom number types) with optional external-BLAS dispatch for **column-major dense float/double**, mirroring the existing `gemv`/`gemm` gating. New `s/d` bindings added to `interface/blas.hpp` (`ger`, `symv`, `trmv`, `trmm`, `trsm`, `symm`, `syrk`, `syr2k`). BLAS leading dimensions are clamped to `max(1,m)` for empty inputs
+- With this, MTL5 covers the core BLAS surface: **L1** dot/nrm2/axpy/scal, **L2** gemv/ger/symv/trmv/trsv, **L3** gemm/trmm/trsm/symm/syrk/syr2k
 
 ### Changed
 - **`mtl::dot` / `dot_real` now dispatch to BLAS `?dot`** when types qualify (consistency with `two_norm`); both `dot` and `two_norm` BLAS paths guard the `int` length cast against overflow (#81)

--- a/docs/sessions/2026-07-19-blas-coverage-and-roadmap.md
+++ b/docs/sessions/2026-07-19-blas-coverage-and-roadmap.md
@@ -1,0 +1,114 @@
+# Session: capability assessment, expansion roadmap, and complete core BLAS coverage
+
+**Date**: 2026-07-19
+**Duration**: Full day session
+**Participants**: Theodore Omtzigt (Ravenwater), Claude Code
+
+## Objective
+
+Step back from feature work to assess where MTL5 stands and where it should go
+(functionality, performance, distributed memory, hardware accelerators), turn
+that into a tracked roadmap, and then execute the first concrete piece of it:
+completing MTL5's core BLAS Level-2 / Level-3 operator surface with a
+multi-backend (OpenBLAS + BLIS) benchmark comparison.
+
+## Context
+
+Coming out of the eigenvalue epic (#202), the library is functionally broad but
+had never had a written, source-grounded assessment of its maturity or a
+prioritized expansion plan. On the BLAS side it implemented only `gemv` (L2) and
+`gemm` (L3) of the matrix-level routines, and the benchmark harness compared
+against OpenBLAS/MKL but not BLIS.
+
+## Work Completed
+
+### Capability assessment & expansion analysis (#219 → PR #219, merged)
+A source-grounded assessment (`docs/design/capability-assessment-and-expansion.md`)
+built from parallel surveys of `include/mtl/`, `tests/`, `benchmarks/`, and CMake.
+Four axes with a maturity scorecard:
+
+- **Functionality** — mature dense/sparse/iterative/eigen coverage; advanced gaps
+  (generalized eig, matrix functions, implicit-restart Krylov, AMG).
+- **Performance** — strong single-thread (Highway SIMD + BLIS-style blocked GEMM
+  at ~80–84% of OpenBLAS); **on-node threading is the biggest gap** (only one GEMM
+  kernel threads, default 1).
+- **Distributed memory** — none, but the Krylov contract (`LinearOperator` +
+  `dot`, and the `operation/resource.hpp` "future distributed-vector" seam) is
+  nearly drop-in ready.
+- **Hardware accelerators** — no GPU code; the `interface/` backend pattern is a
+  clean hook but inherits a float/double-only limit that collides with the
+  custom-number-type mission.
+
+Key cross-cutting finding: both "absent" axes share one enabling prerequisite — a
+**memory-space abstraction** in the storage layer. The report closes with a
+6-step roadmap.
+
+### Roadmap issues (#220–#227)
+Filed the roadmap as a tracked epic **#220** with children **#221** (on-node
+threading), **#222** (runtime cache/ISA detection + SVE/RVV SIMD), **#223**
+(memory-space abstraction — the shared enabler), **#224** (distributed iterative
+solving), **#225** (GPU BLAS backend), **#226** (functional depth), plus **#227**
+(benchmark all core BLAS routines vs OpenBLAS and BLIS). Assigned, milestoned
+(v0.7), and sized on the project board.
+
+### BLIS backend + expanded BLAS benchmark coverage (#227 → PR #228, merged)
+Added a `blis` benchmark backend (CMake `BLA_VENDOR=FLAME`, auto-skipped if
+absent) to `run_sweeps.sh`/`run_scaling.sh`; expanded the harness to benchmark
+all core BLAS routines MTL5 implements (added `axpy`/`scal`); made
+`analyze_gate.py --reference` baseline against OpenBLAS, BLIS, or MKL. Validated
+locally against real OpenBLAS **and** BLIS (`libblis`, `BLA_VENDOR=FLAME`).
+
+### Complete core BLAS L2/L3 operators (#229, three batches — PRs #230/#231/#232, merged)
+Per the decision to pursue **broad BLAS completeness**, filed tracking issue
+**#229** and delivered it in three reviewable batches:
+
+- **Batch 1 — Level 2** (#230): `ger`, `symv`, `trmv`, `trsv`.
+- **Batch 2 — Level 3 triangular** (#231): `trmm`, `trsm`.
+- **Batch 3 — Level 3 symmetric** (#232): `symm`, `syrk`, `syr2k`.
+
+Each operator is a generic templated function (any Matrix/Vector type and
+orientation, and custom number types) with optional external-BLAS dispatch for
+column-major dense float/double, mirroring the existing `gemv`/`gemm` gating; new
+`s/d` bindings were added to `interface/blas.hpp`. Every op is tested on both the
+generic and real-BLAS paths (undefined-symbol checks confirm the BLAS path is
+taken) and wired into the benchmark harness for the OpenBLAS/BLIS comparison.
+
+A CodeRabbit review on batch 2 caught that empty (`m==0`) column-major matrices
+passed `lda==ldb==0`, violating BLAS's `lda,ldb >= max(1,m)` requirement; fixed by
+clamping the leading dimensions to `max(1,m)` (and applied up front in batch 3).
+
+### Board maintenance
+On merge, moved the completed tracking issues (**#227**, **#229**) to **Done** on
+the MTL5 project board.
+
+## Decisions & Rationale
+
+- **Broad BLAS completeness vs. threading-first.** The dependency analysis showed
+  the native factorizations are unblocked/scalar (no L3 building blocks), so
+  completing L3 is a genuine prerequisite for fast native factorizations — but the
+  user chose full BLAS completeness now; threading (#221) remains the top overall
+  roadmap item and is independent.
+- **Generic + BLAS-dispatch per operator**, gated on column-major float/double —
+  the established `gemv`/`gemm` pattern — so custom number types keep working and
+  external BLAS accelerates the standard case.
+- **`syrk`/`syr2k` produce the full symmetric result** (both triangles): generic
+  computes the lower triangle and mirrors; the BLAS path calls the one-triangle
+  kernel and mirrors, so the two paths agree and the result is unsurprising.
+- **Scope kept tight per batch**: left-side/no-transpose triangular variants and
+  accumulator-policy-awareness for the reduction ops were explicitly deferred.
+
+## Outcome
+
+MTL5 now has a written capability assessment and a tracked expansion roadmap, and
+covers the **core BLAS surface end to end**: L1 dot/nrm2/axpy/scal, L2
+gemv/ger/symv/trmv/trsv, L3 gemm/trmm/trsm/symm/syrk/syr2k — each with a generic
+path, external-BLAS dispatch, tests on both paths (GCC + Clang), and benchmark
+coverage against OpenBLAS and BLIS. The natural next step is the roadmap's
+highest-value item, on-node threading (#221).
+
+## Issues / PRs
+
+- Merged this session: #219 (assessment), #228 (BLIS + BLAS benchmark, closes #227),
+  #230/#231/#232 (BLAS L2/L3, closes #229)
+- Roadmap filed: epic #220 with #221–#227; tracking #229
+- Board: #227 and #229 moved to Done


### PR DESCRIPTION
Day wrap-up for 2026-07-19.

## Changes

- **`CHANGELOG.md`** `[Unreleased]`:
  - New `#### Core BLAS Level-2 / Level-3 operators (#229)` subsection under **Added** — `ger/symv/trmv/trsv`, `trmm/trsm`, `symm/syrk/syr2k` (PRs #230/#231/#232); notes the generic + column-major-BLAS dispatch and the `max(1,m)` empty-matrix clamp.
  - **Benchmark suite** bullet for the BLIS backend + expanded BLAS routine coverage + `analyze_gate.py --reference` (#227/#228).
  - **Documentation** bullet for the capability assessment & expansion analysis (#219).
- **`docs/sessions/2026-07-19-blas-coverage-and-roadmap.md`** — full-day session log: the four-axis assessment, the roadmap issues (#220–#227), the three BLAS batches (#230/#231/#232), decisions, and board maintenance.

No code changes. Session docs are repo-only; `CHANGELOG.md` publishes through the normal pipeline (already in `ROOT_FILE_MAP`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added BLIS as a benchmarking backend.
  * Expanded benchmark coverage across implemented BLAS routines.
  * Completed support for core BLAS Level 2 and Level 3 operations, including matrix-vector and matrix-matrix routines.
  * Added single- and double-precision bindings for column-major dense operations.

* **Documentation**
  * Added a capability assessment and expansion roadmap.
  * Documented BLAS coverage, benchmarking updates, implementation decisions, and completed work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->