### PR TITLE
perf(operation): parallel dot/nrm2 reductions + col-major GEMV on the pool (#221, batch 3)

### DIFF
--- a/include/mtl/detail/thread_pool.hpp
+++ b/include/mtl/detail/thread_pool.hpp
@@ -153,7 +153,9 @@ public:
             partials[tid] = map(b, (n < b + chunk) ? n : b + chunk);
         });
         T acc = T{};
-        for (unsigned t = 0; t < team; ++t) acc += partials[t];   // deterministic tid order
+        // Combine with operator+ only (not +=), honoring the documented contract
+        // so plus-only result types work. Deterministic tid order.
+        for (unsigned t = 0; t < team; ++t) acc = acc + partials[t];
         return acc;
     }
 

--- a/include/mtl/detail/thread_pool.hpp
+++ b/include/mtl/detail/thread_pool.hpp
@@ -129,6 +129,34 @@ public:
         });
     }
 
+    /// Reduce over [0, n): map(begin, end) returns a partial T; partials are
+    /// combined with operator+ in chunk (tid) order. Runs serially (a single
+    /// map(0, n)) when the pool is serial or n is below the grain.
+    ///
+    /// Deterministic for a fixed thread count, but NOT bit-identical to the
+    /// serial reduction -- chunking changes the summation grouping/associativity.
+    /// Callers that need serial-exact results must not rely on this.
+    template <typename T, typename MapFn>
+    T parallel_reduce(std::size_t n, std::size_t grain, MapFn&& map) {
+        if (n == 0) return T{};
+        unsigned team = n_;
+        if (team <= 1 || grain == 0 || n < grain * 2) return map(std::size_t{0}, n);
+        const std::size_t max_chunks = n / grain;
+        if (static_cast<std::size_t>(team) > max_chunks)
+            team = static_cast<unsigned>(max_chunks);
+        if (team <= 1) return map(std::size_t{0}, n);
+        const std::size_t chunk = (n + team - 1) / team;
+        std::vector<T> partials(team, T{});
+        run(team, [&](unsigned tid) {
+            const std::size_t b = static_cast<std::size_t>(tid) * chunk;
+            if (b >= n) return;
+            partials[tid] = map(b, (n < b + chunk) ? n : b + chunk);
+        });
+        T acc = T{};
+        for (unsigned t = 0; t < team; ++t) acc += partials[t];   // deterministic tid order
+        return acc;
+    }
+
     thread_pool(const thread_pool&) = delete;
     thread_pool& operator=(const thread_pool&) = delete;
 

--- a/include/mtl/operation/dot.hpp
+++ b/include/mtl/operation/dot.hpp
@@ -12,6 +12,7 @@
 #include <mtl/math/identity.hpp>
 #include <mtl/math/accumulator_traits.hpp>
 #include <mtl/functor/scalar/conj.hpp>
+#include <mtl/detail/thread_pool.hpp>
 #include <mtl/interface/dispatch_traits.hpp>
 #include <mtl/simd/algorithm.hpp>
 #ifdef MTL5_HAS_BLAS
@@ -69,7 +70,14 @@ auto dot(const V1& v1, const V2& v2) {
     // (conj is the identity there, so reduce_dot matches the Hermitian product).
     if constexpr (interface::BlasDenseVector<V1> && interface::BlasDenseVector<V2> &&
                   std::is_same_v<typename V1::value_type, typename V2::value_type>) {
-        return simd::reduce_dot<typename V1::value_type>(v1.data(), v2.data(), v1.size());
+        // Parallel reduction over chunks (deterministic per thread count, but not
+        // serial-bit-identical -- summation grouping differs). Serial by default.
+        using T = typename V1::value_type;
+        const T* a = v1.data();
+        const T* b = v2.data();
+        return detail::thread_pool::instance().parallel_reduce<T>(
+            v1.size(), /*grain=*/std::size_t{65536},
+            [&](std::size_t lo, std::size_t hi) { return simd::reduce_dot<T>(a + lo, b + lo, hi - lo); });
     } else {
         using result_type = std::common_type_t<typename V1::value_type, typename V2::value_type>;
         auto acc = math::zero<result_type>();

--- a/include/mtl/operation/mult.hpp
+++ b/include/mtl/operation/mult.hpp
@@ -153,9 +153,19 @@ void mult(const M& A, const VIn& x, VOut& y) {
                     detail::gemv_rowmajor<T>(e - b, nn, Ap + b * nn, nn, xp, yp + b);
                 });
         } else {
-            // Col-major GEMV accumulates y across columns; left serial (a row
-            // partition would need strided access -- a separate follow-up).
-            detail::gemv_colmajor<T>(mm, nn, A.data(), mm, x.data(), y.data());
+            // Partition over output rows: each y[i] accumulates its columns in
+            // the same order regardless of the row sub-block, so the result is
+            // bit-identical across thread counts. The column stride (lda = mm) is
+            // preserved for the sub-block; A + b offsets to row b.
+            const std::size_t grain =
+                nn ? std::max<std::size_t>(std::size_t{1}, std::size_t{65536} / nn) : std::size_t{1};
+            const T* Ap = A.data();
+            const T* xp = x.data();
+            T* yp = y.data();
+            detail::thread_pool::instance().parallel_for(mm, grain,
+                [&](std::size_t b, std::size_t e) {
+                    detail::gemv_colmajor<T>(e - b, nn, Ap + b, mm, xp, yp + b);
+                });
         }
         return;
     }

--- a/include/mtl/operation/norms.hpp
+++ b/include/mtl/operation/norms.hpp
@@ -11,6 +11,7 @@
 #include <mtl/concepts/magnitude.hpp>
 #include <mtl/math/identity.hpp>
 #include <mtl/math/accumulator_traits.hpp>
+#include <mtl/detail/thread_pool.hpp>
 #include <mtl/interface/dispatch_traits.hpp>
 #include <type_traits>
 #include <mtl/simd/algorithm.hpp>
@@ -67,7 +68,14 @@ auto two_norm(const V& v) {
     // Native SIMD path for contiguous real float/double (abs is the identity).
     if constexpr (interface::BlasDenseVector<V>) {
         using std::sqrt;
-        return sqrt(simd::reduce_sum_squares<typename V::value_type>(v.data(), v.size()));
+        // Parallel reduction of the sum of squares (deterministic per thread
+        // count, not serial-bit-identical). Serial by default.
+        using T = typename V::value_type;
+        const T* d = v.data();
+        const T ss = detail::thread_pool::instance().parallel_reduce<T>(
+            v.size(), /*grain=*/std::size_t{65536},
+            [&](std::size_t lo, std::size_t hi) { return simd::reduce_sum_squares<T>(d + lo, hi - lo); });
+        return sqrt(ss);
     } else {
         auto acc = math::zero<mag_t>();
         for (typename V::size_type i = 0; i < v.size(); ++i) {

--- a/tests/unit/detail/test_thread_pool.cpp
+++ b/tests/unit/detail/test_thread_pool.cpp
@@ -111,6 +111,35 @@ TEST_CASE("thread_pool: parallel_for below grain runs as one chunk", "[detail][t
     REQUIRE(seen_e == 10);
 }
 
+TEST_CASE("thread_pool: parallel_reduce sums correctly", "[detail][thread_pool]") {
+    for (unsigned nt : {1u, 2u, 4u, 8u}) {
+        thread_pool pool(nt);
+        for (std::size_t n : {std::size_t{0}, std::size_t{1}, std::size_t{5},
+                              std::size_t{1000}, std::size_t{250000}}) {
+            long long total = pool.parallel_reduce<long long>(n, /*grain=*/1024,
+                [&](std::size_t b, std::size_t e) {
+                    long long s = 0;
+                    for (std::size_t i = b; i < e; ++i) s += static_cast<long long>(i);
+                    return s;
+                });
+            REQUIRE(total == static_cast<long long>(n) * (n > 0 ? n - 1 : 0) / 2);
+        }
+    }
+}
+
+TEST_CASE("thread_pool: parallel_reduce below grain runs as one map call", "[detail][thread_pool]") {
+    thread_pool pool(8);
+    int calls = 0;
+    long long total = pool.parallel_reduce<long long>(50, /*grain=*/1024,
+        [&](std::size_t b, std::size_t e) {
+            calls++;
+            long long s = 0; for (std::size_t i = b; i < e; ++i) s += static_cast<long long>(i);
+            return s;
+        });
+    REQUIRE(calls == 1);
+    REQUIRE(total == 50LL * 49 / 2);
+}
+
 TEST_CASE("thread_pool: nested run falls back to serial (no deadlock)", "[detail][thread_pool]") {
     thread_pool pool(4);
     std::atomic<int> inner{0};

--- a/tests/unit/detail/test_thread_pool.cpp
+++ b/tests/unit/detail/test_thread_pool.cpp
@@ -127,6 +127,27 @@ TEST_CASE("thread_pool: parallel_reduce sums correctly", "[detail][thread_pool]"
     }
 }
 
+namespace {
+// A result type that defines operator+ but NOT operator+= -- locks the
+// parallel_reduce contract (combine must use operator+ only).
+struct PlusOnly {
+    long long v = 0;
+    friend PlusOnly operator+(PlusOnly a, PlusOnly b) { return PlusOnly{a.v + b.v}; }
+};
+} // namespace
+
+TEST_CASE("thread_pool: parallel_reduce uses operator+ only (plus-only type)", "[detail][thread_pool]") {
+    thread_pool pool(4);
+    const std::size_t n = 100000;
+    PlusOnly total = pool.parallel_reduce<PlusOnly>(n, /*grain=*/1024,
+        [&](std::size_t b, std::size_t e) {
+            PlusOnly s;
+            for (std::size_t i = b; i < e; ++i) s = s + PlusOnly{static_cast<long long>(i)};
+            return s;
+        });
+    REQUIRE(total.v == static_cast<long long>(n) * (n - 1) / 2);
+}
+
 TEST_CASE("thread_pool: parallel_reduce below grain runs as one map call", "[detail][thread_pool]") {
     thread_pool pool(8);
     int calls = 0;


### PR DESCRIPTION
Batch 3 of #221 — completes the **GEMV + L1** threading with the parallel
**reductions** and the remaining GEMV orientation.

## What

- **`thread_pool::parallel_reduce<T>(n, grain, map)`** — `map(begin,end)` returns
  a partial; partials are combined with `+` in chunk (tid) order. Serial below
  the grain / at pool size 1.
- **`dot`** and **`two_norm`** — the native SIMD reduction (`reduce_dot` /
  `reduce_sum_squares`, used in **no-external-BLAS builds and for custom types**)
  now reduces over chunks. **Deterministic per thread count but NOT
  serial-bit-identical** (chunking changes the summation grouping) — documented;
  the tests use `WithinRel`, so accuracy is preserved.
- **col-major GEMV** — partitioned over output rows. Each `y[i]` accumulates its
  columns in the same order regardless of the row sub-block (column stride
  preserved), so this one **IS bit-identical** across thread counts.

`MTL5_NUM_THREADS=1` (default) → everything serial → **zero behavior change**.

## Verification

- `parallel_reduce` tests (explicit pool sizes 1/2/4/8, CI-covered): sums `[0,n)`
  correctly across many n; below-grain runs as a single `map` call. Pool test
  **404k assertions, 11 cases**.
- Full suite **137/137 green at `MTL5_NUM_THREADS=1` and `4`** in both builds.
- **col-major GEMV bit-identical** serial vs threaded (`1146.294230000001`
  at T=1/4/8); `dot`/`nrm2` accurate and deterministic across thread counts.
- `dot` scales **~2.2×** at 4 cores (memory-bandwidth bound); col-major GEMV
  parallelizes at large N.

## #221 status

On-node threading now covers **GEMM (batch 1), row-major GEMV + axpy + scal
(batch 2), and dot + nrm2 + col-major GEMV (batch 3)** — all on one persistent
pool, serial by default. Remaining follow-ups: **sparse triangular solve /
Krylov SpMV**, and a committed multi-core scaling writeup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added parallel reduction support for improved processing of large data ranges.
  - Accelerated compatible dot products, vector norms, and column-major matrix-vector operations through parallel computation.
  - Preserved serial execution for small workloads.

- **Bug Fixes**
  - Ensured empty reductions return a neutral result and small inputs are processed correctly.

- **Tests**
  - Added coverage for reduction accuracy, empty inputs, varying thread counts, and serial fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->