### PR TITLE
perf(mat): parallelize sparse (CRS) matvec on the thread pool (#221, batch 4)

### DIFF
--- a/include/mtl/mat/operators.hpp
+++ b/include/mtl/mat/operators.hpp
@@ -2,6 +2,9 @@
 // MTL5 -- Operator overloads for matrix types (expression template returns)
 #include <type_traits>
 #include <cassert>
+#include <algorithm>
+#include <cstddef>
+#include <mtl/detail/thread_pool.hpp>
 #include <mtl/concepts/matrix.hpp>
 #include <mtl/concepts/vector.hpp>
 #include <mtl/traits/is_expression.hpp>
@@ -131,13 +134,22 @@ auto operator*(const compressed2D<V, P>& A,
     const auto& starts  = A.ref_major();
     const auto& indices = A.ref_minor();
     const auto& data    = A.ref_data();
-    for (size_type r = 0; r < A.num_rows(); ++r) {
-        auto acc = math::zero<result_t>();
-        for (size_type k = starts[r]; k < starts[r + 1]; ++k) {
-            acc += static_cast<result_t>(data[k]) * static_cast<result_t>(x(indices[k]));
-        }
-        y(r) = acc;
-    }
+    // Parallelize over output rows: each y(r) is an independent sparse dot, so
+    // the result is bit-identical across thread counts. Grain targets ~64K
+    // nonzeros per chunk (avg nnz/row). Serial by default (MTL5_NUM_THREADS=1).
+    const std::size_t nrows = A.num_rows();
+    const std::size_t nnz   = data.size();
+    const std::size_t avg   = nrows ? std::max<std::size_t>(std::size_t{1}, nnz / nrows) : std::size_t{1};
+    const std::size_t grain = std::max<std::size_t>(std::size_t{1}, std::size_t{65536} / avg);
+    detail::thread_pool::instance().parallel_for(nrows, grain,
+        [&](std::size_t rb, std::size_t re) {
+            for (std::size_t r = rb; r < re; ++r) {
+                auto acc = math::zero<result_t>();
+                for (size_type k = starts[r]; k < starts[r + 1]; ++k)
+                    acc += static_cast<result_t>(data[k]) * static_cast<result_t>(x(indices[k]));
+                y(r) = acc;
+            }
+        });
     return y;
 }
 


### PR DESCRIPTION
Batch 4 of #221. Parallelizes the **sparse matvec (SpMV)** — the dominant cost of
every Krylov iteration.

## What

`compressed2D * dense_vector` is partitioned over output rows on the persistent
pool. Each `y(r)` is an independent sparse dot, so the result is **bit-identical
across thread counts**. The grain targets ~64K nonzeros per chunk (avg nnz/row);
**serial by default** (`MTL5_NUM_THREADS=1`) → zero behavior change.

Because SpMV dominates CG / GMRES / BiCGSTAB / MINRES / … iteration cost, this
speeds up the whole `itl` iterative-solver stack and the sparse eigensolvers with
no solver-code changes (they call `A * x`).

## Verification

- Full suite **137/137 green at `MTL5_NUM_THREADS=1` and `4`** — the `itl` and
  `sparse` tests exercise SpMV heavily.
- **Bit-identical** serial vs threaded on a 490k-row 2D Laplacian
  (checksum `69.813797057118` at T=1/4/8).
- Scales **~1.87× at 4 cores** (memory-bandwidth bound; plateaus at 8, as
  expected for SpMV).

## Scope / follow-ups

- **Transposed** sparse matvec left serial (it scatters into `y(indices[k])`,
  which races across rows — would need atomics or per-thread accumulation).
- **Sparse triangular solve** is inherently sequential (forward/back
  substitution dependencies); parallelizing it needs **level scheduling** — a
  larger, separate follow-up.

## #221 status

On-node threading now covers **GEMM, GEMV (both orientations), axpy, scal, dot,
nrm2, and sparse SpMV** — all on one persistent pool, serial by default. The
substantial dense + sparse-matvec threading is done; remaining is
level-scheduled sparse triangular solve and a committed multi-core scaling
writeup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved sparse matrix–vector multiplication performance by parallelizing computations across multiple threads.
  * Preserved existing calculation behavior while distributing row-based work more efficiently for larger matrices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->