### PR TITLE
docs: on-node threading model + multi-core scaling writeup (#221)

### DIFF
--- a/docs-site/sync-content.mjs
+++ b/docs-site/sync-content.mjs
@@ -51,6 +51,7 @@ const FILE_MAP = {
   // ── Linear Algebra Algorithms ───────────────────────────────────
   'algorithms/overview.md':                     'algorithms/overview.md',
   'algorithms/eigenvalues.md':                  'algorithms/eigenvalues.md',
+  'algorithms/on-node-threading.md':            'algorithms/on-node-threading.md',
   'algorithms/mixed-precision-kernels.md':      'algorithms/mixed-precision-kernels.md',
   'algorithms/measuring-solver-accuracy.md':    'algorithms/measuring-solver-accuracy.md',
   'algorithms/klu.md':                          'algorithms/klu.md',

--- a/docs-site/sync-content.mjs
+++ b/docs-site/sync-content.mjs
@@ -61,6 +61,7 @@ const FILE_MAP = {
   'sparse-direct-solvers-design.md':            'design/sparse-direct-solvers.md',
   'position-mixed-precision-acceleration.md':   'design/mixed-precision-acceleration.md',
   'design/blas-kernel-architecture.md':         'design/blas-kernel-architecture.md',
+  'design/multicore-scaling-investigation.md':  'design/multicore-scaling-investigation.md',
   'design/mixed-precision-custom-types-SIMD.md': 'design/mixed-precision-custom-types-SIMD.md',
 
   // ── Modernization ──────────────────────────────────────────────────────

--- a/docs/algorithms/on-node-threading.md
+++ b/docs/algorithms/on-node-threading.md
@@ -51,36 +51,66 @@ SpMV/L1 threading with no solver-code changes.
   more than the work; nested/concurrent regions fall back to serial (no
   oversubscription or deadlock).
 
+## Measurement methodology (pin to *distinct physical cores*)
+
+Getting an honest scaling curve requires pinning each software thread to its own
+**physical core** — not to SMT siblings and not to slower efficiency cores. This
+matters especially on hybrid CPUs. On the i7-12700K used below, logical CPUs pair
+up as SMT siblings on 8 P-cores and the 4 E-cores sit at the top:
+
+```text
+lscpu -e=CPU,CORE,MAXMHZ
+# P-cores: logical 0,1 -> core0 ; 2,3 -> core1 ; ... 14,15 -> core7   (~4.9-5.0 GHz)
+# E-cores: logical 16..19 -> cores 8..11                              (3.8 GHz)
+```
+
+So the **one-logical-CPU-per-physical-P-core** set is `0,2,4,6,8,10,12,14`. A
+naive `taskset -c 0-7` instead spans only **four** physical cores (0–3) doubled by
+SMT — an easy way to mismeasure "8 threads" as 4 hyperthreaded cores. Pin
+explicitly:
+
+```bash
+MTL5_NUM_THREADS=8 taskset -c 0,2,4,6,8,10,12,14 ./bench   # 8 distinct P-cores
+```
+
 ## Scaling results (indicative)
 
-> **Indicative only.** Measured on a shared **Intel i7-12700K** (8 P-cores +
-> 4 E-cores), single-run, `taskset`-pinned to logical CPUs 0–7 — which on this
-> hybrid part spans P-core SMT siblings, so the 8-thread column is
-> SMT/bandwidth-limited rather than 8 distinct physical cores. Numbers are
-> directional (±10–15%), not an authoritative benchmark. Reproduce with
-> `MTL5_NUM_THREADS=<n>` on a quiesced, P-core-pinned rig.
+> **Indicative only.** Single-run on a shared **Intel i7-12700K**, fp64, each
+> thread pinned to a distinct physical P-core (`0,2,4,6,8,10,12,14`), no SMT
+> siblings, no E-cores. Directional (±10–15%), not an authoritative benchmark.
 
 fp64 throughput (GFLOP/s) and speedup vs 1 thread:
 
 | Kernel | 1T | 2T | 4T | 8T | speedup @4T | @8T |
 |---|---|---|---|---|---|---|
-| **GEMM** (N=2048) | 58.7 | 109.5 | 196.6 | 252.3 | **3.35×** | 4.30× |
-| **GEMV** (N=8192) | 9.9 | 13.3 | 17.2 | 16.9 | 1.74× | 1.71× |
-| **dot** (N=8M) | 4.6 | 7.4 | 8.7 | 8.8 | 1.89× | 1.92× |
-| **axpy** (N=8M) | 3.5 | 5.3 | 6.3 | 6.2 | 1.79× | 1.76× |
-| **scal** (N=8M) | 2.6 | 4.4 | 4.9 | 5.6 | 1.86× | 2.14× |
-| **SpMV** (490k-row 2D Laplacian) | 1.00× | 1.42× | 1.74× | 1.73× | 1.74× | 1.73× |
+| **GEMM** (N=2048) | 57.4 | 110.3 | 205.1 | 362.5 | 3.57× | **6.32×** |
+| **GEMM** (N=4096) | 57.4 | — | — | 393.7 | — | **6.85×** |
+| **GEMV** (N=8192) | 9.4 | 13.2 | 17.1 | 20.6 | 1.82× | 2.19× |
+| **dot** (N=8M) | 4.6 | 7.6 | 8.6 | 11.1 | 1.89× | 2.43× |
+| **axpy** (N=8M) | 3.4 | 5.3 | 6.4 | 6.9 | 1.87× | 2.02× |
+| **scal** (N=8M) | 2.6 | 4.2 | 5.6 | 6.6 | 2.12× | 2.48× |
+| **SpMV** (490k-row 2D Laplacian) | 1.00× | 1.33× | 1.79× | 1.92× | 1.79× | 1.92× |
 
 ### Reading the results
 
-- **GEMM is compute-bound** and scales with cores (3.35× at 4T, 4.3× at 8T) — its
-  arithmetic intensity keeps the cores fed.
+- **GEMM is compute-bound and scales with cores** — **6.32× at 8 cores** (N=2048),
+  rising to **6.85×** at N=4096 (~86% parallel efficiency). Scaling *improves*
+  with N, which rules out a memory-bandwidth ceiling: larger tiles do more
+  arithmetic per parallel region, so the fixed per-region synchronization
+  amortizes better. At small N (e.g. N=1024, ~5.1×) that per-region handoff is the
+  main limiter; the remaining few percent is the all-core turbo drop.
 - **The Level-1/2 kernels and SpMV are memory-bandwidth-bound.** They reach
-  ~1.7–2× and then **plateau**: a few cores already saturate the memory channels,
-  so adding threads cannot help. This is the expected roofline behavior, not a
-  defect — the win from threading them is the ~2× bandwidth a couple of cores
-  extract over one, and (for the solvers) overlapping that with the compute-bound
+  ~2–2.5× and then **plateau**: a couple of P-cores already saturate the (two
+  DDR5 channel) memory bandwidth, so more threads cannot help. This is the
+  expected roofline behavior, not a defect — the value is the ~2× a few cores
+  extract over one, and (for the solvers) overlapping it with the compute-bound
   GEMM/preconditioner work.
+
+> **Measurement caveat learned the hard way.** An earlier draft of this table
+> reported GEMM at only 4.3× on "8 threads" — that run used `taskset -c 0-7`,
+> which is four physical cores hyperthreaded, not eight cores. Pinning to distinct
+> physical cores (above) shows the real 6.3–6.9×. Always verify the affinity mask
+> against the core topology before drawing a scaling conclusion.
 
 ## Not yet threaded
 

--- a/docs/algorithms/on-node-threading.md
+++ b/docs/algorithms/on-node-threading.md
@@ -13,9 +13,10 @@ MTL5_NUM_THREADS=8 ./your_program
 ```
 
 `MTL5_NUM_THREADS` is read **once** (clamped to the hardware concurrency) and
-sizes a single process-wide pool. Unset or `=1` means fully serial with **zero
-overhead** (no worker threads are created), so the default build behaves exactly
-as before.
+sizes a single process-wide pool. Unset or `=1` means fully serial: **no worker
+threads are created** and each kernel runs its original serial path (a cheap
+pool-size check is all the threading layer adds), so the default build behaves as
+before.
 
 ## What is parallelized
 
@@ -53,10 +54,13 @@ SpMV/L1 threading with no solver-code changes.
 
 ## Measurement methodology (pin to *distinct physical cores*)
 
-Getting an honest scaling curve requires pinning each software thread to its own
-**physical core** — not to SMT siblings and not to slower efficiency cores. This
-matters especially on hybrid CPUs. On the i7-12700K used below, logical CPUs pair
-up as SMT siblings on 8 P-cores and the 4 E-cores sit at the top:
+Getting an honest scaling curve requires confining the run to distinct
+**physical cores** — not to SMT siblings and not to slower efficiency cores.
+`taskset` sets the *process* affinity mask (it does not hard-pin individual
+threads); but when the mask is exactly N logical CPUs, one per physical core, the
+OS keeps the N worker threads one-per-core in steady state. This matters
+especially on hybrid CPUs. On the i7-12700K used below, logical CPUs pair up as
+SMT siblings on 8 P-cores and the 4 E-cores sit at the top:
 
 ```text
 lscpu -e=CPU,CORE,MAXMHZ
@@ -75,9 +79,10 @@ MTL5_NUM_THREADS=8 taskset -c 0,2,4,6,8,10,12,14 ./bench   # 8 distinct P-cores
 
 ## Scaling results (indicative)
 
-> **Indicative only.** Single-run on a shared **Intel i7-12700K**, fp64, each
-> thread pinned to a distinct physical P-core (`0,2,4,6,8,10,12,14`), no SMT
-> siblings, no E-cores. Directional (±10–15%), not an authoritative benchmark.
+> **Indicative only.** Single-run on a shared **Intel i7-12700K**, fp64, the
+> process affinity-masked to N distinct physical P-cores (`0,2,4,6,8,10,12,14`,
+> one logical CPU each — no SMT siblings, no E-cores). Directional (±10–15%), not
+> an authoritative benchmark.
 
 fp64 throughput (GFLOP/s) and speedup vs 1 thread:
 
@@ -89,7 +94,13 @@ fp64 throughput (GFLOP/s) and speedup vs 1 thread:
 | **dot** (N=8M) | 4.6 | 7.6 | 8.6 | 11.1 | 1.89× | 2.43× |
 | **axpy** (N=8M) | 3.4 | 5.3 | 6.4 | 6.9 | 1.87× | 2.02× |
 | **scal** (N=8M) | 2.6 | 4.2 | 5.6 | 6.6 | 2.12× | 2.48× |
-| **SpMV** (490k-row 2D Laplacian) | 1.00× | 1.33× | 1.79× | 1.92× | 1.79× | 1.92× |
+
+**SpMV** (490k-row 2D Laplacian) is measured in **ms/matvec** (lower is better),
+not GFLOP/s:
+
+| threads | 1T | 2T | 4T | 8T | speedup @8T |
+|---|---|---|---|---|---|
+| ms/matvec | 2.18 | 1.64 | 1.21 | 1.13 | **1.92×** |
 
 ### Reading the results
 

--- a/docs/algorithms/on-node-threading.md
+++ b/docs/algorithms/on-node-threading.md
@@ -1,0 +1,98 @@
+# On-Node Threading and Multi-Core Scaling
+
+MTL5 parallelizes its hot kernels across CPU cores with a small persistent thread
+pool (no OpenMP/TBB — just the C++ standard concurrency runtime). Threading is
+**off by default** and opt-in per process.
+
+## Enabling it
+
+Set the environment variable before running:
+
+```bash
+MTL5_NUM_THREADS=8 ./your_program
+```
+
+`MTL5_NUM_THREADS` is read **once** (clamped to the hardware concurrency) and
+sizes a single process-wide pool. Unset or `=1` means fully serial with **zero
+overhead** (no worker threads are created), so the default build behaves exactly
+as before.
+
+## What is parallelized
+
+| Kernel | Where | Partition | Bit-identical to serial? |
+|---|---|---|---|
+| **GEMM** (`mult`, native blocked) | `detail/gemm_blocked.hpp` | ic-blocks of C | **Yes** |
+| **GEMV** (row- and col-major) | `operation/mult.hpp` | output rows | **Yes** |
+| **axpy**, **scal** | `operation/{axpy,scale}.hpp` | element range | **Yes** |
+| **dot**, **two_norm** | `operation/{dot,norms}.hpp` | chunked reduction | No¹ |
+| **SpMV** (`compressed2D * vector`) | `mat/operators.hpp` | output rows | **Yes** |
+
+¹ The reduction kernels sum per-chunk partials, so the result is **deterministic
+for a fixed thread count** but not bit-identical to the serial summation (the
+grouping/associativity differs). The library's tolerances (`WithinRel`) account
+for this. Every other kernel produces each output element from exactly one chunk,
+so its result is bit-identical regardless of `MTL5_NUM_THREADS`.
+
+Because the iterative solvers (`mtl::itl` — CG, GMRES, BiCGSTAB, MINRES, …) and
+the eigensolvers are written against `A * x`, `dot`, and `axpy`, they inherit the
+SpMV/L1 threading with no solver-code changes.
+
+## How it works
+
+- **`detail::thread_pool`** — a persistent pool of worker threads. `run(count,
+  task)` runs `task(tid)` for `tid ∈ [0,count)` (the caller runs tid 0), blocking
+  until all finish. One condition-variable handoff per parallel region — no
+  thread is spawned per call.
+- **`parallel_for(n, grain, body)`** — contiguous chunking of `[0,n)` for the
+  element-wise/per-row kernels.
+- **`parallel_reduce<T>(n, grain, map)`** — chunked reduction combined with
+  `operator+` in chunk order, for `dot`/`nrm2`.
+- A **grain threshold** keeps small problems serial so the handoff never costs
+  more than the work; nested/concurrent regions fall back to serial (no
+  oversubscription or deadlock).
+
+## Scaling results (indicative)
+
+> **Indicative only.** Measured on a shared **Intel i7-12700K** (8 P-cores +
+> 4 E-cores), single-run, `taskset`-pinned to logical CPUs 0–7 — which on this
+> hybrid part spans P-core SMT siblings, so the 8-thread column is
+> SMT/bandwidth-limited rather than 8 distinct physical cores. Numbers are
+> directional (±10–15%), not an authoritative benchmark. Reproduce with
+> `MTL5_NUM_THREADS=<n>` on a quiesced, P-core-pinned rig.
+
+fp64 throughput (GFLOP/s) and speedup vs 1 thread:
+
+| Kernel | 1T | 2T | 4T | 8T | speedup @4T | @8T |
+|---|---|---|---|---|---|---|
+| **GEMM** (N=2048) | 58.7 | 109.5 | 196.6 | 252.3 | **3.35×** | 4.30× |
+| **GEMV** (N=8192) | 9.9 | 13.3 | 17.2 | 16.9 | 1.74× | 1.71× |
+| **dot** (N=8M) | 4.6 | 7.4 | 8.7 | 8.8 | 1.89× | 1.92× |
+| **axpy** (N=8M) | 3.5 | 5.3 | 6.3 | 6.2 | 1.79× | 1.76× |
+| **scal** (N=8M) | 2.6 | 4.4 | 4.9 | 5.6 | 1.86× | 2.14× |
+| **SpMV** (490k-row 2D Laplacian) | 1.00× | 1.42× | 1.74× | 1.73× | 1.74× | 1.73× |
+
+### Reading the results
+
+- **GEMM is compute-bound** and scales with cores (3.35× at 4T, 4.3× at 8T) — its
+  arithmetic intensity keeps the cores fed.
+- **The Level-1/2 kernels and SpMV are memory-bandwidth-bound.** They reach
+  ~1.7–2× and then **plateau**: a few cores already saturate the memory channels,
+  so adding threads cannot help. This is the expected roofline behavior, not a
+  defect — the win from threading them is the ~2× bandwidth a couple of cores
+  extract over one, and (for the solvers) overlapping that with the compute-bound
+  GEMM/preconditioner work.
+
+## Not yet threaded
+
+- **Transposed SpMV** (scatters into `y`, which would race across rows).
+- **Sparse triangular solve** — inherently sequential (forward/back
+  substitution); parallelizing it needs level scheduling.
+- **Dense factorizations** (LU/QR/Cholesky) on the in-house path — these need
+  blocked algorithms over the L3 building blocks first.
+
+## Determinism guidance
+
+For reproducible-to-the-bit results across runs, keep `MTL5_NUM_THREADS` fixed
+(or `=1`): every kernel except `dot`/`nrm2` is bit-identical across thread counts,
+and even those are deterministic for a fixed thread count. If you need
+serial-exact reductions, run those with `MTL5_NUM_THREADS=1`.

--- a/docs/algorithms/on-node-threading.md
+++ b/docs/algorithms/on-node-threading.md
@@ -110,7 +110,10 @@ fp64 throughput (GFLOP/s) and speedup vs 1 thread:
 > reported GEMM at only 4.3× on "8 threads" — that run used `taskset -c 0-7`,
 > which is four physical cores hyperthreaded, not eight cores. Pinning to distinct
 > physical cores (above) shows the real 6.3–6.9×. Always verify the affinity mask
-> against the core topology before drawing a scaling conclusion.
+> against the core topology before drawing a scaling conclusion. The full
+> investigation — hypotheses, controls, and attribution — is written up as a
+> performance-engineering case study:
+> [Multi-Core Scaling of MTL5's Threaded Kernels](../design/multicore-scaling-investigation.md).
 
 ## Not yet threaded
 

--- a/docs/design/multicore-scaling-investigation.md
+++ b/docs/design/multicore-scaling-investigation.md
@@ -89,9 +89,11 @@ experiment never tested eight cores.*
 
 ### 3.3 The corrected design
 
-Pin each software thread to its **own physical P-core** — one logical CPU per
-core, no SMT siblings, no E-cores. The primary logical CPU of each P-core is the
-even id: `0,2,4,6,8,10,12,14`.
+Constrain the process to N **distinct physical P-cores** — one logical CPU per
+core, no SMT siblings, no E-cores. `taskset -c` sets the process affinity mask (it
+does not hard-pin each thread to a specific core), but with one sibling per core
+in the mask the OS keeps the N worker threads one-per-core. The primary logical
+CPU of each P-core is the even id: `0,2,4,6,8,10,12,14`.
 
 ```bash
 MTL5_NUM_THREADS=1 taskset -c 0                        ./bench --suite gemm --sizes 2048
@@ -109,7 +111,7 @@ Controls:
 
 ## 4. Results
 
-### 4.1 GEMM, one thread per distinct physical core (N=2048)
+### 4.1 GEMM, process pinned to N distinct physical cores (N=2048)
 
 | threads | GFLOP/s | speedup | efficiency |
 |---|---|---|---|
@@ -134,7 +136,9 @@ Scaling **improves** with N. A memory-bandwidth ceiling would do the opposite, s
 so the fixed per-`(jc,pc)`-region synchronization amortizes better — pointing at
 **H4** as the small-N limiter.
 
-### 4.3 Memory-bound kernels, distinct physical cores (8T speedup)
+### 4.3 Memory-bound kernels, distinct physical cores
+
+GFLOP/s and speedup vs 1 thread:
 
 | Kernel | 1T | 2T | 4T | 8T | speedup |
 |---|---|---|---|---|---|
@@ -142,7 +146,10 @@ so the fixed per-`(jc,pc)`-region synchronization amortizes better — pointing 
 | dot (N=8M) | 4.6 | 7.6 | 8.6 | 11.1 | 2.43× |
 | axpy (N=8M) | 3.4 | 5.3 | 6.4 | 6.9 | 2.02× |
 | scal (N=8M) | 2.6 | 4.2 | 5.6 | 6.6 | 2.48× |
-| SpMV (490k-row 2D Laplacian) | — | 1.33× | 1.79× | 1.92× | 1.92× |
+
+SpMV (490k-row 2D Laplacian) in **ms/matvec** (lower is better), separately since
+its unit differs: 2.18 / 1.64 / 1.21 / 1.13 ms at 1 / 2 / 4 / 8 cores → **1.92×**
+at 8 cores.
 
 These plateau at ~2–2.5× regardless of correct pinning.
 
@@ -152,7 +159,10 @@ These plateau at ~2–2.5× regardless of correct pinning.
   6.85× at N=4096. The ~14–21% shortfall from ideal splits between (a) the
   per-region pool synchronization — dominant at small N, where there are few
   cache blocks to spread over 8 threads (5.08× at N=1024) — and (b) the all-core
-  turbo drop (H6), the residual few percent after H1–H4 are accounted for.
+  turbo drop (H6), which *plausibly* accounts for the residual few percent. We did
+  not measure the effective clock directly (hardware performance counters were
+  unavailable on this host), so (b) is inferred from the known all-core turbo
+  behavior of this part, not established here.
 - **The Level-1/2 kernels and SpMV are memory-bandwidth-bound.** Two DDR5 channels
   are saturated by a couple of P-cores, so more threads cannot help — the ~2–2.5×
   plateau is the roofline, not a defect. Threading them is still worth the ~2× a
@@ -168,7 +178,9 @@ These plateau at ~2–2.5× regardless of correct pinning.
 2. **H3 (bandwidth) rejected for GEMM**, confirmed for the memory-bound kernels.
 3. **H4 (per-region sync)** is the small-N limiter for GEMM; larger problems
    amortize it away.
-4. **H6 (turbo)** accounts for the last few percent.
+4. **H6 (turbo)** *may* account for the last few percent — inferred from this
+   part's all-core turbo behavior, not directly measured (perf counters were
+   unavailable on this host).
 
 MTL5's on-node threading scales as a from-scratch implementation should: the
 compute-bound kernel tracks cores, and the bandwidth-bound kernels track memory

--- a/docs/design/multicore-scaling-investigation.md
+++ b/docs/design/multicore-scaling-investigation.md
@@ -1,0 +1,207 @@
+# Performance Engineering Case Study: Multi-Core Scaling of MTL5's Threaded Kernels
+
+This is a worked performance-engineering investigation: a scaling result that
+looked like a failure, the experiment designed to explain it, and what the data
+actually showed. It doubles as a template for how to run — and how *not* to run —
+a multi-core scaling experiment. The reference for the threading feature itself is
+[On-Node Threading and Multi-Core Scaling](../algorithms/on-node-threading.md);
+this page is the *why/what/how* of measuring it.
+
+## TL;DR
+
+- A first scaling sweep showed GEMM going from 3.35× (4 threads) to only 4.3×
+  (8 threads) — apparently a wall at 4 cores.
+- The cause was **the experiment, not the code**: the CPU-affinity mask
+  (`taskset -c 0-7`) covered only **four physical cores hyperthreaded**, so
+  "8 threads" ran on 4 cores.
+- Re-run with one thread per **distinct physical core**, GEMM scales **6.32× on
+  8 cores** (N=2048) and **6.85×** at N=4096 (~86% parallel efficiency).
+- A problem-size sweep **rules out a memory-bandwidth ceiling for GEMM** (scaling
+  *improves* with N). The Level-1/2 kernels and SpMV plateau at ~2–2.5× — that
+  *is* a real DDR bandwidth roofline.
+
+## 1. Why — the question
+
+MTL5 added on-node threading (a persistent pool behind GEMM, GEMV, the L1 kernels,
+and sparse SpMV; issue #221). The obvious question for any parallel library is:
+**does it scale with cores?** An initial indicative sweep answered "not past 4":
+
+| threads | GEMM GFLOP/s | speedup |
+|---|---|---|
+| 1 | 58.7 | 1.00× |
+| 2 | 109.5 | 1.87× |
+| 4 | 196.6 | 3.35× |
+| 8 | 252.3 | **4.30×** |
+
+Doubling the thread count from 4 to 8 bought only 1.28×. Either the software has a
+scaling limiter around 4 cores, or the measurement is wrong. "It failed, ship the
+number" is not acceptable — a 4.3×-on-8-cores claim is a strong statement about
+the library, so it needs a root cause.
+
+## 2. What — the system under test
+
+- **CPU:** Intel Core i7-12700K — a **hybrid** part: 8 Performance cores (with
+  2-way SMT → 16 logical CPUs) + 4 Efficiency cores (no SMT, 4 logical CPUs),
+  20 logical CPUs total. P-cores ~4.9–5.0 GHz, E-cores ~3.8 GHz.
+- **Kernels:** the native (no-external-BLAS) threaded paths — blocked GEMM,
+  SIMD GEMV, `dot`/`nrm2`/`axpy`/`scal`, and sparse SpMV.
+- **Metric:** fp64 GFLOP/s (or ms/matvec for SpMV), best of a short repeated run,
+  and speedup vs a single thread. Thread count set with `MTL5_NUM_THREADS`.
+- **Note:** single-run, shared developer machine → numbers are **indicative**
+  (±10–15%). The *shape* of the scaling curve, not the absolute peak, is the
+  object of study.
+
+## 3. How — the experiment
+
+### 3.1 Hypotheses
+
+| # | Hypothesis | How to isolate it |
+|---|---|---|
+| H1 | Threads landed on **SMT siblings**, not distinct cores | pin one thread per physical core; compare against an all-SMT control |
+| H2 | Threads landed on the slower **E-cores** | exclude E-cores from the affinity mask |
+| H3 | **Memory bandwidth** saturates | sweep problem size N; bandwidth-bound scaling gets *worse* with N |
+| H4 | **Thread-pool / per-region sync** overhead dominates | if compute-bound GEMM scales ~linearly, sync is not the wall; check N-dependence |
+| H6 | **All-core turbo** lowers per-core clock under load | measure effective clock, or attribute the residual after H1–H4 |
+
+### 3.2 The flaw: an affinity mask that lies
+
+The original sweep pinned with `taskset -c 0-7`. On this CPU the logical→physical
+map is:
+
+```text
+lscpu -e=CPU,CORE,MAXMHZ
+CPU CORE  MAXMHZ      CPU CORE  MAXMHZ
+  0    0  4900         8    4  4900
+  1    0  4900         9    4  4900
+  2    1  4900        10    5  4900
+  3    1  4900        11    5  4900
+  4    2  5000        12    6  4900
+  5    2  5000        13    6  4900
+  6    3  5000        14    7  4900
+  7    3  5000        16..19  8..11  3800   (E-cores)
+```
+
+Logical CPUs `0–7` are **four physical cores (0–3), each doubled by SMT**. So
+`MTL5_NUM_THREADS=8 taskset -c 0-7` runs eight software threads on **four physical
+cores** — the extra four threads are SMT siblings, worth ~1.25–1.3× on
+compute-bound code. The measured 4→8 gain of 1.28× is exactly that. *The
+experiment never tested eight cores.*
+
+### 3.3 The corrected design
+
+Pin each software thread to its **own physical P-core** — one logical CPU per
+core, no SMT siblings, no E-cores. The primary logical CPU of each P-core is the
+even id: `0,2,4,6,8,10,12,14`.
+
+```bash
+MTL5_NUM_THREADS=1 taskset -c 0                        ./bench --suite gemm --sizes 2048
+MTL5_NUM_THREADS=2 taskset -c 0,2                      ./bench --suite gemm --sizes 2048
+MTL5_NUM_THREADS=4 taskset -c 0,2,4,6                  ./bench --suite gemm --sizes 2048
+MTL5_NUM_THREADS=8 taskset -c 0,2,4,6,8,10,12,14       ./bench --suite gemm --sizes 2048
+```
+
+Controls:
+
+- **SMT control** — repeat T=8 on `0-7` (four cores hyperthreaded) to confirm it
+  reproduces the original number.
+- **Size sweep** — GEMM at N = 1024, 2048, 4096 to separate compute-bound from
+  bandwidth-bound behavior (H3 vs H4).
+
+## 4. Results
+
+### 4.1 GEMM, one thread per distinct physical core (N=2048)
+
+| threads | GFLOP/s | speedup | efficiency |
+|---|---|---|---|
+| 1 | 57.4 | 1.00× | — |
+| 2 | 110.3 | 1.92× | 96% |
+| 4 | 205.1 | 3.57× | 89% |
+| **8** | **362.5** | **6.32×** | **79%** |
+
+**SMT control** — T=8 on `taskset -c 0-7` (4 cores hyperthreaded): **252.1
+GFLOP/s (4.39×)**, reproducing the original "wall" almost exactly. H1 confirmed.
+
+### 4.2 GEMM size sweep at 8 physical cores
+
+| N | 1T | 8T | speedup |
+|---|---|---|---|
+| 1024 | 58.0 | 294.9 | 5.08× |
+| 2048 | 57.2 | 360.6 | 6.30× |
+| 4096 | 57.4 | 393.7 | **6.85×** |
+
+Scaling **improves** with N. A memory-bandwidth ceiling would do the opposite, so
+**H3 is rejected for GEMM**. Bigger tiles do more arithmetic per parallel region,
+so the fixed per-`(jc,pc)`-region synchronization amortizes better — pointing at
+**H4** as the small-N limiter.
+
+### 4.3 Memory-bound kernels, distinct physical cores (8T speedup)
+
+| Kernel | 1T | 2T | 4T | 8T | speedup |
+|---|---|---|---|---|---|
+| GEMV (N=8192) | 9.4 | 13.2 | 17.1 | 20.6 | 2.19× |
+| dot (N=8M) | 4.6 | 7.6 | 8.6 | 11.1 | 2.43× |
+| axpy (N=8M) | 3.4 | 5.3 | 6.4 | 6.9 | 2.02× |
+| scal (N=8M) | 2.6 | 4.2 | 5.6 | 6.6 | 2.48× |
+| SpMV (490k-row 2D Laplacian) | — | 1.33× | 1.79× | 1.92× | 1.92× |
+
+These plateau at ~2–2.5× regardless of correct pinning.
+
+## 5. Analysis
+
+- **GEMM is compute-bound and scales with cores.** 6.32× at 8 cores (N=2048),
+  6.85× at N=4096. The ~14–21% shortfall from ideal splits between (a) the
+  per-region pool synchronization — dominant at small N, where there are few
+  cache blocks to spread over 8 threads (5.08× at N=1024) — and (b) the all-core
+  turbo drop (H6), the residual few percent after H1–H4 are accounted for.
+- **The Level-1/2 kernels and SpMV are memory-bandwidth-bound.** Two DDR5 channels
+  are saturated by a couple of P-cores, so more threads cannot help — the ~2–2.5×
+  plateau is the roofline, not a defect. Threading them is still worth the ~2× a
+  few cores extract over one, and (in a solver) it overlaps with the compute-bound
+  GEMM/preconditioner work.
+- **No software scaling wall at 4 cores exists.** The apparent wall was an
+  affinity-mask artifact.
+
+## 6. Conclusions
+
+1. **H1 (SMT-sibling pinning): the cause.** Eight real cores give 6.3–6.9×, not
+   4.3×.
+2. **H3 (bandwidth) rejected for GEMM**, confirmed for the memory-bound kernels.
+3. **H4 (per-region sync)** is the small-N limiter for GEMM; larger problems
+   amortize it away.
+4. **H6 (turbo)** accounts for the last few percent.
+
+MTL5's on-node threading scales as a from-scratch implementation should: the
+compute-bound kernel tracks cores, and the bandwidth-bound kernels track memory
+channels.
+
+## 7. Reproduction
+
+Build the native-fast benchmark and run the pinned sweep:
+
+```bash
+cmake -B build-nf -DMTL5_BUILD_BENCHMARKS=ON -DCMAKE_BUILD_TYPE=Release \
+      -DMTL5_NATIVE_FAST_GEMM=ON -DMTL5_WITH_HIGHWAY=ON -DMTL5_NATIVE_ARCH=ON
+cmake --build build-nf --target bench_all
+
+# Confirm your topology first, then pin to one logical CPU per physical core:
+lscpu -e=CPU,CORE,MAXMHZ
+for T in 1 2 4 8; do
+  CPUS=$(...)   # even ids of the first T P-cores, e.g. 0,2,4,6,8,10,12,14
+  MTL5_NUM_THREADS=$T taskset -c "$CPUS" ./build-nf/benchmarks/bench_all \
+      --suite gemm --sizes 2048 --label "t$T"
+done
+```
+
+## 8. Lessons — a checklist for scaling experiments
+
+- **Verify the affinity mask against the core topology.** `taskset -c 0-7` is not
+  "8 cores" on an SMT machine. Pin one thread per *physical* core; keep SMT
+  siblings and heterogeneous (E-)cores out unless they are the subject.
+- **Sweep the problem size.** It separates compute-bound from bandwidth-bound
+  behavior and exposes fixed per-region overhead at small sizes.
+- **Keep a control.** An all-SMT run confirmed the artifact and quantified the SMT
+  gain in one measurement.
+- **Attribute the residual.** Frequency (turbo), sync, and imbalance each explain
+  a slice; name them rather than lumping them into "overhead."
+- **Distrust a too-clean failure.** "Exactly the SMT speedup" was the tell that the
+  cores, not the code, were the story.


### PR DESCRIPTION
The committed scaling writeup for the on-node threading work (#221).

## What

`docs/algorithms/on-node-threading.md` — a published page (wired into `FILE_MAP`
/ the "Linear Algebra Algorithms" sidebar) covering:

- **How to enable it** — `MTL5_NUM_THREADS`, read once, serial (zero-overhead) by
  default.
- **What's parallelized** and the **bit-identity status** of each kernel: GEMM,
  GEMV (both orientations), axpy, scal, SpMV are bit-identical; dot/nrm2 are
  deterministic-per-thread-count parallel reductions.
- **How it works** — the persistent `thread_pool`, `parallel_for`,
  `parallel_reduce`, and the grain threshold.
- **Indicative scaling table** (clearly labeled) + a "reading the results"
  section.

## Headline result

| | @4T | @8T |
|---|---|---|
| **GEMM** (compute-bound) | 3.35× | 4.30× |
| GEMV / dot / axpy / scal / SpMV (memory-bound) | ~1.7–2× | plateaus |

GEMM scales with cores; the Level-1/2 kernels and SpMV are bandwidth-bound and
saturate the memory channels after a couple of cores — the expected roofline
behavior.

## Provenance

Numbers are **indicative** — a shared i7-12700K (hybrid P/E), single-run,
`taskset`-pinned to logical CPUs 0–7 (which span P-core SMT siblings, so the
8-thread column is SMT/bandwidth-limited). The page says so explicitly and
points at how to reproduce on a quiesced, P-core-pinned rig. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for enabling and configuring multi-core CPU threading.
  * Documented supported threaded kernels, determinism considerations, scaling results, and current limitations.
  * Added a detailed investigation of CPU affinity, performance scaling, benchmarking methodology, and reproducibility.
  * Updated documentation synchronization to include the new pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->