### PR TITLE
feat(operation): structural matrix + vector property predicates (#244)

### DIFF
--- a/include/mtl/mtl.hpp
+++ b/include/mtl/mtl.hpp
@@ -177,6 +177,8 @@
 #include <mtl/operation/symm.hpp>
 #include <mtl/operation/syrk.hpp>
 #include <mtl/operation/syr2k.hpp>
+#include <mtl/operation/matrix_properties.hpp>
+#include <mtl/operation/vector_properties.hpp>
 #include <mtl/operation/lu.hpp>
 #include <mtl/operation/householder.hpp>
 #include <mtl/operation/qr.hpp>

--- a/include/mtl/operation/matrix_properties.hpp
+++ b/include/mtl/operation/matrix_properties.hpp
@@ -7,6 +7,10 @@
 // requires exact structure (as constructed). Pass tol > 0 for an approximate
 // check on a computed matrix. Works for any Matrix that supports A(i,j) (dense
 // or sparse) and any element type with abs() (real, complex, custom).
+//
+// The deviation tests are written as !(dev <= tol) rather than dev > tol so a
+// NaN entry (dev is NaN, all comparisons unordered) fails the predicate instead
+// of being silently accepted.
 #include <cmath>
 #include <cstddef>
 
@@ -33,7 +37,7 @@ bool is_symmetric(const M& A, magnitude_t<typename M::value_type> tol = 0) {
     const size_type n = A.num_rows();
     for (size_type i = 0; i < n; ++i)
         for (size_type j = i + 1; j < n; ++j)
-            if (abs(A(i, j) - A(j, i)) > tol) return false;
+            if (!(abs(A(i, j) - A(j, i)) <= tol)) return false;
     return true;
 }
 
@@ -48,7 +52,7 @@ bool is_hermitian(const M& A, magnitude_t<typename M::value_type> tol = 0) {
     const size_type n = A.num_rows();
     for (size_type i = 0; i < n; ++i)
         for (size_type j = i; j < n; ++j)   // include the diagonal: Im(A(i,i)) ~ 0
-            if (abs(A(i, j) - functor::scalar::conj<T>::apply(A(j, i))) > tol) return false;
+            if (!(abs(A(i, j) - functor::scalar::conj<T>::apply(A(j, i))) <= tol)) return false;
     return true;
 }
 
@@ -60,7 +64,7 @@ bool is_upper_triangular(const M& A, magnitude_t<typename M::value_type> tol = 0
     const size_type m = A.num_rows(), n = A.num_cols();
     for (size_type i = 0; i < m; ++i)
         for (size_type j = 0; j < i && j < n; ++j)
-            if (abs(A(i, j)) > tol) return false;
+            if (!(abs(A(i, j)) <= tol)) return false;
     return true;
 }
 
@@ -72,7 +76,7 @@ bool is_lower_triangular(const M& A, magnitude_t<typename M::value_type> tol = 0
     const size_type m = A.num_rows(), n = A.num_cols();
     for (size_type i = 0; i < m; ++i)
         for (size_type j = i + 1; j < n; ++j)
-            if (abs(A(i, j)) > tol) return false;
+            if (!(abs(A(i, j)) <= tol)) return false;
     return true;
 }
 
@@ -90,7 +94,7 @@ bool is_diagonal(const M& A, magnitude_t<typename M::value_type> tol = 0) {
     const size_type m = A.num_rows(), n = A.num_cols();
     for (size_type i = 0; i < m; ++i)
         for (size_type j = 0; j < n; ++j)
-            if (i != j && abs(A(i, j)) > tol) return false;
+            if (i != j && !(abs(A(i, j)) <= tol)) return false;
     return true;
 }
 
@@ -106,7 +110,7 @@ bool is_banded(const M& A, std::size_t kl, std::size_t ku,
         for (size_type j = 0; j < n; ++j) {
             const bool below = (i > j) && (static_cast<std::size_t>(i - j) > kl);
             const bool above = (j > i) && (static_cast<std::size_t>(j - i) > ku);
-            if ((below || above) && abs(A(i, j)) > tol) return false;
+            if ((below || above) && !(abs(A(i, j)) <= tol)) return false;
         }
     return true;
 }

--- a/include/mtl/operation/matrix_properties.hpp
+++ b/include/mtl/operation/matrix_properties.hpp
@@ -1,0 +1,133 @@
+#pragma once
+// MTL5 -- Matrix structural property predicates (#244, batch 1).
+// is_square, is_empty, is_symmetric, is_hermitian, is_upper/lower/is_triangular,
+// is_diagonal, is_banded, is_diagonally_dominant.
+//
+// `tol` is an ABSOLUTE threshold on the relevant deviation; the default 0
+// requires exact structure (as constructed). Pass tol > 0 for an approximate
+// check on a computed matrix. Works for any Matrix that supports A(i,j) (dense
+// or sparse) and any element type with abs() (real, complex, custom).
+#include <cmath>
+#include <cstddef>
+
+#include <mtl/concepts/matrix.hpp>
+#include <mtl/concepts/magnitude.hpp>
+#include <mtl/functor/scalar/conj.hpp>
+
+namespace mtl {
+
+/// A.num_rows() == A.num_cols().
+template <Matrix M>
+bool is_square(const M& A) { return A.num_rows() == A.num_cols(); }
+
+/// A has no rows or no columns.
+template <Matrix M>
+bool is_empty(const M& A) { return A.num_rows() == 0 || A.num_cols() == 0; }
+
+/// A == A^T (within tol). Non-square matrices are never symmetric.
+template <Matrix M>
+bool is_symmetric(const M& A, magnitude_t<typename M::value_type> tol = 0) {
+    using std::abs;
+    using size_type = typename M::size_type;
+    if (A.num_rows() != A.num_cols()) return false;
+    const size_type n = A.num_rows();
+    for (size_type i = 0; i < n; ++i)
+        for (size_type j = i + 1; j < n; ++j)
+            if (abs(A(i, j) - A(j, i)) > tol) return false;
+    return true;
+}
+
+/// A == A^H (within tol): A(i,j) == conj(A(j,i)), and the diagonal is real.
+/// For real element types this coincides with is_symmetric.
+template <Matrix M>
+bool is_hermitian(const M& A, magnitude_t<typename M::value_type> tol = 0) {
+    using std::abs;
+    using T = typename M::value_type;
+    using size_type = typename M::size_type;
+    if (A.num_rows() != A.num_cols()) return false;
+    const size_type n = A.num_rows();
+    for (size_type i = 0; i < n; ++i)
+        for (size_type j = i; j < n; ++j)   // include the diagonal: Im(A(i,i)) ~ 0
+            if (abs(A(i, j) - functor::scalar::conj<T>::apply(A(j, i))) > tol) return false;
+    return true;
+}
+
+/// Upper triangular: everything strictly below the main diagonal is ~0.
+template <Matrix M>
+bool is_upper_triangular(const M& A, magnitude_t<typename M::value_type> tol = 0) {
+    using std::abs;
+    using size_type = typename M::size_type;
+    const size_type m = A.num_rows(), n = A.num_cols();
+    for (size_type i = 0; i < m; ++i)
+        for (size_type j = 0; j < i && j < n; ++j)
+            if (abs(A(i, j)) > tol) return false;
+    return true;
+}
+
+/// Lower triangular: everything strictly above the main diagonal is ~0.
+template <Matrix M>
+bool is_lower_triangular(const M& A, magnitude_t<typename M::value_type> tol = 0) {
+    using std::abs;
+    using size_type = typename M::size_type;
+    const size_type m = A.num_rows(), n = A.num_cols();
+    for (size_type i = 0; i < m; ++i)
+        for (size_type j = i + 1; j < n; ++j)
+            if (abs(A(i, j)) > tol) return false;
+    return true;
+}
+
+/// Upper or lower triangular.
+template <Matrix M>
+bool is_triangular(const M& A, magnitude_t<typename M::value_type> tol = 0) {
+    return is_upper_triangular(A, tol) || is_lower_triangular(A, tol);
+}
+
+/// Diagonal: every off-diagonal entry is ~0.
+template <Matrix M>
+bool is_diagonal(const M& A, magnitude_t<typename M::value_type> tol = 0) {
+    using std::abs;
+    using size_type = typename M::size_type;
+    const size_type m = A.num_rows(), n = A.num_cols();
+    for (size_type i = 0; i < m; ++i)
+        for (size_type j = 0; j < n; ++j)
+            if (i != j && abs(A(i, j)) > tol) return false;
+    return true;
+}
+
+/// Banded with lower bandwidth kl and upper bandwidth ku: an entry more than kl
+/// below (i - j > kl) or more than ku above (j - i > ku) the diagonal must be ~0.
+template <Matrix M>
+bool is_banded(const M& A, std::size_t kl, std::size_t ku,
+               magnitude_t<typename M::value_type> tol = 0) {
+    using std::abs;
+    using size_type = typename M::size_type;
+    const size_type m = A.num_rows(), n = A.num_cols();
+    for (size_type i = 0; i < m; ++i)
+        for (size_type j = 0; j < n; ++j) {
+            const bool below = (i > j) && (static_cast<std::size_t>(i - j) > kl);
+            const bool above = (j > i) && (static_cast<std::size_t>(j - i) > ku);
+            if ((below || above) && abs(A(i, j)) > tol) return false;
+        }
+    return true;
+}
+
+/// Row diagonally dominant: |A(i,i)| >= sum_{j != i} |A(i,j)| for every row
+/// (strict: strictly greater). Non-square matrices are never dominant.
+template <Matrix M>
+bool is_diagonally_dominant(const M& A, bool strict = false) {
+    using std::abs;
+    using mag_t = magnitude_t<typename M::value_type>;
+    using size_type = typename M::size_type;
+    if (A.num_rows() != A.num_cols()) return false;
+    const size_type n = A.num_rows();
+    for (size_type i = 0; i < n; ++i) {
+        mag_t off = mag_t(0);
+        for (size_type j = 0; j < n; ++j)
+            if (j != i) off += abs(A(i, j));
+        const mag_t d = abs(A(i, i));
+        if (strict ? !(d > off) : !(d >= off)) return false;
+    }
+    return true;
+}
+
+} // namespace mtl

--- a/include/mtl/operation/vector_properties.hpp
+++ b/include/mtl/operation/vector_properties.hpp
@@ -1,0 +1,127 @@
+#pragma once
+// MTL5 -- Vector property predicates (#244, batch 1).
+// is_zero, is_finite, has_nan, has_inf, is_normalized/is_unit, is_orthogonal_to.
+//
+// Structural checks (is_zero) use an ABSOLUTE tolerance defaulting to 0 (exact).
+// The norm-based checks (is_normalized, is_orthogonal_to) use a RELATIVE
+// tolerance defaulting to a small multiple of the element epsilon, since a
+// computed norm/inner-product is rarely bit-exact.
+#include <cmath>
+#include <limits>
+#include <type_traits>
+
+#include <mtl/concepts/vector.hpp>
+#include <mtl/concepts/magnitude.hpp>
+#include <mtl/operation/norms.hpp>
+#include <mtl/operation/dot.hpp>
+
+namespace mtl {
+
+namespace detail {
+
+// Per-element floating-point classification that degrades gracefully:
+// real floating types use <cmath>; complex checks both parts; every other
+// (exact/integer/custom) type is treated as finite / never nan / never inf.
+template <typename T>
+bool scalar_is_finite(const T& x) {
+    if constexpr (std::is_floating_point_v<T>) {
+        using std::isfinite; return isfinite(x);
+    } else if constexpr (requires { x.real(); x.imag(); }) {
+        using std::isfinite; return isfinite(x.real()) && isfinite(x.imag());
+    } else {
+        return true;
+    }
+}
+template <typename T>
+bool scalar_is_nan(const T& x) {
+    if constexpr (std::is_floating_point_v<T>) {
+        using std::isnan; return isnan(x);
+    } else if constexpr (requires { x.real(); x.imag(); }) {
+        using std::isnan; return isnan(x.real()) || isnan(x.imag());
+    } else {
+        return false;
+    }
+}
+template <typename T>
+bool scalar_is_inf(const T& x) {
+    if constexpr (std::is_floating_point_v<T>) {
+        using std::isinf; return isinf(x);
+    } else if constexpr (requires { x.real(); x.imag(); }) {
+        using std::isinf; return isinf(x.real()) || isinf(x.imag());
+    } else {
+        return false;
+    }
+}
+
+} // namespace detail
+
+/// Default relative tolerance for the norm-based predicates: 128 * eps.
+template <typename Mag>
+constexpr Mag default_norm_tol() {
+    return Mag(128) * std::numeric_limits<Mag>::epsilon();
+}
+
+/// Every entry is within tol of zero (default tol 0: exactly zero).
+template <Vector V>
+bool is_zero(const V& v, magnitude_t<typename V::value_type> tol = 0) {
+    using std::abs;
+    for (typename V::size_type i = 0; i < v.size(); ++i)
+        if (abs(v(i)) > tol) return false;
+    return true;
+}
+
+/// Every entry is finite (no NaN, no ±Inf).
+template <Vector V>
+bool is_finite(const V& v) {
+    for (typename V::size_type i = 0; i < v.size(); ++i)
+        if (!detail::scalar_is_finite(v(i))) return false;
+    return true;
+}
+
+/// At least one entry is NaN.
+template <Vector V>
+bool has_nan(const V& v) {
+    for (typename V::size_type i = 0; i < v.size(); ++i)
+        if (detail::scalar_is_nan(v(i))) return true;
+    return false;
+}
+
+/// At least one entry is ±Inf.
+template <Vector V>
+bool has_inf(const V& v) {
+    for (typename V::size_type i = 0; i < v.size(); ++i)
+        if (detail::scalar_is_inf(v(i))) return true;
+    return false;
+}
+
+/// Unit 2-norm within a relative tolerance (default 128 * eps).
+template <Vector V>
+bool is_normalized(const V& v,
+                   magnitude_t<typename V::value_type> tol =
+                       default_norm_tol<magnitude_t<typename V::value_type>>()) {
+    using mag_t = magnitude_t<typename V::value_type>;
+    using std::abs;
+    return abs(two_norm(v) - mag_t(1)) <= tol;
+}
+
+/// Alias for is_normalized.
+template <Vector V>
+bool is_unit(const V& v,
+             magnitude_t<typename V::value_type> tol =
+                 default_norm_tol<magnitude_t<typename V::value_type>>()) {
+    return is_normalized(v, tol);
+}
+
+/// Numerically orthogonal: |<u,v>| <= tol * ||u|| * ||v|| (relative; default
+/// tol 128 * eps). Zero-length vectors are trivially orthogonal.
+template <Vector V1, Vector V2>
+bool is_orthogonal_to(const V1& u, const V2& v,
+                      magnitude_t<typename V1::value_type> tol =
+                          default_norm_tol<magnitude_t<typename V1::value_type>>()) {
+    using mag_t = magnitude_t<typename V1::value_type>;
+    using std::abs;
+    const mag_t threshold = tol * two_norm(u) * two_norm(v);
+    return abs(dot(u, v)) <= threshold;
+}
+
+} // namespace mtl

--- a/include/mtl/operation/vector_properties.hpp
+++ b/include/mtl/operation/vector_properties.hpp
@@ -70,7 +70,7 @@ bool is_zero(const V& v, magnitude_t<typename V::value_type> tol = 0) {
     return true;
 }
 
-/// Every entry is finite (no NaN, no ±Inf).
+/// Every entry is finite (no NaN, no +/-Inf).
 template <Vector V>
 bool is_finite(const V& v) {
     for (typename V::size_type i = 0; i < v.size(); ++i)
@@ -86,7 +86,7 @@ bool has_nan(const V& v) {
     return false;
 }
 
-/// At least one entry is ±Inf.
+/// At least one entry is +/-Inf.
 template <Vector V>
 bool has_inf(const V& v) {
     for (typename V::size_type i = 0; i < v.size(); ++i)

--- a/include/mtl/operation/vector_properties.hpp
+++ b/include/mtl/operation/vector_properties.hpp
@@ -61,12 +61,13 @@ constexpr Mag default_norm_tol() {
     return Mag(128) * std::numeric_limits<Mag>::epsilon();
 }
 
-/// Every entry is within tol of zero (default tol 0: exactly zero).
+/// Every entry is within tol of zero (default tol 0: exactly zero). Written as
+/// !(abs <= tol) so a NaN entry fails the predicate rather than being accepted.
 template <Vector V>
 bool is_zero(const V& v, magnitude_t<typename V::value_type> tol = 0) {
     using std::abs;
     for (typename V::size_type i = 0; i < v.size(); ++i)
-        if (abs(v(i)) > tol) return false;
+        if (!(abs(v(i)) <= tol)) return false;
     return true;
 }
 

--- a/tests/unit/operation/test_matrix_properties.cpp
+++ b/tests/unit/operation/test_matrix_properties.cpp
@@ -4,6 +4,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <complex>
+#include <limits>
 
 #include <mtl/mat/dense2D.hpp>
 #include <mtl/vec/dense_vector.hpp>
@@ -109,6 +110,22 @@ TEST_CASE("is_banded", "[operation][properties][matrix]") {
     auto Lb = make({{1, 0, 0}, {2, 3, 0}, {0, 4, 5}});
     REQUIRE(is_banded(Lb, 1, 0));
     REQUIRE_FALSE(is_banded(Lb, 0, 0));
+}
+
+TEST_CASE("NaN entries fail structural predicates", "[operation][properties][matrix]") {
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+    // A NaN is unordered, so `abs > tol` would silently accept it; the
+    // predicates use !(dev <= tol) so a NaN must break every structural check.
+    // NaN in an off-diagonal position makes the deviation abs(A(i,j)-A(j,i))
+    // itself NaN, which must fail the symmetry test at any tolerance.
+    auto S = make({{1.0, nan}, {2.0, 3.0}});
+    REQUIRE_FALSE(is_symmetric(S));
+    REQUIRE_FALSE(is_symmetric(S, 1e6));
+    auto Dg = make({{nan, 0.0}, {0.0, 1.0}});  // NaN on diagonal (off-diag zero)
+    REQUIRE(is_diagonal(Dg));                  // off-diagonals are zero
+    auto Off = make({{1.0, nan}, {0.0, 1.0}}); // NaN off-diagonal
+    REQUIRE_FALSE(is_diagonal(Off));
+    REQUIRE_FALSE(is_upper_triangular(make({{1.0, 2.0}, {nan, 1.0}})));
 }
 
 TEST_CASE("is_diagonally_dominant", "[operation][properties][matrix]") {

--- a/tests/unit/operation/test_matrix_properties.cpp
+++ b/tests/unit/operation/test_matrix_properties.cpp
@@ -1,0 +1,128 @@
+// Tests for the matrix structural property predicates (#244, batch 1):
+// is_square, is_empty, is_symmetric, is_hermitian, is_upper/lower/is_triangular,
+// is_diagonal, is_banded, is_diagonally_dominant.
+#include <catch2/catch_test_macros.hpp>
+
+#include <complex>
+
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/operation/matrix_properties.hpp>
+
+using namespace mtl;
+using cd = std::complex<double>;
+
+namespace {
+// Fill a dense2D from a nested initializer list (row by row).
+mat::dense2D<double> make(std::initializer_list<std::initializer_list<double>> rows) {
+    const std::size_t m = rows.size();
+    const std::size_t n = rows.begin()->size();
+    mat::dense2D<double> A(m, n);
+    std::size_t i = 0;
+    for (const auto& r : rows) {
+        std::size_t j = 0;
+        for (double v : r) A(i, j++) = v;
+        ++i;
+    }
+    return A;
+}
+} // namespace
+
+TEST_CASE("is_square / is_empty", "[operation][properties][matrix]") {
+    REQUIRE(is_square(make({{1, 2}, {3, 4}})));
+    REQUIRE_FALSE(is_square(mat::dense2D<double>(2, 3)));
+    REQUIRE(is_empty(mat::dense2D<double>(0, 0)));
+    REQUIRE(is_empty(mat::dense2D<double>(0, 5)));
+    REQUIRE(is_empty(mat::dense2D<double>(5, 0)));
+    REQUIRE_FALSE(is_empty(make({{1}})));
+    // A 0x0 matrix is (vacuously) square, diagonal, triangular, symmetric.
+    mat::dense2D<double> z(0, 0);
+    REQUIRE(is_square(z));
+    REQUIRE(is_symmetric(z));
+    REQUIRE(is_diagonal(z));
+    REQUIRE(is_triangular(z));
+    // 1x1 is everything.
+    auto one = make({{7}});
+    REQUIRE(is_symmetric(one));
+    REQUIRE(is_diagonal(one));
+    REQUIRE(is_triangular(one));
+}
+
+TEST_CASE("is_symmetric: exact, tolerance, non-square", "[operation][properties][matrix]") {
+    REQUIRE(is_symmetric(make({{1, 2, 3}, {2, 4, 5}, {3, 5, 6}})));
+    REQUIRE_FALSE(is_symmetric(make({{1, 2}, {3, 4}})));
+    // Non-square is never symmetric.
+    REQUIRE_FALSE(is_symmetric(mat::dense2D<double>(2, 3)));
+    // Near-symmetric: reads asymmetric at tol=0, symmetric within tol.
+    auto A = make({{1.0, 2.0}, {2.0 + 1e-9, 1.0}});
+    REQUIRE_FALSE(is_symmetric(A));
+    REQUIRE(is_symmetric(A, 1e-6));
+}
+
+TEST_CASE("is_hermitian", "[operation][properties][matrix]") {
+    // Real symmetric is hermitian.
+    mat::dense2D<cd> H(2, 2);
+    H(0, 0) = cd(1, 0);  H(0, 1) = cd(2, -3);
+    H(1, 0) = cd(2, 3);  H(1, 1) = cd(4, 0);
+    REQUIRE(is_hermitian(H));
+    REQUIRE_FALSE(is_symmetric(H));   // A(0,1) != A(1,0)
+    // Non-real diagonal breaks hermitian.
+    H(0, 0) = cd(1, 1);
+    REQUIRE_FALSE(is_hermitian(H));
+}
+
+TEST_CASE("triangular predicates", "[operation][properties][matrix]") {
+    auto U = make({{1, 2, 3}, {0, 4, 5}, {0, 0, 6}});
+    auto L = make({{1, 0, 0}, {2, 3, 0}, {4, 5, 6}});
+    auto D = make({{1, 0, 0}, {0, 2, 0}, {0, 0, 3}});
+    auto F = make({{1, 2}, {3, 4}});
+
+    REQUIRE(is_upper_triangular(U));
+    REQUIRE_FALSE(is_lower_triangular(U));
+    REQUIRE(is_lower_triangular(L));
+    REQUIRE_FALSE(is_upper_triangular(L));
+    REQUIRE(is_triangular(U));
+    REQUIRE(is_triangular(L));
+    REQUIRE_FALSE(is_triangular(F));
+
+    // Diagonal is both upper and lower.
+    REQUIRE(is_upper_triangular(D));
+    REQUIRE(is_lower_triangular(D));
+    REQUIRE(is_diagonal(D));
+    REQUIRE_FALSE(is_diagonal(U));
+}
+
+TEST_CASE("is_banded", "[operation][properties][matrix]") {
+    // Tridiagonal: kl=1, ku=1.
+    auto T = make({{2, -1, 0, 0},
+                   {-1, 2, -1, 0},
+                   {0, -1, 2, -1},
+                   {0, 0, -1, 2}});
+    REQUIRE(is_banded(T, 1, 1));
+    REQUIRE(is_banded(T, 2, 2));      // wider band still holds
+    REQUIRE_FALSE(is_banded(T, 0, 0)); // not diagonal
+    REQUIRE(is_banded(T, 1, 0) == false); // has a superdiagonal
+    // Diagonal is banded with kl=ku=0.
+    auto D = make({{1, 0}, {0, 2}});
+    REQUIRE(is_banded(D, 0, 0));
+    // Lower bidiagonal: kl=1, ku=0.
+    auto Lb = make({{1, 0, 0}, {2, 3, 0}, {0, 4, 5}});
+    REQUIRE(is_banded(Lb, 1, 0));
+    REQUIRE_FALSE(is_banded(Lb, 0, 0));
+}
+
+TEST_CASE("is_diagonally_dominant", "[operation][properties][matrix]") {
+    // Strictly dominant.
+    auto A = make({{4, 1, 0}, {1, 5, -1}, {0, 1, 3}});
+    REQUIRE(is_diagonally_dominant(A));
+    REQUIRE(is_diagonally_dominant(A, /*strict=*/true));
+    // Weakly dominant (row 0 equality): dominant but not strict.
+    auto W = make({{2, 1, 1}, {0, 5, 1}, {0, 0, 4}});
+    REQUIRE(is_diagonally_dominant(W));
+    REQUIRE_FALSE(is_diagonally_dominant(W, /*strict=*/true));
+    // Not dominant.
+    auto N = make({{1, 2}, {2, 1}});
+    REQUIRE_FALSE(is_diagonally_dominant(N));
+    // Non-square is never dominant.
+    REQUIRE_FALSE(is_diagonally_dominant(mat::dense2D<double>(2, 3)));
+}

--- a/tests/unit/operation/test_vector_properties.cpp
+++ b/tests/unit/operation/test_vector_properties.cpp
@@ -37,6 +37,14 @@ TEST_CASE("is_finite / has_nan / has_inf", "[operation][properties][vector]") {
     REQUIRE_FALSE(has_nan(vec_t{1.0, inf, 3.0}));
 }
 
+TEST_CASE("is_zero: NaN entry is not zero", "[operation][properties][vector]") {
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+    // A NaN entry must fail is_zero even under a large tolerance (NaN is
+    // unordered, so the naive `abs > tol` test would wrongly accept it).
+    REQUIRE_FALSE(is_zero(vec_t{0.0, nan, 0.0}));
+    REQUIRE_FALSE(is_zero(vec_t{0.0, nan, 0.0}, 1e6));
+}
+
 TEST_CASE("is_normalized / is_unit", "[operation][properties][vector]") {
     // 3-4-5 normalized.
     REQUIRE(is_normalized(vec_t{0.6, 0.8}));

--- a/tests/unit/operation/test_vector_properties.cpp
+++ b/tests/unit/operation/test_vector_properties.cpp
@@ -1,0 +1,59 @@
+// Tests for the vector property predicates (#244, batch 1):
+// is_zero, is_finite, has_nan, has_inf, is_normalized/is_unit, is_orthogonal_to.
+#include <catch2/catch_test_macros.hpp>
+
+#include <cmath>
+#include <limits>
+
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/operation/vector_properties.hpp>
+
+using namespace mtl;
+using vec_t = vec::dense_vector<double>;
+
+TEST_CASE("is_zero", "[operation][properties][vector]") {
+    REQUIRE(is_zero(vec_t{0.0, 0.0, 0.0}));
+    REQUIRE_FALSE(is_zero(vec_t{0.0, 1e-12, 0.0}));
+    // Within tol.
+    REQUIRE(is_zero(vec_t{0.0, 1e-12, 0.0}, 1e-9));
+    // Empty vector is (vacuously) zero.
+    REQUIRE(is_zero(vec_t(0)));
+}
+
+TEST_CASE("is_finite / has_nan / has_inf", "[operation][properties][vector]") {
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+    const double inf = std::numeric_limits<double>::infinity();
+
+    REQUIRE(is_finite(vec_t{1.0, -2.0, 3.5}));
+    REQUIRE_FALSE(has_nan(vec_t{1.0, -2.0, 3.5}));
+    REQUIRE_FALSE(has_inf(vec_t{1.0, -2.0, 3.5}));
+
+    REQUIRE_FALSE(is_finite(vec_t{1.0, nan, 3.0}));
+    REQUIRE(has_nan(vec_t{1.0, nan, 3.0}));
+    REQUIRE_FALSE(has_inf(vec_t{1.0, nan, 3.0}));
+
+    REQUIRE_FALSE(is_finite(vec_t{1.0, inf, 3.0}));
+    REQUIRE(has_inf(vec_t{1.0, inf, 3.0}));
+    REQUIRE_FALSE(has_nan(vec_t{1.0, inf, 3.0}));
+}
+
+TEST_CASE("is_normalized / is_unit", "[operation][properties][vector]") {
+    // 3-4-5 normalized.
+    REQUIRE(is_normalized(vec_t{0.6, 0.8}));
+    REQUIRE(is_unit(vec_t{1.0, 0.0, 0.0}));
+    REQUIRE_FALSE(is_normalized(vec_t{3.0, 4.0}));  // norm 5
+    // Slightly off unit norm: rejected at default tol, accepted with a loose tol.
+    vec_t nearly{1.0 + 1e-3, 0.0};
+    REQUIRE_FALSE(is_normalized(nearly));
+    REQUIRE(is_normalized(nearly, 1e-2));
+}
+
+TEST_CASE("is_orthogonal_to", "[operation][properties][vector]") {
+    REQUIRE(is_orthogonal_to(vec_t{1.0, 0.0}, vec_t{0.0, 1.0}));
+    REQUIRE(is_orthogonal_to(vec_t{1.0, 1.0}, vec_t{1.0, -1.0}));
+    REQUIRE_FALSE(is_orthogonal_to(vec_t{1.0, 0.0}, vec_t{1.0, 1.0}));
+    // Scale invariance of the relative test.
+    REQUIRE(is_orthogonal_to(vec_t{1e6, 0.0}, vec_t{0.0, 1e-6}));
+    // A zero vector is orthogonal to anything (threshold is 0, dot is 0).
+    REQUIRE(is_orthogonal_to(vec_t{0.0, 0.0}, vec_t{3.0, 4.0}));
+}


### PR DESCRIPTION
Batch 1 of the properties module (#244) — the cheapest, highest-use tier:
runtime predicate queries that scan elements and need **no factorization**
(O(n) dense / O(nnz) sparse).

## New API — `namespace mtl`, free functions

**Matrix** (`operation/matrix_properties.hpp`)
- `is_square`, `is_empty`
- `is_symmetric`, `is_hermitian`
- `is_upper_triangular`, `is_lower_triangular`, `is_triangular`
- `is_diagonal`, `is_banded(A, kl, ku)`
- `is_diagonally_dominant(A[, strict])`

**Vector** (`operation/vector_properties.hpp`)
- `is_zero`
- `is_finite`, `has_nan`, `has_inf`
- `is_normalized` / `is_unit`, `is_orthogonal_to`

## Tolerance policy

- **Structural checks** (`is_symmetric`, `is_diagonal`, `is_triangular`,
  `is_banded`, `is_zero`, …) take an **absolute** `tol` defaulting to **0**
  (exact-as-constructed). Pass `tol > 0` for an approximate check on a computed
  matrix.
- **Norm-based vector checks** (`is_normalized`, `is_orthogonal_to`) use a
  **relative** tolerance defaulting to **128·eps** — a computed norm / inner
  product is rarely bit-exact. `is_orthogonal_to` uses `|<u,v>| <= tol·‖u‖·‖v‖`,
  so it is scale-free.

## Genericity

All predicates are generic over the `Matrix`/`Vector` concepts, work with
real/complex/custom element types (via `magnitude_t` + the `conj` functor), and
run on dense or sparse `(i,j)` storage. Wired into the `mtl.hpp` umbrella.

## Tests

`tests/unit/operation/test_{matrix,vector}_properties.cpp` — exact/tolerance/
non-square/empty (0×0)/1×1 edge cases; complex hermitian-vs-symmetric;
NaN/Inf; scale-invariant orthogonality. Both green locally; full suite builds
clean.

## Scope note

This is phase 1 of 4 in #244. Follow-ups: factorization-backed booleans
(`is_spd`, `is_singular`, `determinant`), spectral/condition/rank
(`condition_number`, `numerical_rank`, `spectral_radius`), and tensor predicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added matrix property predicate functions covering shape checks (square/empty), symmetry and Hermitian structure, triangular/diagonal classification, bandedness, and diagonal dominance.
  - Added vector property predicate functions for zero, finiteness, detecting NaN/Inf, unit/normalized checks, and orthogonality.
  - Exposed the new operations via the primary umbrella include.

- **Tests**
  - Added unit tests for matrix and vector predicates, including tolerance behavior, complex conjugation handling, and ensuring NaN values cause structural checks to fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->