### PR TITLE
feat(operation): factorization-backed matrix predicates (#244 batch 2)

### DIFF
--- a/include/mtl/mtl.hpp
+++ b/include/mtl/mtl.hpp
@@ -186,6 +186,7 @@
 #include <mtl/operation/cholesky.hpp>
 #include <mtl/operation/ldlt.hpp>
 #include <mtl/operation/ldlt_bk.hpp>
+#include <mtl/operation/factorization_properties.hpp>
 #include <mtl/operation/inv.hpp>
 #include <mtl/operation/hessenberg.hpp>
 #include <mtl/operation/eigenvalue_symmetric.hpp>

--- a/include/mtl/operation/factorization_properties.hpp
+++ b/include/mtl/operation/factorization_properties.hpp
@@ -1,0 +1,96 @@
+#pragma once
+// MTL5 -- Factorization-backed matrix property queries (#244, batch 2):
+// is_spd / is_positive_definite, is_singular / is_nonsingular / is_invertible,
+// determinant.
+//
+// These wrap the existing dense factorizations (cholesky_factor, lu_factor).
+// They are O(n^3): each runs a factorization on a COPY of A (the factor
+// routines are destructive), so the caller's matrix is left unchanged. Intended
+// for dense, square matrices with a value type usable by those factorizations.
+#include <cmath>
+#include <vector>
+
+#include <mtl/concepts/matrix.hpp>
+#include <mtl/concepts/magnitude.hpp>
+#include <mtl/math/identity.hpp>
+#include <mtl/operation/cholesky.hpp>
+#include <mtl/operation/lu.hpp>
+#include <mtl/operation/matrix_properties.hpp>   // is_symmetric
+
+namespace mtl {
+
+/// Symmetric positive definite: A is symmetric (within sym_tol, default exact)
+/// and its Cholesky factorization exists (every pivot strictly positive).
+/// Non-square matrices are never SPD. Runs Cholesky on a copy; O(n^3).
+template <Matrix M>
+bool is_spd(const M& A, magnitude_t<typename M::value_type> sym_tol = 0) {
+    if (A.num_rows() != A.num_cols()) return false;
+    if (!is_symmetric(A, sym_tol)) return false;
+    auto work = A;                      // Cholesky is destructive
+    return cholesky_factor(work) == 0;  // 0 => SPD, k+1 => A(k,k) <= 0
+}
+
+/// Alias for is_spd.
+template <Matrix M>
+bool is_positive_definite(const M& A, magnitude_t<typename M::value_type> sym_tol = 0) {
+    return is_spd(A, sym_tol);
+}
+
+/// Singular within tol: the LU factorization has a zero pivot, or the smallest
+/// |U(k,k)| is <= tol (default 0, i.e. an exact zero pivot). Requires a square
+/// matrix. Runs LU on a copy; O(n^3).
+template <Matrix M>
+bool is_singular(const M& A, magnitude_t<typename M::value_type> tol = 0) {
+    using value_type = typename M::value_type;
+    using size_type  = typename M::size_type;
+    using std::abs;
+    const size_type n = A.num_rows();
+    if (A.num_cols() != n) return true;   // non-square: no inverse
+    if (n == 0) return false;             // empty matrix is (vacuously) nonsingular
+    auto work = A;                        // LU is destructive
+    std::vector<size_type> pivot;
+    if (lu_factor(work, pivot) != 0) return true;  // exact zero pivot
+    // No exact zero pivot: flag near-singularity via the smallest |U(k,k)|.
+    auto min_diag = abs(work(0, 0));
+    for (size_type k = 1; k < n; ++k) {
+        auto d = abs(work(k, k));
+        if (d < min_diag) min_diag = d;
+    }
+    return !(min_diag > tol);
+}
+
+/// Complement of is_singular.
+template <Matrix M>
+bool is_nonsingular(const M& A, magnitude_t<typename M::value_type> tol = 0) {
+    return !is_singular(A, tol);
+}
+
+/// Alias for is_nonsingular.
+template <Matrix M>
+bool is_invertible(const M& A, magnitude_t<typename M::value_type> tol = 0) {
+    return is_nonsingular(A, tol);
+}
+
+/// Determinant via LU: sign(permutation) * product of U(k,k). Returns exactly
+/// zero when LU reports a zero pivot (singular). The empty (0x0) determinant is
+/// one by convention. Requires a square matrix. Runs LU on a copy; O(n^3).
+template <Matrix M>
+typename M::value_type determinant(const M& A) {
+    using value_type = typename M::value_type;
+    using size_type  = typename M::size_type;
+    const size_type n = A.num_rows();
+    if (A.num_cols() != n)
+        return math::zero<value_type>();   // non-square: determinant undefined -> 0
+    auto work = A;                          // LU is destructive
+    std::vector<size_type> pivot;
+    if (lu_factor(work, pivot) != 0)
+        return math::zero<value_type>();    // zero pivot => singular
+    value_type det = math::one<value_type>();
+    for (size_type k = 0; k < n; ++k) {
+        det = det * work(k, k);
+        if (pivot[k] != k) det = -det;      // each actual row swap flips the sign
+    }
+    return det;
+}
+
+} // namespace mtl

--- a/tests/unit/operation/test_factorization_properties.cpp
+++ b/tests/unit/operation/test_factorization_properties.cpp
@@ -1,0 +1,124 @@
+// Tests for the factorization-backed matrix property queries (#244, batch 2):
+// is_spd / is_positive_definite, is_singular / is_nonsingular / is_invertible,
+// determinant.
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <vector>
+
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/operation/factorization_properties.hpp>
+#include <mtl/generators/pascal.hpp>
+#include <mtl/generators/randspd.hpp>
+
+using namespace mtl;
+using Catch::Matchers::WithinAbs;
+using Catch::Matchers::WithinRel;
+
+namespace {
+mat::dense2D<double> make(std::initializer_list<std::initializer_list<double>> rows) {
+    const std::size_t m = rows.size();
+    const std::size_t n = rows.begin()->size();
+    mat::dense2D<double> A(m, n);
+    std::size_t i = 0;
+    for (const auto& r : rows) {
+        std::size_t j = 0;
+        for (double v : r) A(i, j++) = v;
+        ++i;
+    }
+    return A;
+}
+} // namespace
+
+TEST_CASE("is_spd: SPD, indefinite, non-symmetric, non-square", "[operation][properties][spd]") {
+    // Tridiagonal SPD (eigenvalues 2 - 2cos(...) > 0), exactly symmetric.
+    auto A = make({{2, -1, 0}, {-1, 2, -1}, {0, -1, 2}});
+    REQUIRE(is_spd(A));
+    REQUIRE(is_positive_definite(A));
+
+    // Symmetric but indefinite (eigenvalues 3, -1).
+    auto Ind = make({{1, 2}, {2, 1}});
+    REQUIRE_FALSE(is_spd(Ind));
+
+    // Symmetric negative definite -> not SPD.
+    auto Neg = make({{-2, 0}, {0, -3}});
+    REQUIRE_FALSE(is_spd(Neg));
+
+    // Non-symmetric (even though it would factor) -> not SPD.
+    auto NS = make({{2, 1}, {0, 2}});
+    REQUIRE_FALSE(is_spd(NS));
+
+    // Non-square -> not SPD.
+    REQUIRE_FALSE(is_spd(mat::dense2D<double>(2, 3)));
+}
+
+TEST_CASE("is_spd: exact Pascal and tolerance on computed SPD", "[operation][properties][spd]") {
+    // Symmetric Pascal matrix: integer, exactly symmetric, SPD.
+    auto P = generators::pascal<double>(5);
+    REQUIRE(is_spd(P));
+
+    // randspd = Q * diag(eig) * Q^T is SPD but only symmetric to rounding, so it
+    // reads asymmetric at the exact default and SPD once sym_tol admits the noise.
+    auto R = generators::randspd<double>(6, std::vector<double>{1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
+    REQUIRE(is_spd(R, 1e-10));
+}
+
+TEST_CASE("is_singular / is_nonsingular / is_invertible", "[operation][properties][singular]") {
+    // Exactly singular (row1 = 0.5*row0): elimination yields an exact zero pivot.
+    auto S = make({{2, 4}, {1, 2}});
+    REQUIRE(is_singular(S));
+    REQUIRE_FALSE(is_nonsingular(S));
+    REQUIRE_FALSE(is_invertible(S));
+
+    // Nonsingular.
+    auto N = make({{2, 1}, {1, 2}});
+    REQUIRE_FALSE(is_singular(N));
+    REQUIRE(is_nonsingular(N));
+    REQUIRE(is_invertible(N));
+
+    // Non-square is treated as singular (no inverse).
+    REQUIRE(is_singular(mat::dense2D<double>(2, 3)));
+
+    // Empty matrix is (vacuously) nonsingular.
+    REQUIRE_FALSE(is_singular(mat::dense2D<double>(0, 0)));
+}
+
+TEST_CASE("is_singular: near-singular tolerance", "[operation][properties][singular]") {
+    // Tiny-but-nonzero pivot: nonsingular at tol 0, singular once tol admits it.
+    auto A = make({{1.0, 0.0}, {0.0, 1e-10}});
+    REQUIRE_FALSE(is_singular(A));          // exact: 1e-10 > 0
+    REQUIRE(is_singular(A, 1e-8));          // within tol -> singular
+}
+
+TEST_CASE("determinant: values, sign, singular, empty", "[operation][properties][determinant]") {
+    REQUIRE_THAT(determinant(make({{1, 2}, {3, 4}})), WithinAbs(-2.0, 1e-12));
+    REQUIRE_THAT(determinant(make({{2, 0}, {0, 3}})), WithinAbs(6.0, 1e-12));
+
+    // Row swap flips the sign: det of the 2x2 exchange matrix is -1.
+    REQUIRE_THAT(determinant(make({{0, 1}, {1, 0}})), WithinAbs(-1.0, 1e-12));
+
+    // 3x3 with a known determinant (-306).
+    auto A = make({{6, 1, 1}, {4, -2, 5}, {2, 8, 7}});
+    REQUIRE_THAT(determinant(A), WithinAbs(-306.0, 1e-9));
+
+    // Triangular: determinant is the product of the diagonal.
+    auto U = make({{2, 5, 9}, {0, 3, 7}, {0, 0, 4}});
+    REQUIRE_THAT(determinant(U), WithinAbs(24.0, 1e-12));
+
+    // Singular -> exactly zero.
+    REQUIRE(determinant(make({{2, 4}, {1, 2}})) == 0.0);
+
+    // Empty (0x0) determinant is 1 by convention.
+    REQUIRE_THAT(determinant(mat::dense2D<double>(0, 0)), WithinAbs(1.0, 1e-15));
+
+    // Pascal matrix has determinant exactly 1.
+    REQUIRE_THAT(determinant(generators::pascal<double>(6)), WithinAbs(1.0, 1e-6));
+}
+
+TEST_CASE("determinant matches the eigenvalue product of randspd", "[operation][properties][determinant]") {
+    std::vector<double> eig{1.0, 2.0, 3.0, 4.0};
+    auto R = generators::randspd<double>(4, eig);
+    double prod = 1.0;
+    for (double e : eig) prod *= e;   // 24
+    REQUIRE_THAT(determinant(R), WithinRel(prod, 1e-9));
+}


### PR DESCRIPTION
Batch 2 of the properties module (#244): predicate/scalar queries backed by the
existing dense factorizations (`cholesky_factor`, `lu_factor`).

## New API — `namespace mtl`, free functions (`operation/factorization_properties.hpp`)

| Function | Backed by | Semantics |
|---|---|---|
| `is_spd(A[, sym_tol])` / `is_positive_definite` | Cholesky | symmetric (within `sym_tol`) **and** Cholesky exists (every pivot > 0) |
| `is_singular(A[, tol])` | LU | LU has a zero pivot, or smallest `\|U(k,k)\|` ≤ `tol` (default 0 = exact zero pivot) |
| `is_nonsingular` / `is_invertible` | LU | complement of `is_singular` |
| `determinant(A)` | LU | `sign(perm) · ∏ U(k,k)`; exactly `0` when singular |

## Behavior

- Each runs a factorization on a **copy** of `A` (the factor routines are
  destructive), so the caller's matrix is unchanged. **O(n³)**, for dense square
  matrices.
- **Edge cases:** non-square is never SPD, is treated as singular, determinant
  `0`; empty (0×0) is nonsingular with determinant `1` (conventions).
- `sym_tol` on `is_spd` defaults to exact (`0`); pass a small tolerance to admit
  the rounding asymmetry of a *computed* SPD matrix (`Q·Λ·Qᵀ`).

## Tests (`test_factorization_properties.cpp`)

- SPD vs indefinite / negative-definite / non-symmetric / non-square.
- Exact **Pascal** matrix (symmetric, SPD, det = 1) and tolerance-admitted
  **randspd**.
- Exact zero-pivot singularity + near-singular via `tol`.
- `determinant` values, **row-swap sign** (exchange matrix → −1), triangular
  product, singular → 0, empty → 1, and `det(randspd)` == eigenvalue product.

## Scope note

Phase 2 of 4 in #244. Deferred from this PR: `inertia` / `is_indefinite` (needs
2×2-block eigen-sign extraction from the Bunch–Kaufman LDLᵀ — better as its own
slice). Next: batch 3 (spectral/condition/rank), batch 4 (tensor predicates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)