### PR TITLE
feat(operation): spectral / condition / rank matrix properties (#244 batch 3)

### DIFF
--- a/include/mtl/mtl.hpp
+++ b/include/mtl/mtl.hpp
@@ -192,6 +192,7 @@
 #include <mtl/operation/eigenvalue_symmetric.hpp>
 #include <mtl/operation/eigenvalue.hpp>
 #include <mtl/operation/svd.hpp>
+#include <mtl/operation/spectral_properties.hpp>
 #include <mtl/operation/kron.hpp>
 #include <mtl/operation/reorder.hpp>
 #include <mtl/operation/transcendental.hpp>

--- a/include/mtl/operation/spectral_properties.hpp
+++ b/include/mtl/operation/spectral_properties.hpp
@@ -1,0 +1,115 @@
+#pragma once
+// MTL5 -- Spectral / condition / rank property queries (#244, batch 3):
+// spectral_radius, condition_number, rcond, numerical_rank, nullity.
+//
+// These wrap the existing dense SVD and eigenvalue solvers (both take A by
+// const reference and copy internally), so the caller's matrix is unchanged.
+// Cost is that of the underlying decomposition (SVD / QR-iteration), for dense
+// matrices with a real floating value type.
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <vector>
+
+#include <mtl/concepts/matrix.hpp>
+#include <mtl/concepts/magnitude.hpp>
+#include <mtl/operation/svd.hpp>
+#include <mtl/operation/eigenvalue.hpp>
+
+namespace mtl {
+
+namespace detail {
+
+// Singular values of A (the diagonal of S from the SVD), length min(m,n),
+// each non-negative. Order is not assumed; callers reduce over the whole set.
+template <Matrix M>
+std::vector<magnitude_t<typename M::value_type>> singular_values(const M& A) {
+    using mag_t = magnitude_t<typename M::value_type>;
+    using size_type = typename M::size_type;
+    using std::abs;
+    const size_type mn = std::min(A.num_rows(), A.num_cols());
+    std::vector<mag_t> sv;
+    sv.reserve(static_cast<std::size_t>(mn));
+    if (mn == 0) return sv;
+    auto [U, S, V] = svd(A);
+    (void)U; (void)V;
+    for (size_type i = 0; i < mn; ++i) sv.push_back(abs(S(i, i)));
+    return sv;
+}
+
+} // namespace detail
+
+/// Spectral radius: max |eigenvalue|. Requires a square matrix; the empty (0x0)
+/// matrix has spectral radius 0.
+template <Matrix M>
+magnitude_t<typename M::value_type> spectral_radius(const M& A) {
+    using mag_t = magnitude_t<typename M::value_type>;
+    using std::abs;
+    if (A.num_rows() == 0) return mag_t(0);
+    auto eigs = eigenvalue(A);
+    mag_t r = mag_t(0);
+    for (typename decltype(eigs)::size_type k = 0; k < eigs.size(); ++k) {
+        mag_t m = abs(eigs(k));
+        if (m > r) r = m;
+    }
+    return r;
+}
+
+/// 2-norm condition number sigma_max / sigma_min. A rank-deficient matrix
+/// (sigma_min == 0) has an infinite condition number. The degenerate empty
+/// matrix returns 1 (a trivial isometry).
+template <Matrix M>
+magnitude_t<typename M::value_type> condition_number(const M& A) {
+    using mag_t = magnitude_t<typename M::value_type>;
+    const auto sv = detail::singular_values(A);
+    if (sv.empty()) return mag_t(1);
+    mag_t smax = sv[0], smin = sv[0];
+    for (mag_t s : sv) { if (s > smax) smax = s; if (s < smin) smin = s; }
+    if (!(smin > mag_t(0))) return std::numeric_limits<mag_t>::infinity();
+    return smax / smin;
+}
+
+/// Reciprocal 2-norm condition number sigma_min / sigma_max, in [0, 1] (0 for a
+/// rank-deficient or zero matrix). Numerically safer than condition_number when
+/// the matrix may be singular. The empty matrix returns 1.
+template <Matrix M>
+magnitude_t<typename M::value_type> rcond(const M& A) {
+    using mag_t = magnitude_t<typename M::value_type>;
+    const auto sv = detail::singular_values(A);
+    if (sv.empty()) return mag_t(1);
+    mag_t smax = sv[0], smin = sv[0];
+    for (mag_t s : sv) { if (s > smax) smax = s; if (s < smin) smin = s; }
+    if (!(smax > mag_t(0))) return mag_t(0);   // zero matrix
+    return smin / smax;
+}
+
+/// Numerical rank: number of singular values above a threshold. The default
+/// threshold is max(m,n) * eps * sigma_max (the standard rank-revealing cutoff);
+/// pass tol to set an explicit absolute threshold on the singular values.
+template <Matrix M>
+std::size_t numerical_rank(const M& A,
+                           magnitude_t<typename M::value_type> tol = -1) {
+    using mag_t = magnitude_t<typename M::value_type>;
+    const auto sv = detail::singular_values(A);
+    if (sv.empty()) return 0;
+    mag_t smax = sv[0];
+    for (mag_t s : sv) if (s > smax) smax = s;
+    mag_t threshold = tol;
+    if (!(tol >= mag_t(0))) {   // negative sentinel -> default cutoff
+        const mag_t dim = static_cast<mag_t>(std::max(A.num_rows(), A.num_cols()));
+        threshold = dim * std::numeric_limits<mag_t>::epsilon() * smax;
+    }
+    std::size_t r = 0;
+    for (mag_t s : sv) if (s > threshold) ++r;
+    return r;
+}
+
+/// Nullity: dimension of the null space = num_cols - numerical_rank.
+template <Matrix M>
+std::size_t nullity(const M& A, magnitude_t<typename M::value_type> tol = -1) {
+    const std::size_t r = numerical_rank(A, tol);
+    const std::size_t ncols = static_cast<std::size_t>(A.num_cols());
+    return ncols > r ? ncols - r : 0;
+}
+
+} // namespace mtl

--- a/include/mtl/operation/spectral_properties.hpp
+++ b/include/mtl/operation/spectral_properties.hpp
@@ -6,6 +6,8 @@
 // const reference and copy internally), so the caller's matrix is unchanged.
 // Cost is that of the underlying decomposition (SVD / QR-iteration), for dense
 // matrices with a real floating value type.
+#include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <cstddef>
 #include <limits>
@@ -25,30 +27,30 @@ namespace detail {
 template <Matrix M>
 std::vector<magnitude_t<typename M::value_type>> singular_values(const M& A) {
     using mag_t = magnitude_t<typename M::value_type>;
-    using size_type = typename M::size_type;
     using std::abs;
-    const size_type mn = std::min(A.num_rows(), A.num_cols());
+    const std::size_t mn = std::min<std::size_t>(A.num_rows(), A.num_cols());
     std::vector<mag_t> sv;
-    sv.reserve(static_cast<std::size_t>(mn));
+    sv.reserve(mn);
     if (mn == 0) return sv;
     auto [U, S, V] = svd(A);
     (void)U; (void)V;
-    for (size_type i = 0; i < mn; ++i) sv.push_back(abs(S(i, i)));
+    for (std::size_t i = 0; i < mn; ++i) sv.push_back(abs(S(i, i)));
     return sv;
 }
 
 } // namespace detail
 
-/// Spectral radius: max |eigenvalue|. Requires a square matrix; the empty (0x0)
-/// matrix has spectral radius 0.
+/// Spectral radius: max |eigenvalue|. Requires a square matrix (precondition,
+/// as for eigenvalue); the empty (0x0) matrix has spectral radius 0.
 template <Matrix M>
 magnitude_t<typename M::value_type> spectral_radius(const M& A) {
     using mag_t = magnitude_t<typename M::value_type>;
     using std::abs;
+    assert(A.num_rows() == A.num_cols() && "spectral_radius requires a square matrix");
     if (A.num_rows() == 0) return mag_t(0);
     auto eigs = eigenvalue(A);
     mag_t r = mag_t(0);
-    for (typename decltype(eigs)::size_type k = 0; k < eigs.size(); ++k) {
+    for (std::size_t k = 0; k < eigs.size(); ++k) {
         mag_t m = abs(eigs(k));
         if (m > r) r = m;
     }
@@ -96,7 +98,7 @@ std::size_t numerical_rank(const M& A,
     for (mag_t s : sv) if (s > smax) smax = s;
     mag_t threshold = tol;
     if (!(tol >= mag_t(0))) {   // negative sentinel -> default cutoff
-        const mag_t dim = static_cast<mag_t>(std::max(A.num_rows(), A.num_cols()));
+        const mag_t dim = static_cast<mag_t>(std::max<std::size_t>(A.num_rows(), A.num_cols()));
         threshold = dim * std::numeric_limits<mag_t>::epsilon() * smax;
     }
     std::size_t r = 0;

--- a/tests/unit/operation/test_spectral_properties.cpp
+++ b/tests/unit/operation/test_spectral_properties.cpp
@@ -1,0 +1,105 @@
+// Tests for the spectral / condition / rank property queries (#244, batch 3):
+// spectral_radius, condition_number, rcond, numerical_rank, nullity.
+//
+// Checks are written to hold for both the LAPACK and the in-house SVD/eigen
+// paths: the in-house SVD yields a tiny-but-nonzero smallest singular value for
+// a singular matrix, so condition_number of a rank-deficient matrix is tested as
+// "very large or infinite" rather than exactly infinite, and rank-deficient rank
+// counts pass an explicit tolerance.
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <cmath>
+#include <vector>
+
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/operation/spectral_properties.hpp>
+#include <mtl/generators/randspd.hpp>
+
+using namespace mtl;
+using Catch::Matchers::WithinAbs;
+using Catch::Matchers::WithinRel;
+
+namespace {
+mat::dense2D<double> make(std::initializer_list<std::initializer_list<double>> rows) {
+    const std::size_t m = rows.size();
+    const std::size_t n = rows.begin()->size();
+    mat::dense2D<double> A(m, n);
+    std::size_t i = 0;
+    for (const auto& r : rows) {
+        std::size_t j = 0;
+        for (double v : r) A(i, j++) = v;
+        ++i;
+    }
+    return A;
+}
+mat::dense2D<double> identity(std::size_t n) {
+    mat::dense2D<double> I(n, n);
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j) I(i, j) = (i == j) ? 1.0 : 0.0;
+    return I;
+}
+} // namespace
+
+TEST_CASE("spectral_radius", "[operation][properties][spectral]") {
+    // Diagonal: radius is max |diag|.
+    REQUIRE_THAT(spectral_radius(make({{2, 0}, {0, -3}})), WithinAbs(3.0, 1e-8));
+    // 2D rotation: eigenvalues +/- i, radius 1.
+    REQUIRE_THAT(spectral_radius(make({{0, -1}, {1, 0}})), WithinAbs(1.0, 1e-8));
+    // SPD: radius is the largest eigenvalue.
+    auto R = generators::randspd<double>(4, std::vector<double>{0.5, 2.0, 3.0, 7.0});
+    REQUIRE_THAT(spectral_radius(R), WithinRel(7.0, 1e-6));
+    // Empty matrix.
+    REQUIRE_THAT(spectral_radius(mat::dense2D<double>(0, 0)), WithinAbs(0.0, 1e-15));
+}
+
+TEST_CASE("condition_number / rcond", "[operation][properties][spectral]") {
+    // Diagonal {10, 1}: sigma = {10, 1}, cond 10, rcond 0.1.
+    auto D = make({{10, 0}, {0, 1}});
+    REQUIRE_THAT(condition_number(D), WithinRel(10.0, 1e-8));
+    REQUIRE_THAT(rcond(D), WithinRel(0.1, 1e-8));
+
+    // Identity is perfectly conditioned.
+    REQUIRE_THAT(condition_number(identity(3)), WithinAbs(1.0, 1e-8));
+    REQUIRE_THAT(rcond(identity(3)), WithinAbs(1.0, 1e-8));
+
+    // SPD with prescribed eigenvalues {1,2,4}: cond = 4, rcond = 0.25.
+    auto R = generators::randspd<double>(3, std::vector<double>{1.0, 2.0, 4.0});
+    REQUIRE_THAT(condition_number(R), WithinRel(4.0, 1e-4));
+    REQUIRE_THAT(rcond(R), WithinRel(0.25, 1e-4));
+
+    // Rank-deficient (rank 1): huge condition number, near-zero rcond.
+    auto S = make({{1, 2}, {2, 4}});
+    REQUIRE(condition_number(S) > 1e6);
+    REQUIRE(rcond(S) < 1e-6);
+
+    // Empty matrix returns 1 (trivial isometry).
+    REQUIRE_THAT(condition_number(mat::dense2D<double>(0, 0)), WithinAbs(1.0, 1e-15));
+}
+
+TEST_CASE("numerical_rank / nullity", "[operation][properties][spectral]") {
+    // Full rank.
+    REQUIRE(numerical_rank(identity(3)) == 3);
+    REQUIRE(nullity(identity(3)) == 0);
+
+    // Rank 2 of 3 (one exactly-zero singular value): explicit tol for robustness.
+    auto A = make({{1, 0, 0}, {0, 1, 0}, {0, 0, 0}});
+    REQUIRE(numerical_rank(A, 1e-8) == 2);
+    REQUIRE(nullity(A, 1e-8) == 1);
+
+    // Rank-1 2x2.
+    auto S = make({{1, 2}, {2, 4}});
+    REQUIRE(numerical_rank(S, 1e-8) == 1);
+    REQUIRE(nullity(S, 1e-8) == 1);
+
+    // Explicit tol below the smallest singular value keeps full rank; a large tol
+    // drops the small ones. Diagonal {4, 1e-3}: rank 2 at tight tol, 1 at loose.
+    auto D = make({{4.0, 0.0}, {0.0, 1e-3}});
+    REQUIRE(numerical_rank(D, 1e-6) == 2);
+    REQUIRE(numerical_rank(D, 1e-2) == 1);
+
+    // Rectangular full column rank: rank = min(m,n) = 2, nullity (cols) = 0.
+    auto T = make({{1, 0}, {0, 1}, {0, 0}});
+    REQUIRE(numerical_rank(T, 1e-8) == 2);
+    REQUIRE(nullity(T, 1e-8) == 0);
+}


### PR DESCRIPTION
Batch 3 of the properties module (#244): numeric queries backed by the existing
dense **SVD** and **eigenvalue** solvers (both copy `A` internally, so the
caller's matrix is unchanged).

## New API — `namespace mtl` (`operation/spectral_properties.hpp`)

| Function | Backed by | Semantics |
|---|---|---|
| `spectral_radius(A)` | eigenvalue | max \|eigenvalue\| |
| `condition_number(A)` | SVD | 2-norm σ_max/σ_min; `+inf` when rank-deficient |
| `rcond(A)` | SVD | reciprocal σ_min/σ_max ∈ [0, 1] (safe when singular) |
| `numerical_rank(A[, tol])` | SVD | count of singular values above a threshold |
| `nullity(A[, tol])` | SVD | `num_cols − numerical_rank` |

**`numerical_rank` threshold:** default cutoff `max(m,n)·eps·σ_max` (the standard
rank-revealing cutoff); pass `tol` for an explicit absolute threshold on the
singular values.

**Edge cases:** empty (0×0) → `spectral_radius` 0, `condition_number`/`rcond` 1;
rectangular ranks reduce over the `min(m,n)` singular values.

## Tests (`test_spectral_properties.cpp`)

- Spectral radius: diagonal, 2-D rotation (±i), SPD (largest eigenvalue), empty.
- Condition number / rcond: diagonal, identity, **randspd** with prescribed
  eigenvalues (cond = 4), rank-deficient (huge cond / near-zero rcond).
- Rank / nullity: full-rank, rank-deficient (zero singular value), tolerance
  sweep, rectangular full-column-rank.

Checks are written to hold on **both** the LAPACK and the in-house SVD/eigen
paths — the rank-deficient condition-number is tested as "very large or infinite"
(the in-house SVD gives a tiny-but-nonzero σ_min) and rank-deficient counts pass
an explicit `tol`. Verified against a `-DMTL5_WITH_LAPACK=ON` build locally.

## Scope note

Phase 3 of 4 in #244. Deferred: `is_orthogonal`/`is_unitary`/`is_normal` (product-
based, different flavor) and `inertia`/`is_indefinite` — a small follow-up slice.
Next: batch 4 (tensor predicates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added matrix spectral/conditioning/rank query functions: spectral radius, condition number, reciprocal condition number, numerical rank, and nullity.
  * Added consistent edge-case behavior for empty and rank-deficient matrices, including tolerance-based rank determination.
  * Made these operations available via the main MTL umbrella include.

* **Tests**
  * Added unit tests validating these queries across diagonal, rotation, SPD, rectangular, empty, and rank-deficient matrices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->