### PR TITLE
feat(tensor): rank-2 tensor symmetry predicates (#244 batch 4)

### DIFF
--- a/include/mtl/mtl.hpp
+++ b/include/mtl/mtl.hpp
@@ -85,6 +85,7 @@
 #include <mtl/tensor/index.hpp>
 #include <mtl/tensor/symmetric.hpp>
 #include <mtl/tensor/metric.hpp>
+#include <mtl/tensor/properties.hpp>
 
 // Scalar functors
 #include <mtl/functor/scalar/plus.hpp>

--- a/include/mtl/tensor/properties.hpp
+++ b/include/mtl/tensor/properties.hpp
@@ -1,0 +1,40 @@
+#pragma once
+// MTL5 -- Rank-2 tensor property predicates (#244, batch 4):
+// is_symmetric, is_antisymmetric.
+//
+// `tol` is an ABSOLUTE threshold on the relevant deviation; the default 0
+// requires exact structure. The tests are written as !(dev <= tol) rather than
+// dev > tol so a NaN component (dev unordered) fails the predicate instead of
+// being silently accepted. Consistent with the matrix property predicates.
+#include <cmath>
+#include <cstddef>
+
+#include <mtl/concepts/magnitude.hpp>
+#include <mtl/tensor/tensor.hpp>
+
+namespace mtl::tensor {
+
+/// Symmetric rank-2 tensor: t(i,j) == t(j,i) (within tol) for all i < j.
+template <typename V, std::size_t D>
+bool is_symmetric(const tensor<V, 2, D>& t, magnitude_t<V> tol = 0) {
+    using std::abs;
+    for (std::size_t i = 0; i < D; ++i)
+        for (std::size_t j = i + 1; j < D; ++j)
+            if (!(abs(t(i, j) - t(j, i)) <= tol)) return false;
+    return true;
+}
+
+/// Antisymmetric (skew) rank-2 tensor: t(i,j) == -t(j,i) (within tol). This
+/// forces a zero diagonal (t(i,i) == -t(i,i)), which is checked explicitly.
+template <typename V, std::size_t D>
+bool is_antisymmetric(const tensor<V, 2, D>& t, magnitude_t<V> tol = 0) {
+    using std::abs;
+    for (std::size_t i = 0; i < D; ++i) {
+        if (!(abs(t(i, i)) <= tol)) return false;               // diagonal must vanish
+        for (std::size_t j = i + 1; j < D; ++j)
+            if (!(abs(t(i, j) + t(j, i)) <= tol)) return false; // t(i,j) == -t(j,i)
+    }
+    return true;
+}
+
+} // namespace mtl::tensor

--- a/tests/unit/tensor/test_tensor_properties.cpp
+++ b/tests/unit/tensor/test_tensor_properties.cpp
@@ -1,0 +1,75 @@
+// Tests for the rank-2 tensor property predicates (#244, batch 4):
+// is_symmetric, is_antisymmetric.
+#include <catch2/catch_test_macros.hpp>
+
+#include <limits>
+
+#include <mtl/tensor/tensor.hpp>
+#include <mtl/tensor/properties.hpp>
+
+using namespace mtl::tensor;
+
+TEST_CASE("tensor is_symmetric", "[tensor][properties]") {
+    tensor<double, 2, 3> S;
+    S(0, 0) = 1; S(0, 1) = 2; S(0, 2) = 3;
+    S(1, 0) = 2; S(1, 1) = 4; S(1, 2) = 5;
+    S(2, 0) = 3; S(2, 1) = 5; S(2, 2) = 6;
+    REQUIRE(is_symmetric(S));
+    REQUIRE_FALSE(is_antisymmetric(S));
+
+    // Break symmetry in one off-diagonal pair.
+    tensor<double, 2, 3> N = S;
+    N(0, 2) = 3.5;
+    REQUIRE_FALSE(is_symmetric(N));
+    REQUIRE(is_symmetric(N, 1.0));   // within a loose tolerance
+
+    // Diagonal tensor is symmetric.
+    tensor<double, 2, 2> D;
+    D(0, 0) = 7; D(1, 1) = -2;
+    REQUIRE(is_symmetric(D));
+}
+
+TEST_CASE("tensor is_antisymmetric", "[tensor][properties]") {
+    // Skew tensor: t(i,j) = -t(j,i), zero diagonal.
+    tensor<double, 2, 3> A;
+    A(0, 1) = 2;  A(1, 0) = -2;
+    A(0, 2) = -3; A(2, 0) = 3;
+    A(1, 2) = 1;  A(2, 1) = -1;
+    REQUIRE(is_antisymmetric(A));
+    REQUIRE_FALSE(is_symmetric(A));
+
+    // A non-zero diagonal breaks antisymmetry even if off-diagonals are skew.
+    tensor<double, 2, 2> B;
+    B(0, 0) = 1;              // must be zero for skew
+    B(0, 1) = 5; B(1, 0) = -5;
+    REQUIRE_FALSE(is_antisymmetric(B));
+
+    // The zero tensor is both symmetric and antisymmetric.
+    tensor<double, 2, 3> Z;
+    REQUIRE(is_symmetric(Z));
+    REQUIRE(is_antisymmetric(Z));
+}
+
+TEST_CASE("tensor predicates are NaN-safe", "[tensor][properties]") {
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+    // NaN off-diagonal makes the deviation unordered; must fail at any tolerance.
+    tensor<double, 2, 2> S;
+    S(0, 0) = 1; S(0, 1) = nan; S(1, 0) = 2; S(1, 1) = 1;
+    REQUIRE_FALSE(is_symmetric(S));
+    REQUIRE_FALSE(is_symmetric(S, 1e6));
+
+    tensor<double, 2, 2> A;
+    A(0, 1) = nan; A(1, 0) = -1;
+    REQUIRE_FALSE(is_antisymmetric(A));
+}
+
+TEST_CASE("tensor 1D degenerate case", "[tensor][properties]") {
+    // A 1x1 rank-2 tensor: symmetric always; antisymmetric iff the sole
+    // (diagonal) component is zero.
+    tensor<double, 2, 1> t;
+    t(0, 0) = 5;
+    REQUIRE(is_symmetric(t));
+    REQUIRE_FALSE(is_antisymmetric(t));
+    t(0, 0) = 0;
+    REQUIRE(is_antisymmetric(t));
+}


### PR DESCRIPTION
Final batch of the properties module (#244) — closes the tensor predicate gap
(the `symmetric_tensor`/`antisymmetric_tensor` storage *types* existed, but there
were no predicates to test an arbitrary rank-2 tensor).

## New API — `namespace mtl::tensor` (`tensor/properties.hpp`)

| Function | Semantics |
|---|---|
| `is_symmetric(t[, tol])` | `t(i,j) == t(j,i)` within tol, for all `i < j` |
| `is_antisymmetric(t[, tol])` | `t(i,j) == -t(j,i)` within tol, **plus** an explicit zero-diagonal check (skew forces `t(i,i) == 0`) |

Both take an absolute `tol` (default `0` = exact) and use the NaN-safe
`!(dev <= tol)` form, consistent with the matrix property predicates.

## Tests (`test_tensor_properties.cpp`)

Symmetric / skew / diagonal / zero tensors (the zero tensor is both), the
non-zero-diagonal antisymmetry break, NaN safety, and the 1×1 degenerate case.

## Module complete

This finishes the 4-batch properties module #244:
1. structural + vector predicates (#245)
2. factorization-backed booleans + determinant (#246)
3. spectral / condition / rank (#247)
4. tensor predicates (this PR)

Remaining follow-ups tracked on #244: `is_orthogonal`/`is_unitary`/`is_normal`
and `inertia`/`is_indefinite` — a small optional slice, not part of the original
4-phase plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)