### PR TITLE
feat(operation): orthogonality + inertia predicates (#244 follow-up)

### DIFF
--- a/include/mtl/operation/matrix_properties.hpp
+++ b/include/mtl/operation/matrix_properties.hpp
@@ -11,11 +11,14 @@
 // The deviation tests are written as !(dev <= tol) rather than dev > tol so a
 // NaN entry (dev is NaN, all comparisons unordered) fails the predicate instead
 // of being silently accepted.
+#include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <limits>
 
 #include <mtl/concepts/matrix.hpp>
 #include <mtl/concepts/magnitude.hpp>
+#include <mtl/math/identity.hpp>
 #include <mtl/functor/scalar/conj.hpp>
 
 namespace mtl {
@@ -131,6 +134,83 @@ bool is_diagonally_dominant(const M& A, bool strict = false) {
         const mag_t d = abs(A(i, i));
         if (strict ? !(d > off) : !(d >= off)) return false;
     }
+    return true;
+}
+
+namespace detail {
+
+// Scale-aware default threshold for the O(n^3) product-based predicates
+// (is_unitary / is_normal). The residual entries scale like n * max|A|^2, so the
+// default relative tolerance is multiplied by that magnitude. A negative caller
+// tol selects this default; a non-negative tol is used verbatim (absolute).
+template <Matrix M>
+magnitude_t<typename M::value_type> product_tol(const M& A,
+                                                magnitude_t<typename M::value_type> tol) {
+    using mag_t = magnitude_t<typename M::value_type>;
+    if (tol >= mag_t(0)) return tol;
+    using std::abs;
+    using size_type = typename M::size_type;
+    const size_type m = A.num_rows(), n = A.num_cols();
+    mag_t scale = mag_t(0);
+    for (size_type i = 0; i < m; ++i)
+        for (size_type j = 0; j < n; ++j)
+            scale = std::max(scale, abs(A(i, j)));
+    const mag_t nn = static_cast<mag_t>(std::max(m, n));
+    return mag_t(128) * std::numeric_limits<mag_t>::epsilon() * nn * scale * scale;
+}
+
+} // namespace detail
+
+/// Unitary: A is square and A^H A == I (within tol). For a real element type
+/// A^H = A^T, i.e. this is the orthogonality test. The default tol is a
+/// scale-aware relative threshold (~128 * n * eps * max|A|^2); pass tol >= 0 for
+/// an explicit absolute threshold. Non-square matrices are never unitary.
+template <Matrix M>
+bool is_unitary(const M& A, magnitude_t<typename M::value_type> tol = -1) {
+    using T = typename M::value_type;
+    using size_type = typename M::size_type;
+    using std::abs;
+    if (A.num_rows() != A.num_cols()) return false;
+    const size_type n = A.num_rows();
+    const auto thr = detail::product_tol(A, tol);
+    for (size_type i = 0; i < n; ++i)
+        for (size_type j = i; j < n; ++j) {         // (A^H A) is Hermitian
+            T s = math::zero<T>();
+            for (size_type k = 0; k < n; ++k)
+                s += functor::scalar::conj<T>::apply(A(k, i)) * A(k, j);
+            const T expected = (i == j) ? math::one<T>() : math::zero<T>();
+            if (!(abs(s - expected) <= thr)) return false;
+        }
+    return true;
+}
+
+/// Orthogonal: alias for is_unitary (conventional name for real matrices).
+template <Matrix M>
+bool is_orthogonal(const M& A, magnitude_t<typename M::value_type> tol = -1) {
+    return is_unitary(A, tol);
+}
+
+/// Normal: A is square and A A^H == A^H A (within tol) -- the class of matrices
+/// unitarily diagonalizable, containing the symmetric/Hermitian, skew, and
+/// unitary matrices. Default tol as for is_unitary. Non-square is never normal.
+template <Matrix M>
+bool is_normal(const M& A, magnitude_t<typename M::value_type> tol = -1) {
+    using T = typename M::value_type;
+    using size_type = typename M::size_type;
+    using std::abs;
+    if (A.num_rows() != A.num_cols()) return false;
+    const size_type n = A.num_rows();
+    const auto thr = detail::product_tol(A, tol);
+    for (size_type i = 0; i < n; ++i)
+        for (size_type j = i; j < n; ++j) {         // residual A A^H - A^H A is Hermitian
+            T aah = math::zero<T>();                 // (A A^H)_{ij} = sum_k A(i,k) conj(A(j,k))
+            T aha = math::zero<T>();                 // (A^H A)_{ij} = sum_k conj(A(k,i)) A(k,j)
+            for (size_type k = 0; k < n; ++k) {
+                aah += A(i, k) * functor::scalar::conj<T>::apply(A(j, k));
+                aha += functor::scalar::conj<T>::apply(A(k, i)) * A(k, j);
+            }
+            if (!(abs(aah - aha) <= thr)) return false;
+        }
     return true;
 }
 

--- a/include/mtl/operation/spectral_properties.hpp
+++ b/include/mtl/operation/spectral_properties.hpp
@@ -17,6 +17,7 @@
 #include <mtl/concepts/magnitude.hpp>
 #include <mtl/operation/svd.hpp>
 #include <mtl/operation/eigenvalue.hpp>
+#include <mtl/operation/eigenvalue_symmetric.hpp>
 
 namespace mtl {
 
@@ -112,6 +113,49 @@ std::size_t nullity(const M& A, magnitude_t<typename M::value_type> tol = -1) {
     const std::size_t r = numerical_rank(A, tol);
     const std::size_t ncols = static_cast<std::size_t>(A.num_cols());
     return ncols > r ? ncols - r : 0;
+}
+
+/// Inertia of a symmetric matrix: the counts (positive, negative, zero) of its
+/// eigenvalues. By Sylvester's law of inertia this triple is invariant under
+/// congruence, so it is the definiteness fingerprint of A: (n,0,0) positive
+/// definite, (0,n,0) negative definite, zero > 0 singular, and positive>0 &&
+/// negative>0 indefinite. Computed from the symmetric eigenvalues; an eigenvalue
+/// is classified zero when |lambda| <= tol (default max|lambda| * n * eps; pass
+/// tol for an explicit cutoff). Precondition: A is real symmetric.
+struct inertia_t {
+    std::size_t positive = 0;
+    std::size_t negative = 0;
+    std::size_t zero     = 0;
+};
+
+template <Matrix M>
+inertia_t inertia(const M& A, magnitude_t<typename M::value_type> tol = -1) {
+    using mag_t = magnitude_t<typename M::value_type>;
+    using std::abs;
+    inertia_t result;
+    if (A.num_rows() == 0) return result;
+    auto eigs = eigenvalue_symmetric(A);   // ascending real eigenvalues
+    mag_t maxabs = mag_t(0);
+    for (std::size_t i = 0; i < eigs.size(); ++i)
+        maxabs = std::max(maxabs, abs(eigs(i)));
+    mag_t threshold = tol;
+    if (!(tol >= mag_t(0)))
+        threshold = static_cast<mag_t>(eigs.size()) *
+                    std::numeric_limits<mag_t>::epsilon() * maxabs;
+    for (std::size_t i = 0; i < eigs.size(); ++i) {
+        const mag_t l = eigs(i);
+        if (l > threshold)       ++result.positive;
+        else if (l < -threshold) ++result.negative;
+        else                     ++result.zero;
+    }
+    return result;
+}
+
+/// Indefinite: a symmetric matrix with both positive and negative eigenvalues.
+template <Matrix M>
+bool is_indefinite(const M& A, magnitude_t<typename M::value_type> tol = -1) {
+    const inertia_t in = inertia(A, tol);
+    return in.positive > 0 && in.negative > 0;
 }
 
 } // namespace mtl

--- a/tests/unit/operation/test_matrix_properties.cpp
+++ b/tests/unit/operation/test_matrix_properties.cpp
@@ -3,12 +3,14 @@
 // is_diagonal, is_banded, is_diagonally_dominant.
 #include <catch2/catch_test_macros.hpp>
 
+#include <cmath>
 #include <complex>
 #include <limits>
 
 #include <mtl/mat/dense2D.hpp>
 #include <mtl/vec/dense_vector.hpp>
 #include <mtl/operation/matrix_properties.hpp>
+#include <mtl/generators/randorth.hpp>
 
 using namespace mtl;
 using cd = std::complex<double>;
@@ -142,4 +144,45 @@ TEST_CASE("is_diagonally_dominant", "[operation][properties][matrix]") {
     REQUIRE_FALSE(is_diagonally_dominant(N));
     // Non-square is never dominant.
     REQUIRE_FALSE(is_diagonally_dominant(mat::dense2D<double>(2, 3)));
+}
+
+TEST_CASE("is_orthogonal / is_unitary", "[operation][properties][orthogonal]") {
+    // Identity and permutation are exactly orthogonal.
+    auto I = make({{1, 0, 0}, {0, 1, 0}, {0, 0, 1}});
+    REQUIRE(is_orthogonal(I));
+    REQUIRE(is_orthogonal(make({{0, 1}, {1, 0}})));
+
+    // Rotation matrix (orthogonal within rounding).
+    const double th = 0.7;
+    auto R = make({{std::cos(th), -std::sin(th)}, {std::sin(th), std::cos(th)}});
+    REQUIRE(is_orthogonal(R));
+
+    // Non-orthogonal (columns not unit / not perpendicular).
+    REQUIRE_FALSE(is_orthogonal(make({{1, 1}, {0, 1}})));
+    // Scaled identity: orthogonal columns but not unit norm.
+    REQUIRE_FALSE(is_orthogonal(make({{2, 0}, {0, 2}})));
+    // Non-square is never orthogonal.
+    REQUIRE_FALSE(is_orthogonal(mat::dense2D<double>(3, 2)));
+
+    // A random orthogonal matrix (Q from QR) passes at the default tolerance.
+    REQUIRE(is_orthogonal(generators::randorth<double>(6)));
+
+    // Complex unitary: diag(i, 1) has A^H A = I.
+    mat::dense2D<cd> U(2, 2);
+    U(0, 0) = cd(0, 1); U(0, 1) = cd(0, 0);
+    U(1, 0) = cd(0, 0); U(1, 1) = cd(1, 0);
+    REQUIRE(is_unitary(U));
+}
+
+TEST_CASE("is_normal", "[operation][properties][normal]") {
+    // Symmetric, skew-symmetric, orthogonal, and diagonal matrices are normal.
+    REQUIRE(is_normal(make({{1, 2, 3}, {2, 4, 5}, {3, 5, 6}})));   // symmetric
+    REQUIRE(is_normal(make({{0, 1}, {-1, 0}})));                   // skew
+    REQUIRE(is_normal(make({{0, 1}, {1, 0}})));                    // orthogonal
+    REQUIRE(is_normal(make({{5, 0}, {0, -2}})));                   // diagonal
+
+    // A generic non-symmetric matrix is not normal (A A^T != A^T A).
+    REQUIRE_FALSE(is_normal(make({{1, 1}, {0, 1}})));
+    // Non-square is never normal.
+    REQUIRE_FALSE(is_normal(mat::dense2D<double>(2, 3)));
 }

--- a/tests/unit/operation/test_spectral_properties.cpp
+++ b/tests/unit/operation/test_spectral_properties.cpp
@@ -103,3 +103,42 @@ TEST_CASE("numerical_rank / nullity", "[operation][properties][spectral]") {
     REQUIRE(numerical_rank(T, 1e-8) == 2);
     REQUIRE(nullity(T, 1e-8) == 0);
 }
+
+TEST_CASE("inertia / is_indefinite", "[operation][properties][inertia]") {
+    // SPD: all eigenvalues positive -> (n, 0, 0), not indefinite.
+    auto SPD = make({{2, -1, 0}, {-1, 2, -1}, {0, -1, 2}});
+    auto iSPD = inertia(SPD);
+    REQUIRE(iSPD.positive == 3);
+    REQUIRE(iSPD.negative == 0);
+    REQUIRE(iSPD.zero == 0);
+    REQUIRE_FALSE(is_indefinite(SPD));
+
+    // Indefinite: eigenvalues 3 and -1 -> (1, 1, 0).
+    auto Ind = make({{1, 2}, {2, 1}});
+    auto iInd = inertia(Ind);
+    REQUIRE(iInd.positive == 1);
+    REQUIRE(iInd.negative == 1);
+    REQUIRE(is_indefinite(Ind));
+
+    // Negative definite -> (0, n, 0).
+    auto Neg = make({{-2, 0}, {0, -3}});
+    auto iNeg = inertia(Neg);
+    REQUIRE(iNeg.positive == 0);
+    REQUIRE(iNeg.negative == 2);
+    REQUIRE_FALSE(is_indefinite(Neg));
+
+    // Semidefinite / singular with mixed signs: diag(3, -1, 0) -> (1, 1, 1).
+    // Explicit tol for robust zero classification on the in-house eigensolver.
+    auto Mix = make({{3, 0, 0}, {0, -1, 0}, {0, 0, 0}});
+    auto iMix = inertia(Mix, 1e-8);
+    REQUIRE(iMix.positive == 1);
+    REQUIRE(iMix.negative == 1);
+    REQUIRE(iMix.zero == 1);
+    REQUIRE(is_indefinite(Mix, 1e-8));   // has both + and - eigenvalues
+
+    // Empty matrix: all counts zero.
+    auto iEmpty = inertia(mat::dense2D<double>(0, 0));
+    REQUIRE(iEmpty.positive == 0);
+    REQUIRE(iEmpty.negative == 0);
+    REQUIRE(iEmpty.zero == 0);
+}


### PR DESCRIPTION
The optional follow-up slice for the properties module (#244), beyond the four
planned batches — the last predicates named on that issue.

## New API — `namespace mtl`

**Product-based (`operation/matrix_properties.hpp`, O(n³))**

| Function | Semantics |
|---|---|
| `is_unitary(A[, tol])` / `is_orthogonal` | A square and `Aᴴ A == I` (`Aᵀ A` for real) |
| `is_normal(A[, tol])` | A square and `A Aᴴ == Aᴴ A` — the unitarily-diagonalizable class (contains symmetric/Hermitian, skew, and unitary) |

Default tolerance is **scale-aware relative** (~`128·n·eps·max\|A\|²`, since the
residual entries scale with the matrix magnitude); pass `tol ≥ 0` for an explicit
absolute threshold.

**Inertia (`operation/spectral_properties.hpp`)**

| Function | Semantics |
|---|---|
| `inertia(A[, tol])` → `inertia_t{positive, negative, zero}` | eigenvalue-sign counts of a symmetric matrix |
| `is_indefinite(A[, tol])` | inertia has both positive and negative eigenvalues |

**What inertia is:** the triple `(n₊, n₋, n₀)` of positive / negative / zero
eigenvalue counts of a symmetric matrix. By **Sylvester's law of inertia** it is
invariant under congruence (`A → SᵀAS`), so it's the definiteness fingerprint:
`(n,0,0)` positive definite, `(0,n,0)` negative definite, `n₀>0` singular,
`n₊>0 ∧ n₋>0` indefinite.

## Design note

`inertia` is backed by the **symmetric eigensolver** rather than by decoding the
Bunch–Kaufman `LDLᵀ` D-blocks. Sylvester's law guarantees the same triple either
way, and the eigenvalue route is robust for singular/semidefinite inputs (a zero
eigenvalue is classified by tolerance) where the BK factor would early-return on a
zero pivot. An eigenvalue is counted zero when `|λ| ≤ tol` (default `max|λ|·n·eps`;
pass `tol` for the in-house eigensolver's looser accuracy floor).

## Tests

- `is_orthogonal`: identity / permutation / rotation / **randorth**, complex
  unitary, and non-orthogonal / scaled / non-square rejections.
- `is_normal`: symmetric / skew / orthogonal / diagonal accepted, generic
  non-symmetric and non-square rejected.
- `inertia` / `is_indefinite`: SPD `(3,0,0)`, indefinite `(1,1,0)`, negative
  definite `(0,2,0)`, mixed-singular `(1,1,1)` with explicit tol, empty.

Verified on **both** the in-house and LAPACK eigen/QR paths.

Closes the follow-up items tracked on #244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)