### PR TITLE
feat(io): from-first-principles PNG writer (#252 batch 1)

### DIFF
--- a/include/mtl/io/png.hpp
+++ b/include/mtl/io/png.hpp
@@ -1,0 +1,183 @@
+#pragma once
+// MTL5 -- Minimal, dependency-free PNG writer (#252, batch 1).
+//
+// Implements the PNG container from first principles -- no libpng, no zlib:
+//   * 8-byte signature + length-tagged chunks (IHDR / IDAT / IEND), each with a
+//     CRC-32 (PNG polynomial) over its type+data.
+//   * IDAT carries a zlib stream whose DEFLATE payload uses only *stored*
+//     (uncompressed) blocks, followed by an Adler-32 checksum. Correct framing
+//     and the two checksums are all a conforming decoder needs -- no compressor.
+//   * 8-bit grayscale (color type 0) and 8-bit RGB (color type 2); each scanline
+//     is prefixed with filter byte 0 (None), per the PNG spec.
+//
+// PNG multi-byte integers are big-endian; DEFLATE stored-block LEN/NLEN are
+// little-endian. Bytes are written through a binary std::ofstream.
+#include <array>
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace mtl::io {
+
+namespace detail {
+
+/// CRC-32 lookup table (reflected polynomial 0xEDB88320), built once.
+inline const std::array<std::uint32_t, 256>& crc32_table() {
+    static const std::array<std::uint32_t, 256> table = [] {
+        std::array<std::uint32_t, 256> t{};
+        for (std::uint32_t n = 0; n < 256; ++n) {
+            std::uint32_t c = n;
+            for (int k = 0; k < 8; ++k)
+                c = (c & 1u) ? (0xEDB88320u ^ (c >> 1)) : (c >> 1);
+            t[n] = c;
+        }
+        return t;
+    }();
+    return table;
+}
+
+/// Fold bytes into a running CRC-32 register (internal, pre-inverted form:
+/// start from 0xFFFFFFFF and XOR 0xFFFFFFFF once at the end).
+inline std::uint32_t crc32_add(std::uint32_t crc, const std::uint8_t* buf, std::size_t len) {
+    const auto& t = crc32_table();
+    for (std::size_t i = 0; i < len; ++i)
+        crc = t[(crc ^ buf[i]) & 0xFFu] ^ (crc >> 8);
+    return crc;
+}
+
+/// Adler-32 (zlib checksum) of a byte buffer.
+inline std::uint32_t adler32(const std::uint8_t* data, std::size_t len) {
+    constexpr std::uint32_t MOD = 65521u;   // largest prime < 2^16
+    std::uint32_t a = 1, b = 0;
+    std::size_t i = 0;
+    while (i < len) {
+        // 5552 is the most iterations before (a,b) can overflow 32 bits.
+        const std::size_t n = std::min<std::size_t>(len - i, 5552);
+        for (std::size_t j = 0; j < n; ++j) { a += data[i + j]; b += a; }
+        a %= MOD; b %= MOD;
+        i += n;
+    }
+    return (b << 16) | a;
+}
+
+inline void put_u32_be(std::vector<std::uint8_t>& v, std::uint32_t x) {
+    v.push_back(std::uint8_t((x >> 24) & 0xFF));
+    v.push_back(std::uint8_t((x >> 16) & 0xFF));
+    v.push_back(std::uint8_t((x >> 8) & 0xFF));
+    v.push_back(std::uint8_t(x & 0xFF));
+}
+
+/// Wrap raw bytes into a zlib stream of DEFLATE *stored* blocks (no compression).
+inline std::vector<std::uint8_t> zlib_store(const std::vector<std::uint8_t>& raw) {
+    std::vector<std::uint8_t> out;
+    out.push_back(0x78);   // zlib CMF: CM=8 (deflate), CINFO=7 (32K window)
+    out.push_back(0x01);   // zlib FLG: FCHECK so (CMF*256+FLG) % 31 == 0, no dict
+    const std::size_t n = raw.size();
+    std::size_t i = 0;
+    if (n == 0) {                          // one empty, final stored block
+        out.push_back(0x01);
+        out.push_back(0x00); out.push_back(0x00);   // LEN  = 0
+        out.push_back(0xFF); out.push_back(0xFF);   // NLEN = ~0
+    }
+    while (i < n) {
+        const std::size_t block = std::min<std::size_t>(n - i, 65535);
+        const bool final = (i + block >= n);
+        out.push_back(final ? 0x01 : 0x00);         // BFINAL + BTYPE=00 (stored)
+        const std::uint16_t len  = static_cast<std::uint16_t>(block);
+        const std::uint16_t nlen = static_cast<std::uint16_t>(~len);
+        out.push_back(std::uint8_t(len & 0xFF));  out.push_back(std::uint8_t((len >> 8) & 0xFF));
+        out.push_back(std::uint8_t(nlen & 0xFF)); out.push_back(std::uint8_t((nlen >> 8) & 0xFF));
+        out.insert(out.end(), raw.begin() + i, raw.begin() + i + block);
+        i += block;
+    }
+    put_u32_be(out, adler32(raw.data(), raw.size()));
+    return out;
+}
+
+/// Write one PNG chunk: length (BE) + type + data + CRC-32(type+data).
+inline void write_chunk(std::ofstream& os, const char type[4],
+                        const std::vector<std::uint8_t>& data) {
+    const std::uint32_t n = static_cast<std::uint32_t>(data.size());
+    const std::uint8_t len[4] = {
+        std::uint8_t((n >> 24) & 0xFF), std::uint8_t((n >> 16) & 0xFF),
+        std::uint8_t((n >> 8) & 0xFF),  std::uint8_t(n & 0xFF)
+    };
+    os.write(reinterpret_cast<const char*>(len), 4);
+    os.write(type, 4);
+    if (!data.empty())
+        os.write(reinterpret_cast<const char*>(data.data()),
+                 static_cast<std::streamsize>(data.size()));
+
+    std::uint32_t crc = 0xFFFFFFFFu;
+    crc = crc32_add(crc, reinterpret_cast<const std::uint8_t*>(type), 4);
+    if (!data.empty()) crc = crc32_add(crc, data.data(), data.size());
+    crc ^= 0xFFFFFFFFu;
+    const std::uint8_t crcb[4] = {
+        std::uint8_t((crc >> 24) & 0xFF), std::uint8_t((crc >> 16) & 0xFF),
+        std::uint8_t((crc >> 8) & 0xFF),  std::uint8_t(crc & 0xFF)
+    };
+    os.write(reinterpret_cast<const char*>(crcb), 4);
+}
+
+/// Core writer: `channels` is 1 (grayscale) or 3 (RGB); `pixels` is row-major,
+/// w*h*channels bytes, top row first.
+inline void write_png(const std::filesystem::path& path, const std::uint8_t* pixels,
+                      std::size_t w, std::size_t h, int channels) {
+    if (w == 0 || h == 0)
+        throw std::runtime_error("write_png: zero image dimension");
+    if (channels != 1 && channels != 3)
+        throw std::runtime_error("write_png: channels must be 1 (gray) or 3 (RGB)");
+
+    std::ofstream os(path, std::ios::binary);
+    if (!os)
+        throw std::runtime_error("write_png: cannot open file: " + path.string());
+
+    static const std::uint8_t signature[8] = {137, 80, 78, 71, 13, 10, 26, 10};
+    os.write(reinterpret_cast<const char*>(signature), 8);
+
+    std::vector<std::uint8_t> ihdr;
+    put_u32_be(ihdr, static_cast<std::uint32_t>(w));
+    put_u32_be(ihdr, static_cast<std::uint32_t>(h));
+    ihdr.push_back(8);                                  // bit depth
+    ihdr.push_back(channels == 1 ? std::uint8_t(0) : std::uint8_t(2)); // 0 gray, 2 RGB
+    ihdr.push_back(0);                                  // compression method (deflate)
+    ihdr.push_back(0);                                  // filter method
+    ihdr.push_back(0);                                  // interlace (none)
+    write_chunk(os, "IHDR", ihdr);
+
+    // Assemble the raw scanline stream: one filter byte (0 = None) per row.
+    const std::size_t stride = w * static_cast<std::size_t>(channels);
+    std::vector<std::uint8_t> raw;
+    raw.reserve(h * (1 + stride));
+    for (std::size_t y = 0; y < h; ++y) {
+        raw.push_back(0);
+        const std::uint8_t* row = pixels + y * stride;
+        raw.insert(raw.end(), row, row + stride);
+    }
+    write_chunk(os, "IDAT", zlib_store(raw));
+    write_chunk(os, "IEND", {});
+
+    if (!os)
+        throw std::runtime_error("write_png: write failed: " + path.string());
+}
+
+} // namespace detail
+
+/// Write an 8-bit grayscale PNG. `pixels` is w*h bytes, row-major, top row first.
+inline void write_png_gray(const std::filesystem::path& path,
+                           const std::uint8_t* pixels, std::size_t w, std::size_t h) {
+    detail::write_png(path, pixels, w, h, 1);
+}
+
+/// Write an 8-bit RGB PNG. `rgb` is w*h*3 bytes (R,G,B per pixel), row-major.
+inline void write_png_rgb(const std::filesystem::path& path,
+                          const std::uint8_t* rgb, std::size_t w, std::size_t h) {
+    detail::write_png(path, rgb, w, h, 3);
+}
+
+} // namespace mtl::io

--- a/include/mtl/mtl.hpp
+++ b/include/mtl/mtl.hpp
@@ -232,6 +232,7 @@
 #include <mtl/io/matrix_market.hpp>
 #include <mtl/io/read_el.hpp>
 #include <mtl/io/write_el.hpp>
+#include <mtl/io/png.hpp>
 
 // Generators -- Test matrix generation facility
 #include <mtl/generators/generators.hpp>

--- a/tests/unit/io/test_png.cpp
+++ b/tests/unit/io/test_png.cpp
@@ -1,0 +1,194 @@
+// Tests for the from-first-principles PNG writer (#252, batch 1).
+// Validates CRC-32 / Adler-32 against known vectors, then round-trips written
+// PNGs by parsing the container, verifying every chunk CRC and the Adler-32,
+// decoding the stored DEFLATE blocks, and comparing pixels.
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include <mtl/io/png.hpp>
+
+using namespace mtl::io;
+
+namespace {
+
+std::uint32_t crc32_of(const std::string& s) {
+    std::uint32_t c = 0xFFFFFFFFu;
+    c = detail::crc32_add(c, reinterpret_cast<const std::uint8_t*>(s.data()), s.size());
+    return c ^ 0xFFFFFFFFu;
+}
+
+std::vector<std::uint8_t> read_file(const std::filesystem::path& p) {
+    std::ifstream in(p, std::ios::binary);
+    return std::vector<std::uint8_t>((std::istreambuf_iterator<char>(in)),
+                                     std::istreambuf_iterator<char>());
+}
+
+std::uint32_t rd_be(const std::vector<std::uint8_t>& b, std::size_t i) {
+    return (std::uint32_t(b[i]) << 24) | (std::uint32_t(b[i + 1]) << 16) |
+           (std::uint32_t(b[i + 2]) << 8) | std::uint32_t(b[i + 3]);
+}
+
+// Minimal PNG decoder for the subset this writer emits (8-bit gray/RGB, filter 0,
+// stored DEFLATE blocks). Verifies chunk CRCs and Adler-32; returns pixels.
+struct Decoded {
+    std::size_t w = 0, h = 0;
+    int channels = 0;
+    std::vector<std::uint8_t> pixels;
+};
+
+Decoded decode_png(const std::vector<std::uint8_t>& f) {
+    static const std::uint8_t sig[8] = {137, 80, 78, 71, 13, 10, 26, 10};
+    REQUIRE(f.size() > 8);
+    for (int i = 0; i < 8; ++i) REQUIRE(f[i] == sig[i]);
+
+    Decoded out;
+    std::vector<std::uint8_t> idat;
+    std::size_t pos = 8;
+    bool seen_iend = false;
+    while (pos + 8 <= f.size()) {
+        const std::uint32_t len = rd_be(f, pos);
+        const char* type = reinterpret_cast<const char*>(&f[pos + 4]);
+        const std::string ctype(type, 4);
+        const std::size_t data_at = pos + 8;
+        REQUIRE(data_at + len + 4 <= f.size());
+
+        // Verify chunk CRC over type+data.
+        std::uint32_t crc = 0xFFFFFFFFu;
+        crc = detail::crc32_add(crc, &f[pos + 4], 4);
+        if (len) crc = detail::crc32_add(crc, &f[data_at], len);
+        crc ^= 0xFFFFFFFFu;
+        REQUIRE(crc == rd_be(f, data_at + len));
+
+        if (ctype == "IHDR") {
+            out.w = rd_be(f, data_at);
+            out.h = rd_be(f, data_at + 4);
+            REQUIRE(f[data_at + 8] == 8);                 // bit depth
+            const std::uint8_t color = f[data_at + 9];
+            out.channels = (color == 0) ? 1 : 3;
+            REQUIRE((color == 0 || color == 2));
+        } else if (ctype == "IDAT") {
+            idat.insert(idat.end(), &f[data_at], &f[data_at] + len);
+        } else if (ctype == "IEND") {
+            seen_iend = true;
+        }
+        pos = data_at + len + 4;
+    }
+    REQUIRE(seen_iend);
+
+    // Decode the zlib stream: skip 2-byte header, parse stored blocks, check adler.
+    std::vector<std::uint8_t> raw;
+    std::size_t p = 2;
+    for (;;) {
+        const std::uint8_t hdr = idat[p++];
+        REQUIRE((hdr & 0x06) == 0);                        // BTYPE == 00 (stored)
+        const std::uint32_t blen = std::uint32_t(idat[p]) | (std::uint32_t(idat[p + 1]) << 8);
+        const std::uint32_t nlen = std::uint32_t(idat[p + 2]) | (std::uint32_t(idat[p + 3]) << 8);
+        REQUIRE((blen ^ 0xFFFFu) == nlen);                 // LEN/NLEN complement
+        p += 4;
+        raw.insert(raw.end(), &idat[p], &idat[p] + blen);
+        p += blen;
+        if (hdr & 0x01) break;                             // BFINAL
+    }
+    const std::uint32_t adler = rd_be(idat, p);
+    REQUIRE(adler == detail::adler32(raw.data(), raw.size()));
+
+    // Strip per-scanline filter bytes (all filter 0).
+    const std::size_t stride = out.w * static_cast<std::size_t>(out.channels);
+    REQUIRE(raw.size() == out.h * (1 + stride));
+    out.pixels.reserve(out.h * stride);
+    for (std::size_t y = 0; y < out.h; ++y) {
+        REQUIRE(raw[y * (1 + stride)] == 0);
+        out.pixels.insert(out.pixels.end(),
+                          &raw[y * (1 + stride) + 1], &raw[y * (1 + stride) + 1] + stride);
+    }
+    return out;
+}
+
+std::filesystem::path tmp(const std::string& name) {
+    return std::filesystem::temp_directory_path() / name;
+}
+
+} // namespace
+
+TEST_CASE("crc32 and adler32 match known vectors", "[io][png]") {
+    // Standard CRC-32 of "123456789".
+    REQUIRE(crc32_of("123456789") == 0xCBF43926u);
+    // Standard Adler-32 of "Wikipedia".
+    const std::string w = "Wikipedia";
+    REQUIRE(detail::adler32(reinterpret_cast<const std::uint8_t*>(w.data()), w.size())
+            == 0x11E60398u);
+    // Adler-32 of the empty string is 1.
+    REQUIRE(detail::adler32(nullptr, 0) == 1u);
+}
+
+TEST_CASE("grayscale PNG round-trips", "[io][png]") {
+    const std::size_t w = 4, h = 3;
+    std::vector<std::uint8_t> px(w * h);
+    for (std::size_t i = 0; i < px.size(); ++i) px[i] = std::uint8_t(i * 20);
+
+    const auto path = tmp("mtl5_png_gray.png");
+    write_png_gray(path, px.data(), w, h);
+    const auto dec = decode_png(read_file(path));
+
+    REQUIRE(dec.w == w);
+    REQUIRE(dec.h == h);
+    REQUIRE(dec.channels == 1);
+    REQUIRE(dec.pixels == px);
+    std::filesystem::remove(path);
+}
+
+TEST_CASE("RGB PNG round-trips", "[io][png]") {
+    const std::size_t w = 2, h = 2;
+    std::vector<std::uint8_t> rgb = {
+        255, 0, 0,   0, 255, 0,
+        0, 0, 255,   10, 20, 30
+    };
+    const auto path = tmp("mtl5_png_rgb.png");
+    write_png_rgb(path, rgb.data(), w, h);
+    const auto dec = decode_png(read_file(path));
+
+    REQUIRE(dec.channels == 3);
+    REQUIRE(dec.w == w);
+    REQUIRE(dec.h == h);
+    REQUIRE(dec.pixels == rgb);
+    std::filesystem::remove(path);
+}
+
+TEST_CASE("1x1 PNG", "[io][png]") {
+    std::uint8_t one = 128;
+    const auto path = tmp("mtl5_png_1x1.png");
+    write_png_gray(path, &one, 1, 1);
+    const auto dec = decode_png(read_file(path));
+    REQUIRE(dec.w == 1);
+    REQUIRE(dec.h == 1);
+    REQUIRE(dec.pixels.size() == 1);
+    REQUIRE(dec.pixels[0] == 128);
+    std::filesystem::remove(path);
+}
+
+TEST_CASE("large PNG spans multiple stored blocks", "[io][png]") {
+    // 300x300 gray -> raw = 300*(1+300) = 90300 bytes > 65535 -> multiple blocks.
+    const std::size_t w = 300, h = 300;
+    std::vector<std::uint8_t> px(w * h);
+    for (std::size_t i = 0; i < px.size(); ++i) px[i] = std::uint8_t((i * 7) & 0xFF);
+
+    const auto path = tmp("mtl5_png_large.png");
+    write_png_gray(path, px.data(), w, h);
+    const auto dec = decode_png(read_file(path));
+
+    REQUIRE(dec.w == w);
+    REQUIRE(dec.h == h);
+    REQUIRE(dec.pixels == px);
+    std::filesystem::remove(path);
+}
+
+TEST_CASE("invalid dimensions throw", "[io][png]") {
+    std::uint8_t dummy = 0;
+    REQUIRE_THROWS(write_png_gray(tmp("mtl5_png_bad.png"), &dummy, 0, 1));
+    REQUIRE_THROWS(write_png_gray(tmp("mtl5_png_bad.png"), &dummy, 1, 0));
+}


### PR DESCRIPTION
Batch 1 of the sparse-matrix visualization work (#252): the enabling primitive —
a minimal, **dependency-free PNG encoder** written from first principles, exactly
as the Universal library does its own image output. **No libpng, no zlib.**

## New API — `include/mtl/io/png.hpp` (`namespace mtl::io`)

```cpp
void write_png_gray(const std::filesystem::path&, const std::uint8_t* pixels, w, h); // 8-bit gray
void write_png_rgb (const std::filesystem::path&, const std::uint8_t* rgb,    w, h); // 8-bit RGB
```

## How it works (the "first principles" part)

- **Container** — 8-byte signature + length-tagged `IHDR`/`IDAT`/`IEND` chunks,
  each with a **CRC-32** (PNG polynomial `0xEDB88320`) over its type+data,
  computed from a generated table with a chained register.
- **IDAT is a zlib stream** with **no compressor**: a 2-byte zlib header, DEFLATE
  **stored (uncompressed) blocks** (`BFINAL`+`BTYPE=00`, `LEN`/`NLEN`, literal
  bytes, chunked at 65535), and a trailing **Adler-32**. Correct framing + the two
  checksums are all a conforming decoder needs.
- Scanlines use **filter 0 (None)**; PNG multi-byte fields are **big-endian**,
  DEFLATE `LEN`/`NLEN` **little-endian**; bytes go through a binary `ofstream`.
  Header-only, zero dependencies, cross-platform.

The `detail::` encoder (`png.hpp`) is deliberately independent of any matrix code
so batch 2's `spy()` — and any other heatmap — can render onto it.

## Tests (`tests/unit/io/test_png.cpp`)

- **Checksums vs known vectors** — CRC-32("123456789") = `0xCBF43926`,
  Adler-32("Wikipedia") = `0x11E60398`, Adler-32("") = 1.
- **Round-trip** — gray, RGB, 1×1, and a **300×300** image that spans multiple
  stored blocks; the in-test decoder verifies every chunk CRC and the Adler-32.
- Zero dimensions throw.

## Independent conformance check

Because the round-trip decoder shares my format, I also validated the output with
**third-party decoders** (run during development, not in CI):
- `file(1)` → *"PNG image data, 64 x 48, 8-bit grayscale / 8-bit/color RGB, non-interlaced"*
- Python **`zlib.decompress`** inflates the stored blocks + per-chunk `zlib.crc32` verifies
- **PIL/Pillow** opens both (`L` and `RGB`)

## Scope

Phase 1 of 2 in #252. Batch 2 adds `spy` / `spy_magnitude` / density
down-sampling in `io/spy.hpp` on top of this writer, across
`compressed2D`/`coordinate2D`/`ell_matrix`/`dense2D`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)