### PR TITLE
operation: add sparse CRS dispatch to mult<Accumulator>()

### DIFF
--- a/include/mtl/operation/mult.hpp
+++ b/include/mtl/operation/mult.hpp
@@ -65,10 +65,11 @@ void mult_sparse_crs(const mat::compressed2D<V, P>& A, const VIn& x, VOut& y) {
     const auto& data    = A.ref_data();
     const std::size_t nrows = A.num_rows();
     if constexpr (std::is_void_v<Accumulator>) {
+        using Value = std::common_type_t<V, typename VIn::value_type>;
         for (std::size_t r = 0; r < nrows; ++r) {
             auto acc = math::zero<Result>();
             for (size_type k = starts[r]; k < starts[r + 1]; ++k)
-                acc += static_cast<Result>(data[k]) * static_cast<Result>(x(indices[k]));
+                acc += static_cast<Result>(static_cast<Value>(data[k]) * static_cast<Value>(x(indices[k])));
             y(r) = acc;
         }
     } else {

--- a/include/mtl/operation/mult.hpp
+++ b/include/mtl/operation/mult.hpp
@@ -8,6 +8,7 @@
 #include <mtl/math/identity.hpp>
 #include <mtl/math/accumulator_traits.hpp>
 #include <mtl/interface/dispatch_traits.hpp>
+#include <mtl/mat/compressed2D.hpp>
 #ifdef MTL5_HAS_BLAS
 #include <mtl/interface/blas.hpp>
 #endif
@@ -46,6 +47,38 @@ void mult_generic(const M& A, const VIn& x, VOut& y) {
             for (typename M::size_type c = 0; c < A.num_cols(); ++c) {
                 AT::add_product(acc, static_cast<Value>(A(r, c)), static_cast<Value>(x(c)));
             }
+            y(r) = AT::template value<Result>(acc);
+        }
+    }
+}
+
+/// Sparse CRS mat*vec: y = A * x, iterating only stored nonzeros. Mirrors
+/// mat::operator*(compressed2D, dense_vector)'s traversal but adds
+/// Accumulator support (accumulator_traits), so mixed-precision / quire
+/// accumulation works on sparse matrices too, not just dense ones.
+template <typename Accumulator = void, typename V, typename P, typename VIn, typename VOut>
+void mult_sparse_crs(const mat::compressed2D<V, P>& A, const VIn& x, VOut& y) {
+    using Result = typename VOut::value_type;
+    using size_type = typename mat::compressed2D<V, P>::size_type;
+    const auto& starts  = A.ref_major();
+    const auto& indices = A.ref_minor();
+    const auto& data    = A.ref_data();
+    const std::size_t nrows = A.num_rows();
+    if constexpr (std::is_void_v<Accumulator>) {
+        for (std::size_t r = 0; r < nrows; ++r) {
+            auto acc = math::zero<Result>();
+            for (size_type k = starts[r]; k < starts[r + 1]; ++k)
+                acc += static_cast<Result>(data[k]) * static_cast<Result>(x(indices[k]));
+            y(r) = acc;
+        }
+    } else {
+        using Value = std::common_type_t<V, typename VIn::value_type>;
+        using AT = math::accumulator_traits<Accumulator, Value>;
+        for (std::size_t r = 0; r < nrows; ++r) {
+            Accumulator acc{};
+            AT::clear(acc);
+            for (size_type k = starts[r]; k < starts[r + 1]; ++k)
+                AT::add_product(acc, static_cast<Value>(data[k]), static_cast<Value>(x(indices[k])));
             y(r) = AT::template value<Result>(acc);
         }
     }
@@ -100,7 +133,10 @@ void mult(const M& A, const VIn& x, VOut& y) {
     assert(A.num_cols() == x.size());
     assert(A.num_rows() == y.size());
 
-    if constexpr (!interface::accumulator_allows_blas_v<Accumulator>) {
+    if constexpr (interface::is_compressed2D_v<M>) {
+        detail::mult_sparse_crs<Accumulator>(A, x, y);
+        return;
+    } else if constexpr (!interface::accumulator_allows_blas_v<Accumulator>) {
         detail::mult_generic<Accumulator>(A, x, y);
         return;
     } else {


### PR DESCRIPTION
## Summary

`mult_generic()` (used by `mult<Accumulator>()`) had no `compressed2D` specialization — it always ran the dense O(rows*cols) nested loop, touching every structural zero, regardless of sparsity. This silently regressed every solver routed through `mult<Accumulator>()` on sparse matrices (CG, BiCGSTAB, GMRES), since the old `A * x` code they replaced used `mat::operator*`'s dedicated sparse CRS overload (`operators.hpp`, iterates only stored nonzeros via `ref_major`/`ref_minor`/`ref_data`).

## Benchmark

On a 4900×4900 sparse Laplacian (50 calls):

| Path | Time |
|---|---|
| `operator*` (sparse) | 0.0166 s |
| `mult<void>` (before fix) | 7.796 s (~2046x slower) |
| `mult<void>` (after fix) | 0.0091 s |

## Fix

Adds `mult_sparse_crs<Accumulator>()`, mirroring `operator*`'s CRS traversal but routed through `accumulator_traits` so custom accumulators (e.g. quire) work on sparse matrices too, not just dense ones. Dispatches via the existing `is_compressed2D_v` trait (`dispatch_traits.hpp`) at the top of `mult()`, ahead of the BLAS/dense-generic chain.

## Verification

- Correctness: matches `operator*` exactly (diff=0) on a 4x4 tridiagonal sanity check
- BiCGSTAB and GMRES regression suites, which previously required trimmed problem sizes to avoid CI timeouts (some cases hung indefinitely), now pass at full original sizes:
  - BiCGSTAB n=24964/Jacobi PC: ~7s (was 300s+ timeout)
  - GMRES n=24964/Jacobi PC, 3837 iterations: ~15s

## Scope

This fix affects every caller of `mult<Accumulator>()` on sparse matrices: CG (already merged and benefiting from this), BiCGSTAB (open PR #255, will benefit once merged), and GMRES (in progress on a separate branch, not yet opened as a PR). A codebase grep confirms these are the only three current callers — no other solver or code path is affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiplying sparse matrices by dense vectors.
  * Supports pre-allocated output vectors and mixed-precision accumulation.
  * Preserves accurate result conversion for different numeric types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->