### PR TITLE
feat(itl): route jacobi smoother through accumulator_traits

### DIFF
--- a/include/mtl/itl/smoother/jacobi.hpp
+++ b/include/mtl/itl/smoother/jacobi.hpp
@@ -3,14 +3,24 @@
 // Allocates x_new, computes all updates, then copies back (true Jacobi).
 #include <cassert>
 #include <cstddef>
+#include <type_traits>
 #include <mtl/vec/dense_vector.hpp>
 #include <mtl/math/identity.hpp>
+#include <mtl/math/accumulator_traits.hpp>
 #include <mtl/mat/compressed2D.hpp>
 
 namespace mtl::itl::smoother {
 
+// Accumulator (optional): accumulation type for the off-diagonal row sum
+// (sigma = sum_{j!=i} A(i,j)*x(j)), routed through math::accumulator_traits
+// (see math/accumulator_traits.hpp, #158/#259). With the default
+// `Accumulator = void` the naive value_type accumulation is used unchanged --
+// same behavior and codegen guarantee as the cg (#238) / bicgstab (#255)
+// Krylov solvers. A wider or exact (quire) accumulator is opt-in and lives
+// downstream (MTL5 stays Universal-free).
+
 /// Jacobi smoother: compute x_new from old x, then swap.
-template <typename Matrix>
+template <typename Matrix, typename Accumulator = void>
 class jacobi {
     using value_type = typename Matrix::value_type;
     using size_type  = typename Matrix::size_type;
@@ -26,10 +36,23 @@ public:
         assert(x.size() == n && b.size() == n);
         vec::dense_vector<value_type> x_new(n);
         for (size_type i = 0; i < n; ++i) {
-            auto sigma = math::zero<value_type>();
-            for (size_type j = 0; j < n; ++j) {
-                if (j != i)
-                    sigma += A_(i, j) * x(j);
+            value_type sigma;
+            if constexpr (std::is_void_v<Accumulator>) {
+                sigma = math::zero<value_type>();
+                for (size_type j = 0; j < n; ++j) {
+                    if (j != i)
+                        sigma += A_(i, j) * x(j);
+                }
+            } else {
+                using AT = math::accumulator_traits<Accumulator, value_type>;
+                Accumulator acc{};
+                AT::clear(acc);
+                for (size_type j = 0; j < n; ++j) {
+                    if (j != i)
+                        AT::add_product(acc, static_cast<value_type>(A_(i, j)),
+                                             static_cast<value_type>(x(j)));
+                }
+                sigma = AT::template value<value_type>(acc);
             }
             x_new(i) = dia_inv_(i) * (b(i) - sigma);
         }
@@ -44,8 +67,8 @@ private:
 };
 
 /// Specialization for compressed2D: O(nnz) sweep.
-template <typename Value, typename Parameters>
-class jacobi<mat::compressed2D<Value, Parameters>> {
+template <typename Value, typename Parameters, typename Accumulator>
+class jacobi<mat::compressed2D<Value, Parameters>, Accumulator> {
     using matrix_type = mat::compressed2D<Value, Parameters>;
     using value_type  = Value;
     using size_type   = typename matrix_type::size_type;
@@ -73,10 +96,23 @@ public:
         const auto& data    = A_.ref_data();
         vec::dense_vector<value_type> x_new(n);
         for (size_type i = 0; i < n; ++i) {
-            auto sigma = math::zero<value_type>();
-            for (size_type k = starts[i]; k < starts[i + 1]; ++k) {
-                if (indices[k] != i)
-                    sigma += data[k] * x(indices[k]);
+            value_type sigma;
+            if constexpr (std::is_void_v<Accumulator>) {
+                sigma = math::zero<value_type>();
+                for (size_type k = starts[i]; k < starts[i + 1]; ++k) {
+                    if (indices[k] != i)
+                        sigma += data[k] * x(indices[k]);
+                }
+            } else {
+                using AT = math::accumulator_traits<Accumulator, value_type>;
+                Accumulator acc{};
+                AT::clear(acc);
+                for (size_type k = starts[i]; k < starts[i + 1]; ++k) {
+                    if (indices[k] != i)
+                        AT::add_product(acc, static_cast<value_type>(data[k]),
+                                             static_cast<value_type>(x(indices[k])));
+                }
+                sigma = AT::template value<value_type>(acc);
             }
             x_new(i) = dia_inv_(i) * (b(i) - sigma);
         }

--- a/tests/unit/itl/test_smoothers.cpp
+++ b/tests/unit/itl/test_smoothers.cpp
@@ -10,6 +10,7 @@
 #include <mtl/itl/smoother/gauss_seidel.hpp>
 #include <mtl/itl/smoother/jacobi.hpp>
 #include <mtl/itl/smoother/sor.hpp>
+#include <mtl/math/accumulator_traits.hpp>
 
 using namespace mtl;
 
@@ -38,6 +39,55 @@ static mat::compressed2D<double> make_sparse_spd() {
     }
     return A;
 }
+
+// Same SPD matrix in float, for the accumulator-routing test (double
+// accumulation over narrower float data -- no Universal needed).
+static mat::dense2D<float> make_dense_spd_f() {
+    mat::dense2D<float> A(4, 4);
+    for (std::size_t i = 0; i < 4; ++i)
+        for (std::size_t j = 0; j < 4; ++j)
+            A(i, j) = 0.0f;
+    A(0,0)=4; A(0,1)=1;
+    A(1,0)=1; A(1,1)=4; A(1,2)=1;
+    A(2,1)=1; A(2,2)=4; A(2,3)=1;
+    A(3,2)=1; A(3,3)=4;
+    return A;
+}
+
+static mat::compressed2D<float> make_sparse_spd_f() {
+    mat::compressed2D<float> A(4, 4);
+    {
+        mat::inserter<mat::compressed2D<float>> ins(A);
+        ins[0][0] << 4.0f; ins[0][1] << 1.0f;
+        ins[1][0] << 1.0f; ins[1][1] << 4.0f; ins[1][2] << 1.0f;
+        ins[2][1] << 1.0f; ins[2][2] << 4.0f; ins[2][3] << 1.0f;
+        ins[3][2] << 1.0f; ins[3][3] << 4.0f;
+    }
+    return A;
+}
+
+namespace {
+// A wider-precision accumulator over float data: the running sum is held in
+// double and every add_product is counted, so the test can assert the jacobi
+// smoother actually routes its off-diagonal row sum through accumulator_traits
+// rather than the naive value_type path.
+int g_jacobi_addproduct_calls = 0;
+struct counting_wide_acc { double v = 0.0; };
+} // namespace
+
+namespace mtl::math {
+template <>
+struct accumulator_traits<counting_wide_acc, float> {
+    static void clear(counting_wide_acc& a) { a.v = 0.0; }
+    static void assign(counting_wide_acc& a, const float& x) { a.v = static_cast<double>(x); }
+    template <typename Result = float>
+    static Result value(const counting_wide_acc& a) { return static_cast<Result>(a.v); }
+    static void add_product(counting_wide_acc& a, const float& m, const float& x) {
+        ++g_jacobi_addproduct_calls;
+        a.v += static_cast<double>(m) * static_cast<double>(x);
+    }
+};
+} // namespace mtl::math
 
 TEST_CASE("Gauss-Seidel reduces residual (dense)", "[itl][smoother][gauss_seidel]") {
     auto A = make_dense_spd();
@@ -89,6 +139,50 @@ TEST_CASE("Jacobi reduces residual", "[itl][smoother][jacobi]") {
     auto r = A * x;
     for (std::size_t i = 0; i < 4; ++i) r(i) = b(i) - r(i);
     REQUIRE(two_norm(r) < 1e-6);
+}
+
+TEST_CASE("Jacobi routes the row sum through accumulator_traits (#262)",
+          "[itl][smoother][jacobi][accumulator]") {
+    vec::dense_vector<float> b = {1.0f, 2.0f, 3.0f, 4.0f};
+
+    SECTION("dense: double-accumulate-over-float matches the void default") {
+        auto A = make_dense_spd_f();
+        vec::dense_vector<float> x_default(4, 0.0f);
+        vec::dense_vector<float> x_wide(4, 0.0f);
+
+        itl::smoother::jacobi<mat::dense2D<float>> jac_default(A);
+        itl::smoother::jacobi<mat::dense2D<float>, counting_wide_acc> jac_wide(A);
+
+        g_jacobi_addproduct_calls = 0;
+        for (int sweep = 0; sweep < 50; ++sweep) {
+            jac_default(x_default, b);
+            jac_wide(x_wide, b);
+        }
+
+        REQUIRE(g_jacobi_addproduct_calls > 0);   // routing actually exercised
+        // Well-conditioned: the wider accumulator converges to the same solution.
+        for (std::size_t i = 0; i < 4; ++i)
+            REQUIRE_THAT(x_wide(i), Catch::Matchers::WithinAbs(x_default(i), 1e-4));
+        auto r = A * x_wide;
+        for (std::size_t i = 0; i < 4; ++i) r(i) = b(i) - r(i);
+        REQUIRE(two_norm(r) < 1e-4f);
+    }
+
+    SECTION("sparse specialization also routes through the accumulator") {
+        auto A = make_sparse_spd_f();
+        vec::dense_vector<float> x(4, 0.0f);
+
+        itl::smoother::jacobi<mat::compressed2D<float>, counting_wide_acc> jac(A);
+
+        g_jacobi_addproduct_calls = 0;
+        for (int sweep = 0; sweep < 50; ++sweep)
+            jac(x, b);
+
+        REQUIRE(g_jacobi_addproduct_calls > 0);   // the specialization routes too
+        auto r = A * x;
+        for (std::size_t i = 0; i < 4; ++i) r(i) = b(i) - r(i);
+        REQUIRE(two_norm(r) < 1e-4f);
+    }
 }
 
 TEST_CASE("SOR with omega=1.0 matches Gauss-Seidel", "[itl][smoother][sor]") {


### PR DESCRIPTION
## Summary
- Adds an optional class-level `Accumulator = void` template parameter to the `jacobi` smoother and routes the off-diagonal row sum `sigma = sum_{j!=i} A(i,j)*x(j)` through `math::accumulator_traits` (`clear` / `add_product` / `value`).
- Matches the `cg` (#238) / `bicgstab` (#255) Krylov precedent and the FMA accumulator config (#259), extending accumulator-aware accumulation to the stationary smoothers (mp-iterative characterization, stillwater-sc/mp-iterative#3/#7).

## Design
- `void` is the sentinel for the plain path. Guarded by `if constexpr (std::is_void_v<Accumulator>)`, the default keeps the naive `value_type` accumulation with **unchanged behavior and codegen** — the same guarantee as #238/#255 (`accumulator_allows_blas_v` treats `void` identically).
- A wider or exact (quire) accumulator is opt-in. MTL5 stays Universal-free; the posit+quire specialization (`math::quire_accumulator`) is downstream in mp-iterative.
- Applied to **both** the generic `jacobi<Matrix>` and the `jacobi<compressed2D<...>>` specialization.

## Changes
- `include/mtl/itl/smoother/jacobi.hpp` — `Accumulator` param + `if constexpr` accumulation split in both classes; include `accumulator_traits.hpp`.
- `tests/unit/itl/test_smoothers.cpp` — a wider-precision counting accumulator (double sum over float data, no Universal) proving both dense and sparse smoothers invoke `add_product` and still converge.

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| itl_test_smoothers | OK | PASS (6 cases) | OK | PASS (6 cases) |
| itl_test_multigrid | OK | PASS (5 cases) | OK | PASS (5 cases) |

Multigrid is the regression check — it drives the jacobi smoother and is unchanged.

## Test plan
- [ ] Fast CI passes (gcc + clang)
- [ ] Promote to ready when satisfied: `gh pr ready`

Resolves #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Jacobi smoothing now supports optional accumulator types for more flexible and precise row-sum calculations.
  * Added support for custom accumulation behavior with both dense and sparse matrices.

* **Tests**
  * Added coverage validating custom accumulator usage, solution consistency, and residual accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->