### PR TITLE
feat(itl): route gauss_seidel smoother through accumulator_traits

### DIFF
--- a/include/mtl/itl/smoother/gauss_seidel.hpp
+++ b/include/mtl/itl/smoother/gauss_seidel.hpp
@@ -3,15 +3,33 @@
 // Generic version uses A(i,j); compressed2D specialization uses raw CRS access.
 #include <cassert>
 #include <cstddef>
+#include <type_traits>
 #include <mtl/vec/dense_vector.hpp>
 #include <mtl/math/identity.hpp>
+#include <mtl/math/accumulator_traits.hpp>
 #include <mtl/mat/compressed2D.hpp>
 
 namespace mtl::itl::smoother {
 
+// Accumulator (optional): accumulation type for the off-diagonal row sum
+// (sigma = sum_{j!=i} A(i,j)*x(j)), routed through math::accumulator_traits
+// (see math/accumulator_traits.hpp, #158/#259), consistent with the jacobi
+// smoother (#262) and the cg (#238) / bicgstab (#255) Krylov solvers. With the
+// default `Accumulator = void` the naive value_type accumulation is used
+// unchanged -- same behavior and codegen guarantee. A wider or exact (quire)
+// accumulator is opt-in and lives downstream (MTL5 stays Universal-free).
+//
+// Accumulator scope is PER ROW (cleared at the start of each row), the same as
+// jacobi. Note that Gauss-Seidel is an in-place sweep: within a single sweep the
+// row sum for row i reads the entries x(j), j < i, that were ALREADY updated
+// earlier in this sweep. The accumulator only governs the rounding of that one
+// row sum; it does not change which (updated vs. old) entries are read. That
+// intra-sweep error propagation is exactly what mp-iterative studies on top of
+// this per-row accumulation policy.
+
 /// Gauss-Seidel smoother: in-place forward sweep.
 /// x[i] = dia_inv[i] * (b[i] - sum_{j!=i} A(i,j)*x[j])
-template <typename Matrix>
+template <typename Matrix, typename Accumulator = void>
 class gauss_seidel {
     using value_type = typename Matrix::value_type;
     using size_type  = typename Matrix::size_type;
@@ -26,10 +44,23 @@ public:
         const size_type n = A_.num_rows();
         assert(x.size() == n && b.size() == n);
         for (size_type i = 0; i < n; ++i) {
-            auto sigma = math::zero<value_type>();
-            for (size_type j = 0; j < n; ++j) {
-                if (j != i)
-                    sigma += A_(i, j) * x(j);
+            value_type sigma;
+            if constexpr (std::is_void_v<Accumulator>) {
+                sigma = math::zero<value_type>();
+                for (size_type j = 0; j < n; ++j) {
+                    if (j != i)
+                        sigma += A_(i, j) * x(j);
+                }
+            } else {
+                using AT = math::accumulator_traits<Accumulator, value_type>;
+                Accumulator acc{};
+                AT::clear(acc);
+                for (size_type j = 0; j < n; ++j) {
+                    if (j != i)
+                        AT::add_product(acc, static_cast<value_type>(A_(i, j)),
+                                             static_cast<value_type>(x(j)));
+                }
+                sigma = AT::template value<value_type>(acc);
             }
             x(i) = dia_inv_(i) * (b(i) - sigma);
         }
@@ -42,8 +73,8 @@ private:
 };
 
 /// Specialization for compressed2D: O(nnz) sweep using raw CRS arrays.
-template <typename Value, typename Parameters>
-class gauss_seidel<mat::compressed2D<Value, Parameters>> {
+template <typename Value, typename Parameters, typename Accumulator>
+class gauss_seidel<mat::compressed2D<Value, Parameters>, Accumulator> {
     using matrix_type = mat::compressed2D<Value, Parameters>;
     using value_type  = Value;
     using size_type   = typename matrix_type::size_type;
@@ -72,10 +103,23 @@ public:
         const auto& indices = A_.ref_minor();
         const auto& data    = A_.ref_data();
         for (size_type i = 0; i < n; ++i) {
-            auto sigma = math::zero<value_type>();
-            for (size_type k = starts[i]; k < starts[i + 1]; ++k) {
-                if (indices[k] != i)
-                    sigma += data[k] * x(indices[k]);
+            value_type sigma;
+            if constexpr (std::is_void_v<Accumulator>) {
+                sigma = math::zero<value_type>();
+                for (size_type k = starts[i]; k < starts[i + 1]; ++k) {
+                    if (indices[k] != i)
+                        sigma += data[k] * x(indices[k]);
+                }
+            } else {
+                using AT = math::accumulator_traits<Accumulator, value_type>;
+                Accumulator acc{};
+                AT::clear(acc);
+                for (size_type k = starts[i]; k < starts[i + 1]; ++k) {
+                    if (indices[k] != i)
+                        AT::add_product(acc, static_cast<value_type>(data[k]),
+                                             static_cast<value_type>(x(indices[k])));
+                }
+                sigma = AT::template value<value_type>(acc);
             }
             x(i) = dia_inv_(i) * (b(i) - sigma);
         }

--- a/tests/unit/itl/test_smoothers.cpp
+++ b/tests/unit/itl/test_smoothers.cpp
@@ -185,6 +185,50 @@ TEST_CASE("Jacobi routes the row sum through accumulator_traits (#262)",
     }
 }
 
+TEST_CASE("Gauss-Seidel routes the row sum through accumulator_traits (#263)",
+          "[itl][smoother][gauss_seidel][accumulator]") {
+    vec::dense_vector<float> b = {1.0f, 2.0f, 3.0f, 4.0f};
+
+    SECTION("dense: double-accumulate-over-float matches the void default") {
+        auto A = make_dense_spd_f();
+        vec::dense_vector<float> x_default(4, 0.0f);
+        vec::dense_vector<float> x_wide(4, 0.0f);
+
+        itl::smoother::gauss_seidel<mat::dense2D<float>> gs_default(A);
+        itl::smoother::gauss_seidel<mat::dense2D<float>, counting_wide_acc> gs_wide(A);
+
+        g_jacobi_addproduct_calls = 0;
+        for (int sweep = 0; sweep < 30; ++sweep) {
+            gs_default(x_default, b);
+            gs_wide(x_wide, b);
+        }
+
+        REQUIRE(g_jacobi_addproduct_calls > 0);   // routing actually exercised
+        // Well-conditioned: the wider accumulator converges to the same solution.
+        for (std::size_t i = 0; i < 4; ++i)
+            REQUIRE_THAT(x_wide(i), Catch::Matchers::WithinAbs(x_default(i), 1e-4));
+        auto r = A * x_wide;
+        for (std::size_t i = 0; i < 4; ++i) r(i) = b(i) - r(i);
+        REQUIRE(two_norm(r) < 1e-4f);
+    }
+
+    SECTION("sparse specialization also routes through the accumulator") {
+        auto A = make_sparse_spd_f();
+        vec::dense_vector<float> x(4, 0.0f);
+
+        itl::smoother::gauss_seidel<mat::compressed2D<float>, counting_wide_acc> gs(A);
+
+        g_jacobi_addproduct_calls = 0;
+        for (int sweep = 0; sweep < 30; ++sweep)
+            gs(x, b);
+
+        REQUIRE(g_jacobi_addproduct_calls > 0);   // the specialization routes too
+        auto r = A * x;
+        for (std::size_t i = 0; i < 4; ++i) r(i) = b(i) - r(i);
+        REQUIRE(two_norm(r) < 1e-4f);
+    }
+}
+
 TEST_CASE("SOR with omega=1.0 matches Gauss-Seidel", "[itl][smoother][sor]") {
     auto A = make_dense_spd();
     vec::dense_vector<double> b = {1.0, 2.0, 3.0, 4.0};


### PR DESCRIPTION
## Summary
- Companion to the jacobi smoother (#262, merged in #265): adds an optional class-level `Accumulator = void` template parameter to `gauss_seidel` and routes the off-diagonal row sum `sigma = sum_{j!=i} A(i,j)*x(j)` through `math::accumulator_traits` (`clear` / `add_product` / `value`).
- Matches the `cg` (#238) / `bicgstab` (#255) Krylov precedent and the FMA config (#259), extending accumulator-aware accumulation to the Gauss-Seidel stationary smoother (mp-iterative characterization, stillwater-sc/mp-iterative#4/#7).

## Design
- `void` is the sentinel for the plain path. Guarded by `if constexpr (std::is_void_v<Accumulator>)`, the default keeps the naive `value_type` accumulation with **unchanged behavior and codegen**.
- **Header docs state the accumulator scope explicitly** (per the issue's design note): it is **per-row** (cleared each row), the same as jacobi. Gauss-Seidel is an in-place sweep, so the row sum for row `i` reads `x(j)`, `j<i`, already updated earlier in the sweep; the accumulator governs only the *rounding* of that one row sum, not which (updated vs. old) entries are read — the intra-sweep error propagation mp-iterative studies on top of this policy.
- Applied to **both** the generic `gauss_seidel<Matrix>` and the `gauss_seidel<compressed2D<...>>` specialization.
- A wider or exact (quire) accumulator is opt-in. MTL5 stays Universal-free; the posit+quire specialization is downstream in mp-iterative.

## Changes
- `include/mtl/itl/smoother/gauss_seidel.hpp` — `Accumulator` param + `if constexpr` accumulation split in both classes; per-row-scope header docs; include `accumulator_traits.hpp`.
- `tests/unit/itl/test_smoothers.cpp` — a Gauss-Seidel routing test (dense + sparse) using the wider-precision counting accumulator introduced in #262 (double sum over float, no Universal).

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| itl_test_smoothers | OK | PASS (7 cases) | OK | PASS (7 cases) |
| itl_test_multigrid | OK | PASS (5 cases) | OK | PASS (5 cases) |

Multigrid is the regression check — it drives the Gauss-Seidel smoother and is unchanged.

## Test plan
- [ ] Fast CI passes (gcc + clang)
- [ ] Promote to ready when satisfied: `gh pr ready`

Resolves #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gauss-Seidel smoothing now supports optional wide-precision accumulation for improved numerical robustness.
  * Accumulator-based row-sum handling is available for both dense and sparse matrix formats.

* **Tests**
  * Added coverage validating accumulator routing, solution consistency, and residual accuracy across dense and sparse systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->