### PR TITLE
feat(itl): route sor smoother through accumulator_traits

### DIFF
--- a/include/mtl/itl/smoother/sor.hpp
+++ b/include/mtl/itl/smoother/sor.hpp
@@ -3,15 +3,33 @@
 // Relaxed Gauss-Seidel: x[i] = omega * GS_update + (1 - omega) * x[i]
 #include <cassert>
 #include <cstddef>
+#include <type_traits>
 #include <mtl/vec/dense_vector.hpp>
 #include <mtl/math/identity.hpp>
+#include <mtl/math/accumulator_traits.hpp>
 #include <mtl/mat/compressed2D.hpp>
 
 namespace mtl::itl::smoother {
 
+// Accumulator (optional): accumulation type for the off-diagonal row sum
+// (sigma = sum_{j!=i} A(i,j)*x(j)), routed through math::accumulator_traits
+// (see math/accumulator_traits.hpp, #158/#259), consistent with the jacobi
+// (#262) and gauss_seidel (#263) smoothers and the cg (#238) / bicgstab (#255)
+// Krylov solvers. With the default `Accumulator = void` the naive value_type
+// accumulation is used unchanged -- same behavior and codegen guarantee. A wider
+// or exact (quire) accumulator is opt-in and lives downstream (MTL5 stays
+// Universal-free).
+//
+// Accumulator scope is PER ROW (cleared each row), the same as gauss_seidel.
+// The relaxation is deliberately kept OUTSIDE the accumulator: only the row sum
+// is accumulated and rounded out to a scalar sigma; the Gauss-Seidel update
+// dia_inv*(b - sigma) and the omega blend x_i = omega*gs_update + (1-omega)*x_i
+// are ordinary scalar arithmetic on that rounded value. That clean separation
+// lets mp-iterative study omega-vs-precision independently of the sum rounding.
+
 /// SOR smoother with relaxation parameter omega.
 /// omega=1.0 reduces to Gauss-Seidel.
-template <typename Matrix>
+template <typename Matrix, typename Accumulator = void>
 class sor {
     using value_type = typename Matrix::value_type;
     using size_type  = typename Matrix::size_type;
@@ -28,11 +46,25 @@ public:
         const size_type n = A_.num_rows();
         assert(x.size() == n && b.size() == n);
         for (size_type i = 0; i < n; ++i) {
-            auto sigma = math::zero<value_type>();
-            for (size_type j = 0; j < n; ++j) {
-                if (j != i)
-                    sigma += A_(i, j) * x(j);
+            value_type sigma;
+            if constexpr (std::is_void_v<Accumulator>) {
+                sigma = math::zero<value_type>();
+                for (size_type j = 0; j < n; ++j) {
+                    if (j != i)
+                        sigma += A_(i, j) * x(j);
+                }
+            } else {
+                using AT = math::accumulator_traits<Accumulator, value_type>;
+                Accumulator acc{};
+                AT::clear(acc);
+                for (size_type j = 0; j < n; ++j) {
+                    if (j != i)
+                        AT::add_product(acc, static_cast<value_type>(A_(i, j)),
+                                             static_cast<value_type>(x(j)));
+                }
+                sigma = AT::template value<value_type>(acc);
             }
+            // omega blend stays outside the accumulator (scalar arithmetic).
             auto gs_update = dia_inv_(i) * (b(i) - sigma);
             x(i) = omega_ * gs_update + (value_type(1) - omega_) * x(i);
         }
@@ -46,8 +78,8 @@ private:
 };
 
 /// Specialization for compressed2D: O(nnz) sweep.
-template <typename Value, typename Parameters>
-class sor<mat::compressed2D<Value, Parameters>> {
+template <typename Value, typename Parameters, typename Accumulator>
+class sor<mat::compressed2D<Value, Parameters>, Accumulator> {
     using matrix_type = mat::compressed2D<Value, Parameters>;
     using value_type  = Value;
     using size_type   = typename matrix_type::size_type;
@@ -76,11 +108,25 @@ public:
         const auto& indices = A_.ref_minor();
         const auto& data    = A_.ref_data();
         for (size_type i = 0; i < n; ++i) {
-            auto sigma = math::zero<value_type>();
-            for (size_type k = starts[i]; k < starts[i + 1]; ++k) {
-                if (indices[k] != i)
-                    sigma += data[k] * x(indices[k]);
+            value_type sigma;
+            if constexpr (std::is_void_v<Accumulator>) {
+                sigma = math::zero<value_type>();
+                for (size_type k = starts[i]; k < starts[i + 1]; ++k) {
+                    if (indices[k] != i)
+                        sigma += data[k] * x(indices[k]);
+                }
+            } else {
+                using AT = math::accumulator_traits<Accumulator, value_type>;
+                Accumulator acc{};
+                AT::clear(acc);
+                for (size_type k = starts[i]; k < starts[i + 1]; ++k) {
+                    if (indices[k] != i)
+                        AT::add_product(acc, static_cast<value_type>(data[k]),
+                                             static_cast<value_type>(x(indices[k])));
+                }
+                sigma = AT::template value<value_type>(acc);
             }
+            // omega blend stays outside the accumulator (scalar arithmetic).
             auto gs_update = dia_inv_(i) * (b(i) - sigma);
             x(i) = omega_ * gs_update + (value_type(1) - omega_) * x(i);
         }

--- a/tests/unit/itl/test_smoothers.cpp
+++ b/tests/unit/itl/test_smoothers.cpp
@@ -248,6 +248,51 @@ TEST_CASE("SOR with omega=1.0 matches Gauss-Seidel", "[itl][smoother][sor]") {
     }
 }
 
+TEST_CASE("SOR routes the row sum through accumulator_traits (#264)",
+          "[itl][smoother][sor][accumulator]") {
+    vec::dense_vector<float> b = {1.0f, 2.0f, 3.0f, 4.0f};
+    const float omega = 1.1f;   // over-relaxation: exercises the omega blend
+
+    SECTION("dense: double-accumulate-over-float matches the void default") {
+        auto A = make_dense_spd_f();
+        vec::dense_vector<float> x_default(4, 0.0f);
+        vec::dense_vector<float> x_wide(4, 0.0f);
+
+        itl::smoother::sor<mat::dense2D<float>> sor_default(A, omega);
+        itl::smoother::sor<mat::dense2D<float>, counting_wide_acc> sor_wide(A, omega);
+
+        g_jacobi_addproduct_calls = 0;
+        for (int sweep = 0; sweep < 40; ++sweep) {
+            sor_default(x_default, b);
+            sor_wide(x_wide, b);
+        }
+
+        REQUIRE(g_jacobi_addproduct_calls > 0);   // routing actually exercised
+        // Well-conditioned: the wider accumulator converges to the same solution.
+        for (std::size_t i = 0; i < 4; ++i)
+            REQUIRE_THAT(x_wide(i), Catch::Matchers::WithinAbs(x_default(i), 1e-4));
+        auto r = A * x_wide;
+        for (std::size_t i = 0; i < 4; ++i) r(i) = b(i) - r(i);
+        REQUIRE(two_norm(r) < 1e-4f);
+    }
+
+    SECTION("sparse specialization also routes through the accumulator") {
+        auto A = make_sparse_spd_f();
+        vec::dense_vector<float> x(4, 0.0f);
+
+        itl::smoother::sor<mat::compressed2D<float>, counting_wide_acc> sor_s(A, omega);
+
+        g_jacobi_addproduct_calls = 0;
+        for (int sweep = 0; sweep < 40; ++sweep)
+            sor_s(x, b);
+
+        REQUIRE(g_jacobi_addproduct_calls > 0);   // the specialization routes too
+        auto r = A * x;
+        for (std::size_t i = 0; i < 4; ++i) r(i) = b(i) - r(i);
+        REQUIRE(two_norm(r) < 1e-4f);
+    }
+}
+
 TEST_CASE("Sparse specialization matches generic version", "[itl][smoother][sparse]") {
     auto Ad = make_dense_spd();
     auto As = make_sparse_spd();


### PR DESCRIPTION
## Summary
- Completes the stationary-smoother accumulator trilogy (after jacobi #262/#265 and gauss_seidel #263/#266): adds an optional class-level `Accumulator = void` parameter to **both** `sor<Matrix>` and `sor<compressed2D<...>>`, routing the off-diagonal row sum `sigma = sum_{j!=i} A(i,j)*x(j)` through `math::accumulator_traits` (`clear` / `add_product` / `value`).
- Matches the `cg` (#238) / `bicgstab` (#255) Krylov precedent and the FMA config (#259) (mp-iterative characterization, stillwater-sc/mp-iterative#5/#7).

## Design
- `void` is the sentinel for the plain path. Guarded by `if constexpr (std::is_void_v<Accumulator>)`, the default keeps the naive `value_type` accumulation with **unchanged behavior and codegen**.
- **Relaxation is kept outside the accumulator** (per the issue's design constraint): only the row sum is accumulated and rounded out to a scalar `sigma`; the GS update `dia_inv*(b - sigma)` and the omega blend `x_i = omega*gs_update + (1-omega)*x_i` are ordinary scalar arithmetic on that rounded value. That clean separation — documented in the header — lets mp-iterative study omega-vs-precision independently of the sum rounding.
- Applied to **both** the generic and `compressed2D` variants.
- A wider or exact (quire) accumulator is opt-in. MTL5 stays Universal-free; the posit+quire specialization is downstream in mp-iterative.

## Changes
- `include/mtl/itl/smoother/sor.hpp` — `Accumulator` param + `if constexpr` split on the row-sum loop only in both classes; omega-separation header docs; include `accumulator_traits.hpp`.
- `tests/unit/itl/test_smoothers.cpp` — an SOR routing test (dense + sparse, `omega=1.1` to exercise the blend) reusing the wider-precision counting accumulator from #262.

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| itl_test_smoothers | OK | PASS (8 cases) | OK | PASS (8 cases) |
| itl_test_multigrid | OK | PASS (5 cases) | OK | PASS (5 cases) |

Multigrid is the regression check and is unchanged.

## Test plan
- [ ] Fast CI passes (gcc + clang)
- [ ] Promote to ready when satisfied: `gh pr ready`

Resolves #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)