### PR TITLE
gmres: route through accumulator-aware mult()/dot(), fix lucky-breakdown hang

### DIFF
--- a/include/mtl/itl/krylov/gmres.hpp
+++ b/include/mtl/itl/krylov/gmres.hpp
@@ -8,6 +8,7 @@
 #include <mtl/operation/dot.hpp>
 #include <mtl/operation/norms.hpp>
 #include <mtl/operation/givens.hpp>
+#include <mtl/operation/mult.hpp>
 #include <mtl/math/identity.hpp>
 
 namespace mtl::itl {
@@ -17,7 +18,7 @@ namespace detail {
 /// Single GMRES cycle (inner iteration) -- up to kmax Arnoldi steps.
 /// Returns 0 on convergence, 1 if kmax exhausted (restart needed).
 template <typename LinearOp, typename VecX, typename VecB,
-          typename PC, typename Iter>
+          typename PC, typename Iter, typename Accumulator = void>
 int gmres_inner(const LinearOp& A, VecX& x, const VecB& b,
                 const PC& M, Iter& iter, int kmax) {
     using value_type = typename VecX::value_type;
@@ -26,7 +27,8 @@ int gmres_inner(const LinearOp& A, VecX& x, const VecB& b,
 
     // r = M^{-1}(b - A*x)
     vec::dense_vector<value_type> r0(n), r(n);
-    auto Ax = A * x;
+    vec::dense_vector<value_type> Ax(n);
+    mtl::mult<Accumulator>(A, x, Ax);
     for (size_type i = 0; i < n; ++i)
         r0(i) = b(i) - Ax(i);
     M.solve(r, r0);
@@ -56,29 +58,23 @@ int gmres_inner(const LinearOp& A, VecX& x, const VecB& b,
     for (; k < kmax; ++k) {
         // w = M^{-1}(A * V[k])
         vec::dense_vector<value_type> w_tmp(n), w(n);
-        auto Avk = A * V[k];
-        for (size_type i = 0; i < n; ++i)
-            w_tmp(i) = Avk(i);
+        mtl::mult<Accumulator>(A, V[k], w_tmp);
         M.solve(w, w_tmp);
 
         // Modified Gram-Schmidt
         for (int j = 0; j <= k; ++j) {
-            H(j, k) = mtl::dot(V[j], w);
+            H(j, k) = mtl::dot<Accumulator, value_type>(V[j], w);
             for (size_type i = 0; i < n; ++i)
                 w(i) -= H(j, k) * V[j](i);
         }
 
         H(k + 1, k) = mtl::two_norm(w);
 
-        // Check for breakdown
-        if (H(k + 1, k) == math::zero<value_type>()) {
-            // Lucky breakdown: exact solution in Krylov subspace
-            // Apply existing stored rotations and solve
-            break;
+        bool breakdown = (H(k + 1, k) == math::zero<value_type>());
+        if (!breakdown) {
+            for (size_type i = 0; i < n; ++i)
+                V[k + 1](i) = w(i) / H(k + 1, k);
         }
-
-        for (size_type i = 0; i < n; ++i)
-            V[k + 1](i) = w(i) / H(k + 1, k);
 
         // Apply previously stored Givens rotations to column k
         for (int j = 0; j < k; ++j)
@@ -88,6 +84,17 @@ int gmres_inner(const LinearOp& A, VecX& x, const VecB& b,
         mtl::apply_givens_rotation(H, g, cs, sn, static_cast<size_type>(k));
 
         ++iter;
+
+        if (breakdown) {
+            // Lucky breakdown: exact solution lies in the Krylov subspace
+            // spanned by V[0..k]. Column k's rotation was just applied
+            // above, so it's valid to include in back-substitution --
+            // unlike the old code, which broke out before applying the
+            // rotation or incrementing iter, leaving x and iter unchanged
+            // and causing gmres()'s outer restart loop to spin forever.
+            ++k;
+            break;
+        }
 
         // Check convergence using |g(k+1)|
         using std::abs;
@@ -121,11 +128,11 @@ int gmres_inner(const LinearOp& A, VecX& x, const VecB& b,
 /// Solves A*x = b with left preconditioner M.
 /// restart: maximum Krylov subspace dimension before restart (default 30).
 template <typename LinearOp, typename VecX, typename VecB,
-          typename PC, typename Iter>
+          typename PC, typename Iter, typename Accumulator = void>
 int gmres(const LinearOp& A, VecX& x, const VecB& b,
           const PC& M, Iter& iter, int restart = 30) {
     while (!iter.is_finished()) {
-        detail::gmres_inner(A, x, b, M, iter, restart);
+        detail::gmres_inner<LinearOp, VecX, VecB, PC, Iter, Accumulator>(A, x, b, M, iter, restart);
     }
     return iter;
 }

--- a/tests/unit/itl/test_gmres.cpp
+++ b/tests/unit/itl/test_gmres.cpp
@@ -111,11 +111,11 @@ TEST_CASE("GMRES lucky breakdown converges (does not hang)", "[itl][gmres][break
     vec::dense_vector<double> x(4, 0.0);
 
     itl::pc::identity<mat::dense2D<double>> pc(A);
-    itl::basic_iteration<double> iter(b, 50, 1e-10);
+    itl::basic_iteration<double> iter(b, /*max_iter=*/3, 1e-10);
 
     int err = itl::gmres(A, x, b, pc, iter, /*restart=*/10);
     REQUIRE(err == 0);
-    REQUIRE(iter.iterations() > 0);   // must have actually advanced, not stalled
+    REQUIRE(iter.iterations() == 2);   // old buggy code cannot reach exact convergence in this budget
 
     auto r = A * x;
     for (std::size_t i = 0; i < 4; ++i)

--- a/tests/unit/itl/test_gmres.cpp
+++ b/tests/unit/itl/test_gmres.cpp
@@ -95,3 +95,29 @@ TEST_CASE("GMRES with diagonal preconditioner", "[itl][gmres][pc]") {
         REQUIRE_THAT(Ax(i), Catch::Matchers::WithinAbs(b(i), 1e-8));
     }
 }
+
+// --- Regression: lucky breakdown must not hang or leave x/iter unchanged.
+// A matrix with only 2 distinct eigenvalues converges GMRES in <=2 Krylov
+// steps; if x(1)^2 spans exactly that subspace, H(k+1,k) hits an exact zero. ---
+TEST_CASE("GMRES lucky breakdown converges (does not hang)", "[itl][gmres][breakdown]") {
+    mat::dense2D<double> A(4, 4);
+    for (std::size_t i = 0; i < 4; ++i)
+        for (std::size_t j = 0; j < 4; ++j)
+            A(i,j) = 0.0;
+    // Two distinct eigenvalues (2 and 5), each with multiplicity 2.
+    A(0,0) = 2; A(1,1) = 2; A(2,2) = 5; A(3,3) = 5;
+
+    vec::dense_vector<double> b = {1.0, 1.0, 1.0, 1.0};
+    vec::dense_vector<double> x(4, 0.0);
+
+    itl::pc::identity<mat::dense2D<double>> pc(A);
+    itl::basic_iteration<double> iter(b, 50, 1e-10);
+
+    int err = itl::gmres(A, x, b, pc, iter, /*restart=*/10);
+    REQUIRE(err == 0);
+    REQUIRE(iter.iterations() > 0);   // must have actually advanced, not stalled
+
+    auto r = A * x;
+    for (std::size_t i = 0; i < 4; ++i)
+        REQUIRE_THAT(r(i), Catch::Matchers::WithinAbs(b(i), 1e-8));
+}


### PR DESCRIPTION
Wires GMRES into the existing accumulator_traits hook (same pattern as CG #238 and BiCGSTAB #255), so posit+quire accumulation is available in the matvec/dot path. Also fixes a pre-existing infinite-loop bug in the lucky-breakdown path.

Part of #254 (gmres.hpp item).

- include/mtl/itl/krylov/gmres.hpp: accumulator-aware mult()/dot() routing + lucky-breakdown hang fix
- tests/unit/itl/test_gmres.cpp: new test coverage, tightened per review to fail under the old early-break behavior