### PR TITLE
feat(generators): range spacing vectors (linspace family) + magic square

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Format follows [Conventional Commits](https://www.conventionalcommits.org/).
 
 ### Added
 
+#### Range and test-matrix generators (BLAS extraction from Universal)
+- **`mtl::generators::{arange, linspace, logspace, geomspace}`** (`generators/ranges.hpp`) — NumPy-style spacing vectors returning `vec::dense_vector<T>`, generic over the scalar type (Universal-free). `geomspace` computes a true geometric progression between its endpoints, fixing the historical Universal implementation that aliased `logspace` and treated the endpoints as exponents (`geomspace(1, 1000, 4) == {1, 10, 100, 1000}`).
+- **`mtl::generators::magic`** (`generators/magic.hpp`) — magic square of order N (odd via the Siamese method, doubly-even via the complement method); singly-even orders throw `std::invalid_argument` pending support.
+- Migrated from Universal's `sw::blas` as the first step of extracting the linear-algebra layer into MTL5 (Universal epic #1204, phase #1206).
+
 #### Matrix/vector/tensor property predicate module (#244)
 A cohesive set of runtime property and predicate queries as free functions in `namespace mtl`, built on the existing primitives (cholesky/lu/svd/eigenvalue/norms) with no new dependencies. Consistent tolerance policy: structural checks are exact-by-default and NaN-safe (`!(dev <= tol)`), while norm/factorization/spectral-backed checks use relative or scale-aware tolerances; verified on both the in-house and LAPACK paths.
 - **Structural + vector predicates** (`operation/matrix_properties.hpp`, `operation/vector_properties.hpp`) — `is_square`, `is_empty`, `is_symmetric`, `is_hermitian`, `is_upper/lower/is_triangular`, `is_diagonal`, `is_banded`, `is_diagonally_dominant`; `is_zero`, `is_finite`/`has_nan`/`has_inf`, `is_normalized`/`is_unit`, `is_orthogonal_to`. O(n)/O(nnz), no factorization (#245)

--- a/include/mtl/generators/generators.hpp
+++ b/include/mtl/generators/generators.hpp
@@ -9,7 +9,11 @@
 #include <mtl/generators/ones.hpp>
 #include <mtl/generators/minij.hpp>
 
+// Range / spacing vector generators (return dense_vector<T>)
+#include <mtl/generators/ranges.hpp>
+
 // Tier 2: Dense factory generators (return dense2D<T>)
+#include <mtl/generators/magic.hpp>
 #include <mtl/generators/kahan.hpp>
 #include <mtl/generators/frank.hpp>
 #include <mtl/generators/moler.hpp>

--- a/include/mtl/generators/magic.hpp
+++ b/include/mtl/generators/magic.hpp
@@ -1,0 +1,59 @@
+#pragma once
+// MTL5 -- magic square generator (factory, returns dense2D)
+// A magic square of order N contains the integers 1..N^2 arranged so that
+// every row, every column, and both main diagonals sum to N*(N^2+1)/2.
+#include <cstddef>
+#include <stdexcept>
+#include <mtl/mat/dense2D.hpp>
+
+namespace mtl::generators {
+
+/// Magic square of order N.
+/// Supported orders:
+///   - odd N            -> Siamese (De la Loubere) method;
+///   - doubly-even N    -> (N % 4 == 0) complement method.
+/// Singly-even orders (N even, N % 4 != 0, e.g. 6, 10) are not yet supported
+/// and throw std::invalid_argument, as does N == 0.
+template <typename T = double>
+mat::dense2D<T> magic(std::size_t N) {
+    if (N == 0) throw std::invalid_argument("magic: order must be >= 1");
+
+    mat::dense2D<T> A(N, N);
+    for (std::size_t i = 0; i < N; ++i)
+        for (std::size_t j = 0; j < N; ++j) A(i, j) = T(0);
+
+    if (N % 2 == 1) {
+        // Siamese method: start at the middle of the top row, step up-and-right
+        // with wraparound; on collision drop straight down instead.
+        std::size_t i = 0, j = N / 2;
+        for (std::size_t k = 1; k <= N * N; ++k) {
+            A(i, j) = T(k);
+            std::size_t ni = (i == 0) ? N - 1 : i - 1;
+            std::size_t nj = (j == N - 1) ? 0 : j + 1;
+            if (A(ni, nj) != T(0)) {          // target occupied -> move down
+                ni = (i == N - 1) ? 0 : i + 1;
+                nj = j;
+            }
+            i = ni;
+            j = nj;
+        }
+    }
+    else if (N % 4 == 0) {
+        // Doubly-even method: fill 1..N^2 in row order, then complement
+        // (v -> N^2+1-v) the cells lying on the diagonals of each 4x4 block.
+        for (std::size_t i = 0; i < N; ++i)
+            for (std::size_t j = 0; j < N; ++j) {
+                std::size_t val = i * N + j + 1;
+                if ((i % 4 == j % 4) || ((i % 4 + j % 4) == 3))
+                    val = N * N + 1 - val;
+                A(i, j) = T(val);
+            }
+    }
+    else {
+        throw std::invalid_argument("magic: singly-even order (N%2==0, N%4!=0) is not yet supported");
+    }
+
+    return A;
+}
+
+} // namespace mtl::generators

--- a/include/mtl/generators/magic.hpp
+++ b/include/mtl/generators/magic.hpp
@@ -3,6 +3,7 @@
 // A magic square of order N contains the integers 1..N^2 arranged so that
 // every row, every column, and both main diagonals sum to N*(N^2+1)/2.
 #include <cstddef>
+#include <limits>
 #include <stdexcept>
 #include <mtl/mat/dense2D.hpp>
 
@@ -17,6 +18,12 @@ namespace mtl::generators {
 template <typename T = double>
 mat::dense2D<T> magic(std::size_t N) {
     if (N == 0) throw std::invalid_argument("magic: order must be >= 1");
+    // Guard N*N before it is used for the allocation, the value range, and the
+    // complement expressions; a wrapped square would mis-size the matrix and
+    // corrupt the placement/complement counts (out-of-bounds writes for large N).
+    if (N > std::numeric_limits<std::size_t>::max() / N)
+        throw std::invalid_argument("magic: order too large (N*N overflows size_t)");
+    const std::size_t N2 = N * N;
 
     mat::dense2D<T> A(N, N);
     for (std::size_t i = 0; i < N; ++i)
@@ -26,7 +33,7 @@ mat::dense2D<T> magic(std::size_t N) {
         // Siamese method: start at the middle of the top row, step up-and-right
         // with wraparound; on collision drop straight down instead.
         std::size_t i = 0, j = N / 2;
-        for (std::size_t k = 1; k <= N * N; ++k) {
+        for (std::size_t k = 1; k <= N2; ++k) {
             A(i, j) = T(k);
             std::size_t ni = (i == 0) ? N - 1 : i - 1;
             std::size_t nj = (j == N - 1) ? 0 : j + 1;
@@ -45,7 +52,7 @@ mat::dense2D<T> magic(std::size_t N) {
             for (std::size_t j = 0; j < N; ++j) {
                 std::size_t val = i * N + j + 1;
                 if ((i % 4 == j % 4) || ((i % 4 + j % 4) == 3))
-                    val = N * N + 1 - val;
+                    val = N2 + 1 - val;
                 A(i, j) = T(val);
             }
     }

--- a/include/mtl/generators/ranges.hpp
+++ b/include/mtl/generators/ranges.hpp
@@ -5,6 +5,8 @@
 #include <cstddef>
 #include <cstdint>
 #include <cmath>
+#include <stdexcept>
+#include <type_traits>
 #include <mtl/vec/dense_vector.hpp>
 
 namespace mtl::generators {
@@ -15,14 +17,24 @@ namespace mtl::generators {
 template <typename T = double>
 vec::dense_vector<T> arange(std::int64_t start, std::int64_t stop, std::int64_t step = 1) {
     if (step == 0) return vec::dense_vector<T>();
+    // Count the elements in unsigned arithmetic so it never overflows for valid
+    // int64 arguments (spans near INT64_MIN..INT64_MAX, or step == INT64_MIN).
     std::size_t n = 0;
-    if (step > 0 && stop > start)
-        n = static_cast<std::size_t>((stop - start + step - 1) / step);
-    else if (step < 0 && stop < start)
-        n = static_cast<std::size_t>((start - stop + (-step) - 1) / (-step));
+    if (step > 0 && stop > start) {
+        std::uint64_t span = static_cast<std::uint64_t>(stop) - static_cast<std::uint64_t>(start);
+        std::uint64_t mag  = static_cast<std::uint64_t>(step);
+        n = static_cast<std::size_t>((span + mag - 1) / mag);
+    } else if (step < 0 && stop < start) {
+        std::uint64_t span = static_cast<std::uint64_t>(start) - static_cast<std::uint64_t>(stop);
+        std::uint64_t mag  = 0u - static_cast<std::uint64_t>(step);   // |step|, safe for INT64_MIN
+        n = static_cast<std::size_t>((span + mag - 1) / mag);
+    }
     vec::dense_vector<T> v(n);
     std::int64_t sample = start;
-    for (std::size_t i = 0; i < n; ++i) { v[i] = T(sample); sample += step; }
+    for (std::size_t i = 0; i < n; ++i) {
+        v[i] = T(sample);
+        if (i + 1 < n) sample += step;   // skip the unused final increment (would overflow)
+    }
     return v;
 }
 
@@ -31,6 +43,8 @@ vec::dense_vector<T> arange(std::int64_t start, std::int64_t stop, std::int64_t 
 /// with endpoint == false the interval is treated as half-open.
 template <typename T = double>
 vec::dense_vector<T> linspace(const T& start, const T& stop, std::size_t steps, bool endpoint = true) {
+    static_assert(!std::is_integral_v<T>,
+                  "linspace requires a non-integral scalar T; integral T truncates the spacing");
     if (steps == 0) return vec::dense_vector<T>();
     vec::dense_vector<T> v(steps);
     if (steps == 1) { v[0] = start; return v; }
@@ -46,6 +60,8 @@ vec::dense_vector<T> linspace(const T& start, const T& stop, std::size_t steps, 
 /// `stop` are exponents, not endpoints (see geomspace for endpoint semantics).
 template <typename T = double>
 vec::dense_vector<T> logspace(const T& start, const T& stop, std::size_t steps, bool endpoint = true, const T& base = T(10)) {
+    static_assert(!std::is_integral_v<T>,
+                  "logspace requires a non-integral scalar T; integral T truncates the spacing");
     using std::pow;
     vec::dense_vector<T> e = linspace(start, stop, steps, endpoint);
     for (std::size_t i = 0; i < e.size(); ++i) e[i] = pow(base, e[i]);
@@ -61,7 +77,16 @@ vec::dense_vector<T> logspace(const T& start, const T& stop, std::size_t steps, 
 /// geometric progression: geomspace(1, 1000, 4) == {1, 10, 100, 1000}.
 template <typename T = double>
 vec::dense_vector<T> geomspace(const T& start, const T& stop, std::size_t steps, bool endpoint = true) {
+    static_assert(!std::is_integral_v<T>,
+                  "geomspace requires a non-integral scalar T; integral T truncates the spacing");
     using std::pow;
+    // A geometric progression is undefined through zero or across a sign change:
+    // ratio = stop/start would divide by zero or, for opposite signs, feed a
+    // negative base to pow(ratio, fractional) and yield NaN. Reject up front.
+    if (start == T(0) || stop == T(0))
+        throw std::invalid_argument("geomspace: endpoints must be nonzero");
+    if ((start < T(0)) != (stop < T(0)))
+        throw std::invalid_argument("geomspace: endpoints must have the same sign");
     if (steps == 0) return vec::dense_vector<T>();
     vec::dense_vector<T> v(steps);
     if (steps == 1) { v[0] = start; return v; }

--- a/include/mtl/generators/ranges.hpp
+++ b/include/mtl/generators/ranges.hpp
@@ -1,0 +1,78 @@
+#pragma once
+// MTL5 -- range / spacing vector generators (NumPy-style)
+// arange, linspace, logspace, geomspace. Each returns a vec::dense_vector<T>
+// and is generic over the scalar type T (Universal-free).
+#include <cstddef>
+#include <cstdint>
+#include <cmath>
+#include <mtl/vec/dense_vector.hpp>
+
+namespace mtl::generators {
+
+/// arange: integer-strided sequence projected into T over the half-open
+/// interval [start, stop) (NumPy semantics -- the stop value is excluded).
+/// Returns an empty vector if step == 0 or the interval is empty.
+template <typename T = double>
+vec::dense_vector<T> arange(std::int64_t start, std::int64_t stop, std::int64_t step = 1) {
+    if (step == 0) return vec::dense_vector<T>();
+    std::size_t n = 0;
+    if (step > 0 && stop > start)
+        n = static_cast<std::size_t>((stop - start + step - 1) / step);
+    else if (step < 0 && stop < start)
+        n = static_cast<std::size_t>((start - stop + (-step) - 1) / (-step));
+    vec::dense_vector<T> v(n);
+    std::int64_t sample = start;
+    for (std::size_t i = 0; i < n; ++i) { v[i] = T(sample); sample += step; }
+    return v;
+}
+
+/// linspace: `steps` evenly spaced samples over the interval [start, stop].
+/// With endpoint == true (default, NumPy semantics) stop is the last sample;
+/// with endpoint == false the interval is treated as half-open.
+template <typename T = double>
+vec::dense_vector<T> linspace(const T& start, const T& stop, std::size_t steps, bool endpoint = true) {
+    if (steps == 0) return vec::dense_vector<T>();
+    vec::dense_vector<T> v(steps);
+    if (steps == 1) { v[0] = start; return v; }
+    std::size_t divisor = endpoint ? steps - 1 : steps;   // number of segments
+    T step = (stop - start) / T(divisor);
+    for (std::size_t i = 0; i < steps; ++i) v[i] = start + T(i) * step;
+    if (endpoint) v[steps - 1] = stop;                    // pin the exact endpoint
+    return v;
+}
+
+/// logspace: `steps` samples whose exponents are evenly spaced over
+/// [start, stop]; element i equals base^exponent_i. As in NumPy, `start` and
+/// `stop` are exponents, not endpoints (see geomspace for endpoint semantics).
+template <typename T = double>
+vec::dense_vector<T> logspace(const T& start, const T& stop, std::size_t steps, bool endpoint = true, const T& base = T(10)) {
+    using std::pow;
+    vec::dense_vector<T> e = linspace(start, stop, steps, endpoint);
+    for (std::size_t i = 0; i < e.size(); ++i) e[i] = pow(base, e[i]);
+    return e;
+}
+
+/// geomspace: `steps` samples in a geometric progression from `start` to `stop`
+/// (NumPy semantics -- start and stop are the actual endpoints). Requires
+/// start and stop to be nonzero and of the same sign.
+///
+/// Note: unlike the historical Universal implementation (which aliased logspace
+/// and therefore treated the endpoints as exponents), this computes a true
+/// geometric progression: geomspace(1, 1000, 4) == {1, 10, 100, 1000}.
+template <typename T = double>
+vec::dense_vector<T> geomspace(const T& start, const T& stop, std::size_t steps, bool endpoint = true) {
+    using std::pow;
+    if (steps == 0) return vec::dense_vector<T>();
+    vec::dense_vector<T> v(steps);
+    if (steps == 1) { v[0] = start; return v; }
+    std::size_t divisor = endpoint ? steps - 1 : steps;
+    T ratio = stop / start;
+    for (std::size_t i = 0; i < steps; ++i) {
+        T t = T(i) / T(divisor);
+        v[i] = start * pow(ratio, t);
+    }
+    if (endpoint) v[steps - 1] = stop;                    // pin the exact endpoint
+    return v;
+}
+
+} // namespace mtl::generators

--- a/include/mtl/generators/ranges.hpp
+++ b/include/mtl/generators/ranges.hpp
@@ -19,15 +19,17 @@ vec::dense_vector<T> arange(std::int64_t start, std::int64_t stop, std::int64_t 
     if (step == 0) return vec::dense_vector<T>();
     // Count the elements in unsigned arithmetic so it never overflows for valid
     // int64 arguments (spans near INT64_MIN..INT64_MAX, or step == INT64_MIN).
+    // ceil(span / mag) written as span/mag + (span%mag != 0) so it stays exact
+    // even when span is the full uint64 range (span + mag - 1 would itself wrap).
     std::size_t n = 0;
     if (step > 0 && stop > start) {
         std::uint64_t span = static_cast<std::uint64_t>(stop) - static_cast<std::uint64_t>(start);
         std::uint64_t mag  = static_cast<std::uint64_t>(step);
-        n = static_cast<std::size_t>((span + mag - 1) / mag);
+        n = static_cast<std::size_t>(span / mag + (span % mag != 0));
     } else if (step < 0 && stop < start) {
         std::uint64_t span = static_cast<std::uint64_t>(start) - static_cast<std::uint64_t>(stop);
         std::uint64_t mag  = 0u - static_cast<std::uint64_t>(step);   // |step|, safe for INT64_MIN
-        n = static_cast<std::size_t>((span + mag - 1) / mag);
+        n = static_cast<std::size_t>(span / mag + (span % mag != 0));
     }
     vec::dense_vector<T> v(n);
     std::int64_t sample = start;

--- a/tests/unit/generators/test_magic.cpp
+++ b/tests/unit/generators/test_magic.cpp
@@ -35,6 +35,13 @@ TEST_CASE("magic dimensions", "[generators][magic]") {
     REQUIRE(A.num_cols() == 5);
 }
 
+TEST_CASE("magic order 1 (minimum supported)", "[generators][magic]") {
+    auto A = generators::magic<double>(1);
+    REQUIRE(A.num_rows() == 1);
+    REQUIRE(A.num_cols() == 1);
+    REQUIRE_THAT(A(0, 0), WithinAbs(1.0, 1e-12));   // the only cell holds 1
+}
+
 TEST_CASE("magic order 3 known values", "[generators][magic]") {
     auto A = generators::magic<double>(3);
     // Siamese 3x3:  8 1 6 / 3 5 7 / 4 9 2

--- a/tests/unit/generators/test_magic.cpp
+++ b/tests/unit/generators/test_magic.cpp
@@ -1,0 +1,80 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <vector>
+#include <mtl/generators/magic.hpp>
+
+using namespace mtl;
+using Catch::Matchers::WithinAbs;
+
+namespace {
+    // the magic constant: every row/column/diagonal sums to N(N^2+1)/2
+    double magic_constant(std::size_t N) { return double(N) * (double(N) * double(N) + 1.0) / 2.0; }
+
+    template <typename M>
+    void require_magic(const M& A, std::size_t N) {
+        const double M0 = magic_constant(N);
+        // rows and columns
+        for (std::size_t i = 0; i < N; ++i) {
+            double rsum = 0.0, csum = 0.0;
+            for (std::size_t j = 0; j < N; ++j) { rsum += A(i, j); csum += A(j, i); }
+            REQUIRE_THAT(rsum, WithinAbs(M0, 1e-9));
+            REQUIRE_THAT(csum, WithinAbs(M0, 1e-9));
+        }
+        // both main diagonals
+        double d1 = 0.0, d2 = 0.0;
+        for (std::size_t i = 0; i < N; ++i) { d1 += A(i, i); d2 += A(i, N - 1 - i); }
+        REQUIRE_THAT(d1, WithinAbs(M0, 1e-9));
+        REQUIRE_THAT(d2, WithinAbs(M0, 1e-9));
+    }
+}
+
+TEST_CASE("magic dimensions", "[generators][magic]") {
+    auto A = generators::magic<double>(5);
+    REQUIRE(A.num_rows() == 5);
+    REQUIRE(A.num_cols() == 5);
+}
+
+TEST_CASE("magic order 3 known values", "[generators][magic]") {
+    auto A = generators::magic<double>(3);
+    // Siamese 3x3:  8 1 6 / 3 5 7 / 4 9 2
+    REQUIRE_THAT(A(0, 0), WithinAbs(8.0, 1e-12));
+    REQUIRE_THAT(A(0, 1), WithinAbs(1.0, 1e-12));
+    REQUIRE_THAT(A(0, 2), WithinAbs(6.0, 1e-12));
+    REQUIRE_THAT(A(1, 1), WithinAbs(5.0, 1e-12));
+    REQUIRE_THAT(A(2, 0), WithinAbs(4.0, 1e-12));
+    REQUIRE_THAT(A(2, 1), WithinAbs(9.0, 1e-12));
+    require_magic(A, 3);
+}
+
+TEST_CASE("magic odd orders are magic", "[generators][magic]") {
+    require_magic(generators::magic<double>(5), 5);   // constant 65
+    require_magic(generators::magic<double>(7), 7);   // constant 175
+    require_magic(generators::magic<double>(9), 9);   // constant 369
+}
+
+TEST_CASE("magic doubly-even orders are magic", "[generators][magic]") {
+    require_magic(generators::magic<double>(4), 4);   // constant 34
+    require_magic(generators::magic<double>(8), 8);   // constant 260
+    require_magic(generators::magic<double>(12), 12); // constant 870
+}
+
+TEST_CASE("magic contains a permutation of 1..N^2", "[generators][magic]") {
+    const std::size_t N = 5;
+    auto A = generators::magic<double>(N);
+    std::vector<bool> seen(N * N + 1, false);
+    for (std::size_t i = 0; i < N; ++i)
+        for (std::size_t j = 0; j < N; ++j) {
+            auto v = static_cast<std::size_t>(A(i, j) + 0.5);
+            REQUIRE(v >= 1);
+            REQUIRE(v <= N * N);
+            REQUIRE_FALSE(seen[v]);   // no duplicates
+            seen[v] = true;
+        }
+}
+
+TEST_CASE("magic unsupported orders throw", "[generators][magic]") {
+    REQUIRE_THROWS_AS(generators::magic<double>(0), std::invalid_argument);
+    REQUIRE_THROWS_AS(generators::magic<double>(6), std::invalid_argument);  // singly-even
+    REQUIRE_THROWS_AS(generators::magic<double>(10), std::invalid_argument); // singly-even
+}

--- a/tests/unit/generators/test_ranges.cpp
+++ b/tests/unit/generators/test_ranges.cpp
@@ -2,6 +2,9 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 #include <cmath>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
 #include <mtl/generators/ranges.hpp>
 
 using namespace mtl;
@@ -34,6 +37,19 @@ TEST_CASE("arange empty and degenerate", "[generators][ranges][arange]") {
     REQUIRE(generators::arange<double>(5, 0).size() == 0);   // wrong direction
     REQUIRE(generators::arange<double>(0, 0).size() == 0);   // empty
     REQUIRE(generators::arange<double>(0, 5, 0).size() == 0);// zero step
+}
+
+TEST_CASE("arange int64 extremes do not overflow", "[generators][ranges][arange]") {
+    constexpr std::int64_t IMAX = std::numeric_limits<std::int64_t>::max();
+    constexpr std::int64_t IMIN = std::numeric_limits<std::int64_t>::min();
+    // One element just below the max: the unused final increment must not overflow.
+    auto a = generators::arange<double>(IMAX - 1, IMAX, 2);
+    REQUIRE(a.size() == 1);
+    REQUIRE_THAT(a[0], WithinAbs(double(IMAX - 1), 0.0));
+    // Descending with step == INT64_MIN: |step| must be computed without overflow.
+    auto b = generators::arange<double>(0, IMIN, IMIN);   // one element: 0
+    REQUIRE(b.size() == 1);
+    REQUIRE_THAT(b[0], WithinAbs(0.0, 0.0));
 }
 
 // -- linspace ------------------------------------------------------------
@@ -96,5 +112,17 @@ TEST_CASE("geomspace negative same-sign endpoints", "[generators][ranges][geomsp
     auto v = generators::geomspace<double>(-1000.0, -1.0, 4);   // -1000,-100,-10,-1
     REQUIRE(v.size() == 4);
     REQUIRE_THAT(v[0], WithinAbs(-1000.0, 1e-6));
+    REQUIRE_THAT(v[1], WithinAbs(-100.0, 1e-6));   // interior values, geometric
+    REQUIRE_THAT(v[2], WithinAbs(-10.0, 1e-6));
     REQUIRE_THAT(v[3], WithinAbs(-1.0, 1e-9));
+}
+
+TEST_CASE("geomspace rejects invalid domains", "[generators][ranges][geomspace]") {
+    using generators::geomspace;
+    // zero endpoint: ratio would divide by zero
+    REQUIRE_THROWS_AS(geomspace<double>(0.0, 10.0, 4), std::invalid_argument);
+    REQUIRE_THROWS_AS(geomspace<double>(1.0, 0.0, 4), std::invalid_argument);
+    // opposite signs: pow(negative ratio, fractional) is NaN
+    REQUIRE_THROWS_AS(geomspace<double>(-1.0, 1000.0, 4), std::invalid_argument);
+    REQUIRE_THROWS_AS(geomspace<double>(1.0, -1000.0, 4), std::invalid_argument);
 }

--- a/tests/unit/generators/test_ranges.cpp
+++ b/tests/unit/generators/test_ranges.cpp
@@ -50,6 +50,11 @@ TEST_CASE("arange int64 extremes do not overflow", "[generators][ranges][arange]
     auto b = generators::arange<double>(0, IMIN, IMIN);   // one element: 0
     REQUIRE(b.size() == 1);
     REQUIRE_THAT(b[0], WithinAbs(0.0, 0.0));
+    // Full-range span: the ceiling-division count must not wrap in uint64.
+    auto c = generators::arange<double>(IMIN, IMAX, IMAX);   // IMIN, -1, IMAX-1
+    REQUIRE(c.size() == 3);
+    REQUIRE_THAT(c[0], WithinAbs(double(IMIN), 0.0));
+    REQUIRE_THAT(c[1], WithinAbs(-1.0, 0.0));
 }
 
 // -- linspace ------------------------------------------------------------

--- a/tests/unit/generators/test_ranges.cpp
+++ b/tests/unit/generators/test_ranges.cpp
@@ -1,0 +1,100 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <cmath>
+#include <mtl/generators/ranges.hpp>
+
+using namespace mtl;
+using Catch::Matchers::WithinAbs;
+
+// -- arange (half-open, NumPy semantics) ---------------------------------
+
+TEST_CASE("arange basic half-open", "[generators][ranges][arange]") {
+    auto v = generators::arange<double>(0, 5);
+    REQUIRE(v.size() == 5);
+    for (std::size_t i = 0; i < 5; ++i) REQUIRE_THAT(v[i], WithinAbs(double(i), 1e-12));
+    // stop is excluded
+}
+
+TEST_CASE("arange with step", "[generators][ranges][arange]") {
+    auto v = generators::arange<double>(1, 10, 2);   // 1,3,5,7,9
+    REQUIRE(v.size() == 5);
+    REQUIRE_THAT(v[0], WithinAbs(1.0, 1e-12));
+    REQUIRE_THAT(v[4], WithinAbs(9.0, 1e-12));
+}
+
+TEST_CASE("arange negative step", "[generators][ranges][arange]") {
+    auto v = generators::arange<double>(5, 0, -1);   // 5,4,3,2,1
+    REQUIRE(v.size() == 5);
+    REQUIRE_THAT(v[0], WithinAbs(5.0, 1e-12));
+    REQUIRE_THAT(v[4], WithinAbs(1.0, 1e-12));
+}
+
+TEST_CASE("arange empty and degenerate", "[generators][ranges][arange]") {
+    REQUIRE(generators::arange<double>(5, 0).size() == 0);   // wrong direction
+    REQUIRE(generators::arange<double>(0, 0).size() == 0);   // empty
+    REQUIRE(generators::arange<double>(0, 5, 0).size() == 0);// zero step
+}
+
+// -- linspace ------------------------------------------------------------
+
+TEST_CASE("linspace endpoint inclusive", "[generators][ranges][linspace]") {
+    auto v = generators::linspace<double>(0.0, 1.0, 5);   // 0,.25,.5,.75,1
+    REQUIRE(v.size() == 5);
+    REQUIRE_THAT(v[0], WithinAbs(0.0, 1e-12));
+    REQUIRE_THAT(v[1], WithinAbs(0.25, 1e-12));
+    REQUIRE_THAT(v[2], WithinAbs(0.50, 1e-12));
+    REQUIRE_THAT(v[3], WithinAbs(0.75, 1e-12));
+    REQUIRE_THAT(v[4], WithinAbs(1.0, 1e-12));   // exact endpoint
+}
+
+TEST_CASE("linspace endpoint exclusive", "[generators][ranges][linspace]") {
+    auto v = generators::linspace<double>(0.0, 1.0, 5, false);   // 0,.2,.4,.6,.8
+    REQUIRE(v.size() == 5);
+    REQUIRE_THAT(v[0], WithinAbs(0.0, 1e-12));
+    REQUIRE_THAT(v[1], WithinAbs(0.2, 1e-12));
+    REQUIRE_THAT(v[4], WithinAbs(0.8, 1e-12));
+}
+
+TEST_CASE("linspace edge cases", "[generators][ranges][linspace]") {
+    REQUIRE(generators::linspace<double>(0.0, 1.0, 0).size() == 0);
+    auto one = generators::linspace<double>(3.0, 9.0, 1);
+    REQUIRE(one.size() == 1);
+    REQUIRE_THAT(one[0], WithinAbs(3.0, 1e-12));
+}
+
+// -- logspace (start/stop are exponents) ---------------------------------
+
+TEST_CASE("logspace base 10 exponents", "[generators][ranges][logspace]") {
+    auto v = generators::logspace<double>(0.0, 3.0, 4);   // 10^0..10^3
+    REQUIRE(v.size() == 4);
+    REQUIRE_THAT(v[0], WithinAbs(1.0, 1e-9));
+    REQUIRE_THAT(v[1], WithinAbs(10.0, 1e-9));
+    REQUIRE_THAT(v[2], WithinAbs(100.0, 1e-9));
+    REQUIRE_THAT(v[3], WithinAbs(1000.0, 1e-9));
+}
+
+// -- geomspace (start/stop are endpoints -- fixes the old Universal bug) --
+
+TEST_CASE("geomspace decade endpoints", "[generators][ranges][geomspace]") {
+    auto v = generators::geomspace<double>(1.0, 1000.0, 4);   // 1,10,100,1000
+    REQUIRE(v.size() == 4);
+    REQUIRE_THAT(v[0], WithinAbs(1.0, 1e-9));
+    REQUIRE_THAT(v[1], WithinAbs(10.0, 1e-9));
+    REQUIRE_THAT(v[2], WithinAbs(100.0, 1e-9));
+    REQUIRE_THAT(v[3], WithinAbs(1000.0, 1e-9));
+}
+
+TEST_CASE("geomspace powers of two", "[generators][ranges][geomspace]") {
+    auto v = generators::geomspace<double>(1.0, 256.0, 9);   // 1,2,4,...,256
+    REQUIRE(v.size() == 9);
+    for (std::size_t i = 0; i < 9; ++i)
+        REQUIRE_THAT(v[i], WithinAbs(std::pow(2.0, double(i)), 1e-6));
+}
+
+TEST_CASE("geomspace negative same-sign endpoints", "[generators][ranges][geomspace]") {
+    auto v = generators::geomspace<double>(-1000.0, -1.0, 4);   // -1000,-100,-10,-1
+    REQUIRE(v.size() == 4);
+    REQUIRE_THAT(v[0], WithinAbs(-1000.0, 1e-6));
+    REQUIRE_THAT(v[3], WithinAbs(-1.0, 1e-9));
+}


### PR DESCRIPTION
## Summary
First step of extracting the linear-algebra layer out of Universal into MTL5 (Universal epic stillwater-sc/universal#1204, phase stillwater-sc/universal#1206). The survey of Universal's `sw::blas` vs MTL5 found MTL5 already has essentially the entire BLAS surface -- the only genuinely-missing utilities are the NumPy-style range/spacing vectors and `magic`. This adds them.

## What's added
- **`generators/ranges.hpp`** -- `arange`, `linspace`, `logspace`, `geomspace`, returning `vec::dense_vector<T>`, generic over the scalar type (Universal-free, `mtl::generators` namespace).
  - `arange` -- half-open `[start, stop)` integer-strided (NumPy semantics).
  - `linspace` -- `steps` samples over `[start, stop]`, endpoint pinned exactly; `endpoint=false` for the half-open variant.
  - `logspace` -- `base^linspace(start, stop)` (start/stop are exponents).
  - `geomspace` -- **true geometric progression between the endpoints**. This corrects the historical Universal implementation, which aliased `logspace` and treated the endpoints as exponents (making `geomspace(1,1000,4)` wildly wrong); it now yields `{1, 10, 100, 1000}`.
- **`generators/magic.hpp`** -- magic square of order N: odd via the Siamese method, doubly-even (`N%4==0`) via the complement method. Singly-even orders throw `std::invalid_argument` pending support. Every row/column/diagonal sums to `N(N^2+1)/2`.
- Both added to `generators/generators.hpp`; CHANGELOG updated.

## Tests (`tests/unit/generators/`)
- `test_ranges.cpp` -- 51 assertions / 11 cases (arange half-open + negative step + degenerate; linspace inclusive/exclusive/edge; logspace decades; geomspace decades, powers-of-two, negative same-sign).
- `test_magic.cpp` -- 196 assertions / 6 cases (magic-constant on odd + doubly-even orders, permutation-of-`1..N^2`, known 3x3 values, unsupported-order throws).

| | gcc (ctest) | clang (-Wall -Wpedantic) |
|---|---|---|
| build | OK | OK |
| tests | PASS | PASS (headers) |

## Notes
- Universal-free: no `find_package(universal)`; generic over the `Scalar` type.
- `linspace` was the specifically-requested gap; `geomspace` is delivered corrected rather than a verbatim port of the buggy Universal version.

Part of the Universal->MTL5 BLAS extraction (stillwater-sc/universal#1206).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added NumPy-style `arange`, `linspace`, `logspace`, and `geomspace` vector generators with dense output, endpoint control, and input validation (including true geometric progression for `geomspace`).
  - Added `magic` square matrix generator supporting odd and doubly-even sizes, with exceptions for unsupported/invalid orders.
  - Exposed the new generators through the main generator interface.
- **Tests**
  - Added unit tests validating magic-square properties and generator edge cases.
- **Documentation**
  - Updated the unreleased changelog to describe the new generators and semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->