### PR TITLE
fix(idr_s): replace std::normal_distribution with portable Box-Muller

### DIFF
--- a/include/mtl/itl/krylov/idr_s.hpp
+++ b/include/mtl/itl/krylov/idr_s.hpp
@@ -29,12 +29,20 @@ int idr_s(const LinearOp& A, VecX& x, const VecB& b, const PC& M, Iter& iter,
 
     // Random shadow space P (n x s)
     std::mt19937 gen(42);
-    std::normal_distribution<double> dist(0.0, 1.0);
+    auto next_uniform = [&gen]() {
+        return static_cast<double>(gen() - gen.min()) /
+               static_cast<double>(gen.max() - gen.min());
+    };
+    auto next_normal = [&]() {
+        double u1 = std::max(next_uniform(), 1e-12);
+        double u2 = next_uniform();
+        return std::sqrt(-2.0 * std::log(u1)) * std::cos(2.0 * M_PI * u2);
+    };
 
     std::vector<vec::dense_vector<value_type>> P(s, vec::dense_vector<value_type>(n));
     for (size_type j = 0; j < s; ++j)
         for (size_type i = 0; i < n; ++i)
-            P[j](i) = value_type(dist(gen));
+            P[j](i) = value_type(next_normal());
 
     // Workspace
     vec::dense_vector<value_type> r(n), v(n), t(n);

--- a/include/mtl/itl/krylov/idr_s.hpp
+++ b/include/mtl/itl/krylov/idr_s.hpp
@@ -4,6 +4,7 @@
 // Parameter s controls shadow space dimension (default 4).
 #include <cmath>
 #include <random>
+#include <numbers>
 #include <vector>
 #include <mtl/vec/dense_vector.hpp>
 #include <mtl/mat/dense2D.hpp>
@@ -36,7 +37,7 @@ int idr_s(const LinearOp& A, VecX& x, const VecB& b, const PC& M, Iter& iter,
     auto next_normal = [&]() {
         double u1 = std::max(next_uniform(), 1e-12);
         double u2 = next_uniform();
-        return std::sqrt(-2.0 * std::log(u1)) * std::cos(2.0 * M_PI * u2);
+        return std::sqrt(-2.0 * std::log(u1)) * std::cos(2.0 * std::numbers::pi_v<double> * u2);
     };
 
     std::vector<vec::dense_vector<value_type>> P(s, vec::dense_vector<value_type>(n));


### PR DESCRIPTION
Closes #274

`idr_s`'s shadow space `P` was seeded via `std::mt19937(42)` +`std::normal_distribution<double>`. While `mt19937` is portable, `std::normal_distribution`'s output is implementation-defined even with identical seed/engine state — libstdc++ (Linux GCC/Clang), libc++ (macOS), and MSVC's STL each produce a different sequence from the same seed.

This caused `idr_s` to converge along different (valid) trajectories per platform, which tripped the quire-vs-naive residual comparison in mp-iterative's `test_idr_s_quire` on macOS ARM64 and Windows x64 while passing on Linux (both Linux jobs use libstdc++, so they agreed with each other by coincidence, not by correctness).

Fix: replaced `std::normal_distribution` with a hand-rolled Box-Muller transform driven directly from `mt19937`'s portable integer output, so `P` is now bit-identical across platforms.

Verified locally: `itl_test_idr_s` builds clean and passes on WSL/Linux. Cross-platform fix should be confirmed once mp-iterative's PR re-runs CI against this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the random value generation used by the IDR(s) solver’s internal shadow space.
  * Added safeguards to avoid invalid numerical operations during random sampling.
  * Solver behavior and overall control flow remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->