### PR TITLE
feat(itl): wire accumulator_traits into qmr -- posit+quire accuracy path

### DIFF
--- a/include/mtl/itl/krylov/qmr.hpp
+++ b/include/mtl/itl/krylov/qmr.hpp
@@ -7,12 +7,13 @@
 #include <mtl/operation/dot.hpp>
 #include <mtl/operation/norms.hpp>
 #include <mtl/operation/trans.hpp>
+#include <mtl/operation/mult.hpp>
 
 namespace mtl::itl {
 
 /// QMR solver for non-symmetric systems A*x = b.
 template <typename LinearOp, typename VecX, typename VecB,
-          typename PC, typename Iter>
+          typename PC, typename Iter, typename Accumulator = void>
 int qmr(const LinearOp& A, VecX& x, const VecB& b, const PC& M, Iter& iter) {
     using value_type = typename VecX::value_type;
     using size_type  = typename VecX::size_type;
@@ -25,7 +26,8 @@ int qmr(const LinearOp& A, VecX& x, const VecB& b, const PC& M, Iter& iter) {
     vec::dense_vector<value_type> p(n), q(n), d(n), s(n), p_tilde(n);
 
     // r = b - A*x
-    auto Ax = A * x;
+    vec::dense_vector<value_type> Ax(n);
+    mtl::mult<Accumulator>(A, x, Ax);
     for (size_type i = 0; i < n; ++i) {
         r(i) = b(i) - Ax(i);
         v_tilde(i) = r(i);
@@ -64,7 +66,7 @@ int qmr(const LinearOp& A, VecX& x, const VecB& b, const PC& M, Iter& iter) {
             z(i) = z(i) / xi;
         }
 
-        value_type delta = mtl::dot(z, y);
+        value_type delta = mtl::dot<Accumulator, value_type>(z, y);
         if (delta == value_type(0)) {
             iter.fail(2, "qmr breakdown: delta == 0");
             return iter;
@@ -87,11 +89,9 @@ int qmr(const LinearOp& A, VecX& x, const VecB& b, const PC& M, Iter& iter) {
         }
 
         // p_tilde = A * p
-        auto Ap = A * p;
-        for (size_type i = 0; i < n; ++i)
-            p_tilde(i) = Ap(i);
+        mtl::mult<Accumulator>(A, p, p_tilde);
 
-        epsilon = mtl::dot(q, p_tilde);
+        epsilon = mtl::dot<Accumulator, value_type>(q, p_tilde);
         if (epsilon == value_type(0)) {
             iter.fail(2, "qmr breakdown: epsilon == 0");
             return iter;
@@ -109,7 +109,8 @@ int qmr(const LinearOp& A, VecX& x, const VecB& b, const PC& M, Iter& iter) {
         value_type rho_new = mtl::two_norm(y);
 
         // w_tilde = A^T * q - beta * w
-        auto Atq = trans(A) * q;
+        vec::dense_vector<value_type> Atq(n);
+        mtl::mult<Accumulator>(trans(A), q, Atq);
         for (size_type i = 0; i < n; ++i)
             w_tilde(i) = Atq(i) - beta * w(i);
 

--- a/include/mtl/operation/mult.hpp
+++ b/include/mtl/operation/mult.hpp
@@ -9,6 +9,8 @@
 #include <mtl/math/accumulator_traits.hpp>
 #include <mtl/interface/dispatch_traits.hpp>
 #include <mtl/mat/compressed2D.hpp>
+#include <mtl/mat/view/transposed_view.hpp>
+#include <vector>
 #ifdef MTL5_HAS_BLAS
 #include <mtl/interface/blas.hpp>
 #endif
@@ -121,6 +123,43 @@ void mult_generic(const MA& A, const MB& B, MC& C) {
     }
 }
 
+
+/// Transposed sparse CRS mat*vec: y = A^T * x, O(nnz), scatter into y.
+/// Mirrors mat::operator*(transposed_view<compressed2D>, dense_vector) but
+/// adds Accumulator support so mixed-precision / quire accumulation works
+/// on transposed sparse matvecs too. Scatter pattern means each y(j)
+/// receives contributions from multiple rows r, so accumulation is done
+/// per-output-element rather than per-row.
+template <typename Accumulator = void, typename V, typename P, typename VIn, typename VOut>
+void mult_sparse_crs_transposed(const mat::view::transposed_view<mat::compressed2D<V, P>>& At,
+                                 const VIn& x, VOut& y) {
+    using Result = typename VOut::value_type;
+    using size_type = typename mat::compressed2D<V, P>::size_type;
+    const auto& A = At.base();
+    const auto& starts  = A.ref_major();
+    const auto& indices = A.ref_minor();
+    const auto& data    = A.ref_data();
+    const std::size_t nrows = A.num_rows();
+    for (typename VOut::size_type i = 0; i < y.size(); ++i)
+        y(i) = math::zero<Result>();
+    if constexpr (std::is_void_v<Accumulator>) {
+        using Value = std::common_type_t<V, typename VIn::value_type>;
+        for (std::size_t r = 0; r < nrows; ++r)
+            for (size_type k = starts[r]; k < starts[r + 1]; ++k)
+                y(indices[k]) += static_cast<Result>(static_cast<Value>(data[k]) * static_cast<Value>(x(r)));
+    } else {
+        using Value = std::common_type_t<V, typename VIn::value_type>;
+        using AT = math::accumulator_traits<Accumulator, Value>;
+        std::vector<Accumulator> accs(y.size());
+        for (auto& a : accs) AT::clear(a);
+        for (std::size_t r = 0; r < nrows; ++r)
+            for (size_type k = starts[r]; k < starts[r + 1]; ++k)
+                AT::add_product(accs[indices[k]], static_cast<Value>(data[k]), static_cast<Value>(x(r)));
+        for (typename VOut::size_type j = 0; j < y.size(); ++j)
+            y(j) = AT::template value<Result>(accs[j]);
+    }
+}
+
 } // namespace detail
 
 /// mat*vec multiply into pre-allocated y: y = A * x.
@@ -129,6 +168,16 @@ void mult_generic(const MA& A, const MB& B, MC& C) {
 /// precision distinct from the operand element type; the result is rounded out to
 /// y's element type. Default `Accumulator = void` keeps the BLAS / native-fast /
 /// generic dispatch unchanged.
+/// mat*vec multiply for a transposed sparse view: y = A^T * x, O(nnz).
+/// Mirrors mat::operator*(transposed_view<compressed2D>, dense_vector) but
+/// adds Accumulator support for mixed-precision / quire accumulation.
+template <typename Accumulator = void, typename V, typename P, typename VIn, typename VOut>
+void mult(const mat::view::transposed_view<mat::compressed2D<V, P>>& At, const VIn& x, VOut& y) {
+    assert(At.num_cols() == x.size());
+    assert(At.num_rows() == y.size());
+    detail::mult_sparse_crs_transposed<Accumulator>(At, x, y);
+}
+
 template <typename Accumulator = void, Matrix M, Vector VIn, Vector VOut>
 void mult(const M& A, const VIn& x, VOut& y) {
     assert(A.num_cols() == x.size());

--- a/tests/unit/itl/test_qmr_accumulator.cpp
+++ b/tests/unit/itl/test_qmr_accumulator.cpp
@@ -27,44 +27,83 @@ TEST_CASE("QMR default (unspecified Accumulator) behavior is unchanged",
     vec::dense_vector<double> x1(3, 0.0);
     itl::pc::identity<mat::dense2D<double>> pc1(A);
     itl::basic_iteration<double> iter1(b, 200, 1e-10);
-    itl::qmr(A, x1, b, pc1, iter1);
+    int err1 = itl::qmr(A, x1, b, pc1, iter1);
 
     vec::dense_vector<double> x2(3, 0.0);
     itl::pc::identity<mat::dense2D<double>> pc2(A);
     itl::basic_iteration<double> iter2(b, 200, 1e-10);
-    itl::qmr<mat::dense2D<double>, vec::dense_vector<double>, vec::dense_vector<double>,
+    int err2 = itl::qmr<mat::dense2D<double>, vec::dense_vector<double>, vec::dense_vector<double>,
              itl::pc::identity<mat::dense2D<double>>, itl::basic_iteration<double>, void>
              (A, x2, b, pc2, iter2);
 
+    REQUIRE(err1 == 0);
+    REQUIRE(err2 == 0);
     for (std::size_t i = 0; i < 3; ++i)
         REQUIRE(x1(i) == x2(i));   // bit-for-bit identical
+
+    // Also confirm convergence is real, not just agreement between two failures.
+    auto r1 = A * x1;
+    for (std::size_t i = 0; i < 3; ++i)
+        REQUIRE_THAT(r1(i), WithinAbs(b(i), 1e-8));
 }
 
-TEST_CASE("QMR sparse tridiagonal system with explicit double Accumulator",
+TEST_CASE("QMR nonsymmetric sparse system with explicit float->double Accumulator",
           "[itl][qmr][accumulator]") {
+    // Nonsymmetric on purpose: A != A^T here, so a broken trans(A) routing
+    // (e.g. accidentally reusing A instead of A^T) would fail to converge
+    // or converge to the wrong solution, unlike a symmetric test matrix
+    // where A and A^T are indistinguishable. float operands with a double
+    // Accumulator also exercises genuine mixed-precision accumulation
+    // instead of a same-type no-op.
     const std::size_t n = 20;
-    mat::compressed2D<double> A(n, n);
+    mat::compressed2D<float> A(n, n);
     {
-        mat::inserter<mat::compressed2D<double>> ins(A);
+        mat::inserter<mat::compressed2D<float>> ins(A);
         for (std::size_t i = 0; i < n; ++i) {
-            ins[i][i] << 4.0;
-            if (i > 0)     ins[i][i-1] << -1.0;
-            if (i < n - 1) ins[i][i+1] << -1.0;
+            ins[i][i] << 4.0f;
+            if (i > 0)     ins[i][i-1] << -1.5f;   // asymmetric off-diagonals
+            if (i < n - 1) ins[i][i+1] << -0.5f;
         }
     }
-    vec::dense_vector<double> b(n, 1.0);
-    vec::dense_vector<double> x(n, 0.0);
+    vec::dense_vector<float> b(n, 1.0f);
+    vec::dense_vector<float> x(n, 0.0f);
 
-    itl::pc::identity<mat::compressed2D<double>> pc(A);
-    itl::basic_iteration<double> iter(b, 500, 1e-10);
+    itl::pc::identity<mat::compressed2D<float>> pc(A);
+    itl::basic_iteration<float> iter(b, 500, 1e-5f);
 
-    int err = itl::qmr<mat::compressed2D<double>, vec::dense_vector<double>,
-                        vec::dense_vector<double>, itl::pc::identity<mat::compressed2D<double>>,
-                        itl::basic_iteration<double>, double>
+    int err = itl::qmr<mat::compressed2D<float>, vec::dense_vector<float>,
+                        vec::dense_vector<float>, itl::pc::identity<mat::compressed2D<float>>,
+                        itl::basic_iteration<float>, double>
                         (A, x, b, pc, iter);
     REQUIRE(err == 0);
 
     auto Ax = A * x;
     for (std::size_t i = 0; i < n; ++i)
-        REQUIRE_THAT(Ax(i), WithinAbs(b(i), 1e-8));
+        REQUIRE_THAT(Ax(i), WithinAbs(b(i), 1e-3));
+}
+
+TEST_CASE("QMR transposed sparse matvec: A^T*x direct check",
+          "[itl][qmr][accumulator]") {
+    // Direct, isolated coverage for the mult<Accumulator>(trans(A), x, y)
+    // path qmr.hpp relies on: build a small nonsymmetric sparse matrix,
+    // compute A^T*x via mult(), and check it against a hand-computed
+    // reference -- independent of whether QMR itself converges.
+    mat::compressed2D<double> A(2, 3);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        ins[0][0] << 1.0; ins[0][1] << 2.0;
+        ins[1][1] << 3.0; ins[1][2] << 4.0;
+    }
+    // A = [1 2 0]
+    //     [0 3 4]
+    // A^T = [1 0]
+    //       [2 3]
+    //       [0 4]
+    vec::dense_vector<double> x = {1.0, 1.0};
+    vec::dense_vector<double> y(3, 0.0);
+    mtl::mult(trans(A), x, y);
+
+    REQUIRE_THAT(y(0), WithinAbs(1.0, 1e-12));
+    REQUIRE_THAT(y(1), WithinAbs(5.0, 1e-12));
+    REQUIRE_THAT(y(2), WithinAbs(4.0, 1e-12));
 }

--- a/tests/unit/itl/test_qmr_accumulator.cpp
+++ b/tests/unit/itl/test_qmr_accumulator.cpp
@@ -1,0 +1,70 @@
+// MTL5 -- accumulator policy for QMR (itl::qmr), mirroring cg/gmres (#237, #268).
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <cstddef>
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/mat/compressed2D.hpp>
+#include <mtl/mat/inserter.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/operation/operators.hpp>
+#include <mtl/operation/norms.hpp>
+#include <mtl/itl/pc/identity.hpp>
+#include <mtl/itl/iteration/basic_iteration.hpp>
+#include <mtl/itl/krylov/qmr.hpp>
+
+using namespace mtl;
+using Catch::Matchers::WithinAbs;
+
+TEST_CASE("QMR default (unspecified Accumulator) behavior is unchanged",
+          "[itl][qmr][accumulator]") {
+    mat::dense2D<double> A(3, 3);
+    A(0,0) = 4; A(0,1) = 1; A(0,2) = 0;
+    A(1,0) = 1; A(1,1) = 4; A(1,2) = 1;
+    A(2,0) = 0; A(2,1) = 1; A(2,2) = 4;
+
+    vec::dense_vector<double> b = {1.0, 2.0, 3.0};
+
+    vec::dense_vector<double> x1(3, 0.0);
+    itl::pc::identity<mat::dense2D<double>> pc1(A);
+    itl::basic_iteration<double> iter1(b, 200, 1e-10);
+    itl::qmr(A, x1, b, pc1, iter1);
+
+    vec::dense_vector<double> x2(3, 0.0);
+    itl::pc::identity<mat::dense2D<double>> pc2(A);
+    itl::basic_iteration<double> iter2(b, 200, 1e-10);
+    itl::qmr<mat::dense2D<double>, vec::dense_vector<double>, vec::dense_vector<double>,
+             itl::pc::identity<mat::dense2D<double>>, itl::basic_iteration<double>, void>
+             (A, x2, b, pc2, iter2);
+
+    for (std::size_t i = 0; i < 3; ++i)
+        REQUIRE(x1(i) == x2(i));   // bit-for-bit identical
+}
+
+TEST_CASE("QMR sparse tridiagonal system with explicit double Accumulator",
+          "[itl][qmr][accumulator]") {
+    const std::size_t n = 20;
+    mat::compressed2D<double> A(n, n);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        for (std::size_t i = 0; i < n; ++i) {
+            ins[i][i] << 4.0;
+            if (i > 0)     ins[i][i-1] << -1.0;
+            if (i < n - 1) ins[i][i+1] << -1.0;
+        }
+    }
+    vec::dense_vector<double> b(n, 1.0);
+    vec::dense_vector<double> x(n, 0.0);
+
+    itl::pc::identity<mat::compressed2D<double>> pc(A);
+    itl::basic_iteration<double> iter(b, 500, 1e-10);
+
+    int err = itl::qmr<mat::compressed2D<double>, vec::dense_vector<double>,
+                        vec::dense_vector<double>, itl::pc::identity<mat::compressed2D<double>>,
+                        itl::basic_iteration<double>, double>
+                        (A, x, b, pc, iter);
+    REQUIRE(err == 0);
+
+    auto Ax = A * x;
+    for (std::size_t i = 0; i < n; ++i)
+        REQUIRE_THAT(Ax(i), WithinAbs(b(i), 1e-8));
+}


### PR DESCRIPTION
Routes qmr.hpp's dot products and mult()/transpose-mult() calls through accumulator_traits, following the pattern established for cg, bicgstab, and gmres.

Also fixes a real bug found along the way: `transposed_view::operator()` bound `compressed2D`'s by-value `operator()` return to a dangling `const_reference`, causing UB (SIGSEGV under -O3) whenever a transposed sparse matvec went through the generic `mult()` path. Added a dedicated `mult_sparse_crs_transposed()` + `mult()` overload for `transposed_view<compressed2D<...>>`, mirroring the existing O(nnz) sparse transpose logic in `mat::operator*(transposed_view, vector)`, with Accumulator support added.

Unspecified-Accumulator behavior confirmed unchanged via regression test (bit-for-bit identical output, no Accumulator given).

Closes #276. Feeds stillwater-sc/mp-iterative#22.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable accumulation support to the QMR solver, including optional mixed-precision calculations.
  - Improved support for multiplying transposed sparse matrices by dense vectors.
  - Added compatibility for pre-allocated output vectors in these operations.

- **Bug Fixes**
  - Preserved existing QMR behavior when no accumulator type is specified.
  - Improved numerical reliability for sparse matrix operations and solver results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->