### PR TITLE
fix(mat): transposed_view dangling reference in operator()

### DIFF
--- a/include/mtl/mat/view/transposed_view.hpp
+++ b/include/mtl/mat/view/transposed_view.hpp
@@ -19,7 +19,14 @@ public:
 
     explicit transposed_view(const Matrix& m) : ref_(m) {}
 
-    const_reference operator()(size_type r, size_type c) const {
+    // NOTE: returns value_type by value, not const_reference. The underlying
+    // Matrix::operator() (e.g. compressed2D) returns value_type by value for
+    // sparse accessors (structural zeros have no storage to reference), so
+    // binding a const_reference to ref_(c, r) here produced a dangling
+    // reference to a temporary -- SIGSEGV the moment BiCG's trans(A) path
+    // exercised it through mult(). CG/BiCGSTAB/GMRES never triggered this
+    // since none of them multiply by trans(A).
+    value_type operator()(size_type r, size_type c) const {
         return ref_(c, r);
     }
 


### PR DESCRIPTION
## Summary
transposed_view::operator() declared const_reference as its return type but bound it to ref_(c, r), where compressed2D::operator() returns value_type by value for sparse accessors. This produced a reference to a temporary that dangled immediately.

## Bug
SIGSEGV the first time a caller exercised trans(A) through mult() -- BiCG's adjoint matvec (stillwater-sc/mp-iterative#18) is the first solver to multiply by trans(A); cg/bicgstab/gmres/idr_s never triggered this path (verified: no trans( calls in any of those four files).

## Fix
operator() now returns value_type by value, matching the underlying matrix's own accessor semantics.

## Verification
Full regression suite: 144/144 tests passing.
itl_test_bicg (blocked on this fix): now passes, was SIGSEGV before.

## Related
Closes #279. Found while wiring BiCG's accumulator support, part of #254.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transposed matrix view element access to safely handle sparse matrices that return temporary values.
  * Prevented potential dangling references when reading elements through a transposed view.
  * Preserved existing access behavior while returning stable values for callers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->