### PR TITLE
krylov(tfqmr): route through accumulator-aware mult()/dot()

### DIFF
--- a/include/mtl/itl/krylov/tfqmr.hpp
+++ b/include/mtl/itl/krylov/tfqmr.hpp
@@ -5,13 +5,20 @@
 #include <mtl/vec/dense_vector.hpp>
 #include <mtl/operation/dot.hpp>
 #include <mtl/operation/norms.hpp>
+#include <mtl/operation/mult.hpp>
 
 namespace mtl::itl {
 
 /// TFQMR solver for non-symmetric systems A*x = b.
 /// Does not require A^T (transpose-free). Left preconditioner M.
+///
+/// Accumulator (optional): accumulation type for the dot products and the
+/// matrix-vector products (see math/accumulator_traits.hpp, #158).
+/// Defaults to void, matching dot()/mult()'s own default -- unspecified
+/// behavior is unchanged.
 template <typename LinearOp, typename VecX, typename VecB,
-          typename PC, typename Iter>
+          typename PC, typename Iter,
+          typename Accumulator = void>
 int tfqmr(const LinearOp& A, VecX& x, const VecB& b, const PC& M, Iter& iter) {
     using value_type = typename VecX::value_type;
     using size_type  = typename VecX::size_type;
@@ -23,7 +30,8 @@ int tfqmr(const LinearOp& A, VecX& x, const VecB& b, const PC& M, Iter& iter) {
     vec::dense_vector<value_type> d(n), v(n), u1(n), u2(n), tmp(n);
 
     // r = b - A*x
-    auto Ax = A * x;
+    vec::dense_vector<value_type> Ax(n);
+    mtl::mult<Accumulator>(A, x, Ax);
     for (size_type i = 0; i < n; ++i) {
         r(i) = b(i) - Ax(i);
         r_star(i) = r(i);
@@ -34,21 +42,19 @@ int tfqmr(const LinearOp& A, VecX& x, const VecB& b, const PC& M, Iter& iter) {
     // y1 = M^{-1} r
     M.solve(y1, r);
 
-    auto Ay1 = A * y1;
-    for (size_type i = 0; i < n; ++i) {
-        u1(i) = Ay1(i);
+    mtl::mult<Accumulator>(A, y1, u1);
+    for (size_type i = 0; i < n; ++i)
         v(i) = u1(i);
-    }
 
     value_type tau = mtl::two_norm(r);
     value_type theta = value_type(0);
     value_type eta = value_type(0);
-    value_type rho = mtl::dot(r_star, r);
+    value_type rho = mtl::dot<Accumulator, value_type>(r_star, r);
 
     while (!iter.finished(tau)) {
         ++iter;
 
-        value_type sigma = mtl::dot(r_star, v);
+        value_type sigma = mtl::dot<Accumulator, value_type>(r_star, v);
         if (sigma == value_type(0)) {
             iter.fail(2, "tfqmr breakdown: sigma == 0");
             return iter;
@@ -78,9 +84,7 @@ int tfqmr(const LinearOp& A, VecX& x, const VecB& b, const PC& M, Iter& iter) {
         // y2 = M^{-1} w
         M.solve(y2, w);
 
-        auto Ay2 = A * y2;
-        for (size_type i = 0; i < n; ++i)
-            u2(i) = Ay2(i);
+        mtl::mult<Accumulator>(A, y2, u2);
 
         // Even half-step
         for (size_type i = 0; i < n; ++i)
@@ -100,7 +104,7 @@ int tfqmr(const LinearOp& A, VecX& x, const VecB& b, const PC& M, Iter& iter) {
         for (size_type i = 0; i < n; ++i)
             x(i) += eta * d(i);
 
-        value_type rho_new = mtl::dot(r_star, w);
+        value_type rho_new = mtl::dot<Accumulator, value_type>(r_star, w);
         if (rho == value_type(0)) {
             iter.fail(2, "tfqmr breakdown: rho == 0");
             return iter;
@@ -111,9 +115,7 @@ int tfqmr(const LinearOp& A, VecX& x, const VecB& b, const PC& M, Iter& iter) {
         // y1 = M^{-1} w
         M.solve(y1, w);
 
-        auto Ay1n = A * y1;
-        for (size_type i = 0; i < n; ++i)
-            u1(i) = Ay1n(i);
+        mtl::mult<Accumulator>(A, y1, u1);
 
         // v = u1 + beta * (u2 + beta * v)
         for (size_type i = 0; i < n; ++i)


### PR DESCRIPTION
## Summary
Routes TFQMR's matrix-vector products and inner products through the accumulator-aware interfaces (mtl::mult<Accumulator>() and mtl::dot<Accumulator, value_type>()), following the same pattern already applied in cg, bicgstab, gmres, idr_s, bicg, bicgstab_ell, cgs, and minres.

## Changes
- Added typename Accumulator = void to the template parameter list
- Routed the initial residual matvec (A * x) through mtl::mult<Accumulator>(A, x, Ax)
- Routed u1 = A * y1 (odd half-step, both the initial setup and the recurrence at the end of each iteration) through mtl::mult<Accumulator>(), writing directly into u1 instead of a temp+copy
- Routed u2 = A * y2 (even half-step) through mtl::mult<Accumulator>(), writing directly into u2
- Routed rho = dot(r_star, r), sigma = dot(r_star, v), and rho_new = dot(r_star, w) through mtl::dot<Accumulator, value_type>()
- Default behavior (Accumulator = void) is unchanged

## Verification
itl_test_tfqmr: passes (0.01s, 0 failures)
Full regression suite: 144/144 passing

## Related
Closes #289. Part of #254 / stillwater-sc/mp-iterative#23.