### PR TITLE
feat(itl): backward + symmetric Gauss-Seidel smoothers

### DIFF
--- a/include/mtl/itl/smoother/gauss_seidel.hpp
+++ b/include/mtl/itl/smoother/gauss_seidel.hpp
@@ -27,8 +27,11 @@ namespace mtl::itl::smoother {
 // intra-sweep error propagation is exactly what mp-iterative studies on top of
 // this per-row accumulation policy.
 
-/// Gauss-Seidel smoother: in-place forward sweep.
+/// Gauss-Seidel smoother.
 /// x[i] = dia_inv[i] * (b[i] - sum_{j!=i} A(i,j)*x[j])
+/// operator() runs a forward (ascending-row) sweep; forward()/backward() expose
+/// the sweep direction explicitly (backward_gauss_seidel / symmetric_gauss_seidel
+/// build on them). All variants carry the optional Accumulator unchanged.
 template <typename Matrix, typename Accumulator = void>
 class gauss_seidel {
     using value_type = typename Matrix::value_type;
@@ -39,11 +42,25 @@ public:
             dia_inv_(i) = value_type(1) / A(i, i);
     }
 
+    /// Forward sweep (rows 0..n-1). Default application.
     template <typename VecX, typename VecB>
-    VecX& operator()(VecX& x, const VecB& b) {
+    VecX& operator()(VecX& x, const VecB& b) { return forward(x, b); }
+
+    /// Forward sweep: rows iterated in ascending order.
+    template <typename VecX, typename VecB>
+    VecX& forward(VecX& x, const VecB& b) { return sweep(x, b, /*ascending=*/true); }
+
+    /// Backward sweep: rows iterated in descending order (n-1..0).
+    template <typename VecX, typename VecB>
+    VecX& backward(VecX& x, const VecB& b) { return sweep(x, b, /*ascending=*/false); }
+
+private:
+    template <typename VecX, typename VecB>
+    VecX& sweep(VecX& x, const VecB& b, bool ascending) {
         const size_type n = A_.num_rows();
         assert(x.size() == n && b.size() == n);
-        for (size_type i = 0; i < n; ++i) {
+        for (size_type step = 0; step < n; ++step) {
+            const size_type i = ascending ? step : (n - 1 - step);
             value_type sigma;
             if constexpr (std::is_void_v<Accumulator>) {
                 sigma = math::zero<value_type>();
@@ -67,7 +84,6 @@ public:
         return x;
     }
 
-private:
     const Matrix& A_;
     vec::dense_vector<value_type> dia_inv_;
 };
@@ -95,14 +111,28 @@ public:
         }
     }
 
+    /// Forward sweep (rows 0..n-1). Default application.
     template <typename VecX, typename VecB>
-    VecX& operator()(VecX& x, const VecB& b) {
+    VecX& operator()(VecX& x, const VecB& b) { return forward(x, b); }
+
+    /// Forward sweep: rows iterated in ascending order.
+    template <typename VecX, typename VecB>
+    VecX& forward(VecX& x, const VecB& b) { return sweep(x, b, /*ascending=*/true); }
+
+    /// Backward sweep: rows iterated in descending order (n-1..0).
+    template <typename VecX, typename VecB>
+    VecX& backward(VecX& x, const VecB& b) { return sweep(x, b, /*ascending=*/false); }
+
+private:
+    template <typename VecX, typename VecB>
+    VecX& sweep(VecX& x, const VecB& b, bool ascending) {
         const size_type n = A_.num_rows();
         assert(x.size() == n && b.size() == n);
         const auto& starts  = A_.ref_major();
         const auto& indices = A_.ref_minor();
         const auto& data    = A_.ref_data();
-        for (size_type i = 0; i < n; ++i) {
+        for (size_type step = 0; step < n; ++step) {
+            const size_type i = ascending ? step : (n - 1 - step);
             value_type sigma;
             if constexpr (std::is_void_v<Accumulator>) {
                 sigma = math::zero<value_type>();
@@ -126,10 +156,44 @@ public:
         return x;
     }
 
-private:
     const matrix_type& A_;
     vec::dense_vector<value_type> dia_inv_;
     std::vector<size_type> dia_pos_;
+};
+
+/// Backward Gauss-Seidel: one in-place sweep in descending row order.
+/// Same fixed point as the forward sweep; the sweep direction is what
+/// mp-iterative studies against low-precision error propagation.
+template <typename Matrix, typename Accumulator = void>
+class backward_gauss_seidel {
+public:
+    explicit backward_gauss_seidel(const Matrix& A) : gs_(A) {}
+
+    template <typename VecX, typename VecB>
+    VecX& operator()(VecX& x, const VecB& b) { return gs_.backward(x, b); }
+
+private:
+    gauss_seidel<Matrix, Accumulator> gs_;
+};
+
+/// Symmetric Gauss-Seidel (SGS): one forward sweep immediately followed by one
+/// backward sweep per application. For symmetric A this application is itself
+/// symmetric (SPD-preserving), which is why Krylov methods use it as a
+/// preconditioner -- hence a first-class primitive rather than a caller-side
+/// compose. Carries the optional Accumulator through both sweeps.
+template <typename Matrix, typename Accumulator = void>
+class symmetric_gauss_seidel {
+public:
+    explicit symmetric_gauss_seidel(const Matrix& A) : gs_(A) {}
+
+    template <typename VecX, typename VecB>
+    VecX& operator()(VecX& x, const VecB& b) {
+        gs_.forward(x, b);
+        return gs_.backward(x, b);
+    }
+
+private:
+    gauss_seidel<Matrix, Accumulator> gs_;
 };
 
 } // namespace mtl::itl::smoother

--- a/tests/unit/itl/test_smoothers.cpp
+++ b/tests/unit/itl/test_smoothers.cpp
@@ -444,11 +444,21 @@ TEST_CASE("backward / symmetric Gauss-Seidel edge cases: 1x1 and empty (#269)",
         sgs(xs, b); REQUIRE_THAT(xs(0), Catch::Matchers::WithinAbs(0.5, 1e-15));
     }
 
-    SECTION("empty system is a safe no-op") {
+    SECTION("empty system is a safe no-op (dense)") {
         mat::dense2D<double> A(0, 0);
         vec::dense_vector<double> b(0), xb(0), xs(0);
         itl::smoother::backward_gauss_seidel<mat::dense2D<double>> bwd(A);
         itl::smoother::symmetric_gauss_seidel<mat::dense2D<double>> sgs(A);
+        bwd(xb, b); REQUIRE(xb.size() == 0);
+        sgs(xs, b); REQUIRE(xs.size() == 0);
+    }
+
+    SECTION("empty system is a safe no-op (sparse)") {
+        // Exercise the compressed2D specialization's zero-row / zero-nnz path.
+        mat::compressed2D<double> A(0, 0);
+        vec::dense_vector<double> b(0), xb(0), xs(0);
+        itl::smoother::backward_gauss_seidel<mat::compressed2D<double>> bwd(A);
+        itl::smoother::symmetric_gauss_seidel<mat::compressed2D<double>> sgs(A);
         bwd(xb, b); REQUIRE(xb.size() == 0);
         sgs(xs, b); REQUIRE(xs.size() == 0);
     }

--- a/tests/unit/itl/test_smoothers.cpp
+++ b/tests/unit/itl/test_smoothers.cpp
@@ -312,3 +312,108 @@ TEST_CASE("Sparse specialization matches generic version", "[itl][smoother][spar
         REQUIRE_THAT(x_sparse(i), Catch::Matchers::WithinAbs(x_dense(i), 1e-12));
     }
 }
+
+// -- backward + symmetric Gauss-Seidel (#269) ----------------------------
+
+TEST_CASE("Backward Gauss-Seidel reaches the same fixed point as forward (#269)",
+          "[itl][smoother][gauss_seidel][backward]") {
+    vec::dense_vector<double> b = {1.0, 2.0, 3.0, 4.0};
+
+    SECTION("dense") {
+        auto A = make_dense_spd();
+        vec::dense_vector<double> xf(4, 0.0), xb(4, 0.0);
+        itl::smoother::gauss_seidel<mat::dense2D<double>> fwd(A);
+        itl::smoother::backward_gauss_seidel<mat::dense2D<double>> bwd(A);
+        for (int s = 0; s < 100; ++s) { fwd(xf, b); bwd(xb, b); }
+        // Both convergent sweep orders reach the same A^{-1} b on an SPD system.
+        for (std::size_t i = 0; i < 4; ++i)
+            REQUIRE_THAT(xb(i), Catch::Matchers::WithinAbs(xf(i), 1e-9));
+        auto r = A * xb;
+        for (std::size_t i = 0; i < 4; ++i) r(i) = b(i) - r(i);
+        REQUIRE(two_norm(r) < 1e-9);
+    }
+
+    SECTION("sparse specialization") {
+        auto A = make_sparse_spd();
+        vec::dense_vector<double> xb(4, 0.0);
+        itl::smoother::backward_gauss_seidel<mat::compressed2D<double>> bwd(A);
+        for (int s = 0; s < 100; ++s) bwd(xb, b);
+        auto r = A * xb;
+        for (std::size_t i = 0; i < 4; ++i) r(i) = b(i) - r(i);
+        REQUIRE(two_norm(r) < 1e-9);
+    }
+}
+
+TEST_CASE("Symmetric Gauss-Seidel = forward then backward, order-symmetric (#269)",
+          "[itl][smoother][gauss_seidel][symmetric]") {
+    auto A = make_dense_spd();
+    vec::dense_vector<double> b = {1.0, 2.0, 3.0, 4.0};
+
+    SECTION("one SGS application equals a forward sweep then a backward sweep") {
+        vec::dense_vector<double> x_sgs(4, 0.0), x_manual(4, 0.0);
+        itl::smoother::symmetric_gauss_seidel<mat::dense2D<double>> sgs(A);
+        itl::smoother::gauss_seidel<mat::dense2D<double>> gs(A);
+        sgs(x_sgs, b);
+        gs.forward(x_manual, b);
+        gs.backward(x_manual, b);
+        for (std::size_t i = 0; i < 4; ++i)
+            REQUIRE_THAT(x_sgs(i), Catch::Matchers::WithinAbs(x_manual(i), 1e-15));
+    }
+
+    SECTION("forward+backward and backward+forward reach the same fixed point") {
+        // "Independent of which end it starts": both symmetric orderings converge
+        // to the same solution on an SPD system.
+        vec::dense_vector<double> x_fb(4, 0.0), x_bf(4, 0.0);
+        itl::smoother::symmetric_gauss_seidel<mat::dense2D<double>> sgs(A);   // F then B
+        itl::smoother::gauss_seidel<mat::dense2D<double>> gs(A);
+        for (int s = 0; s < 60; ++s) {
+            sgs(x_fb, b);
+            gs.backward(x_bf, b);                                             // B then F
+            gs.forward(x_bf, b);
+        }
+        for (std::size_t i = 0; i < 4; ++i)
+            REQUIRE_THAT(x_fb(i), Catch::Matchers::WithinAbs(x_bf(i), 1e-9));
+        auto r = A * x_fb;
+        for (std::size_t i = 0; i < 4; ++i) r(i) = b(i) - r(i);
+        REQUIRE(two_norm(r) < 1e-9);
+    }
+
+    SECTION("sparse specialization converges") {
+        auto As = make_sparse_spd();
+        vec::dense_vector<double> x(4, 0.0);
+        itl::smoother::symmetric_gauss_seidel<mat::compressed2D<double>> sgs(As);
+        for (int s = 0; s < 60; ++s) sgs(x, b);
+        auto r = As * x;
+        for (std::size_t i = 0; i < 4; ++i) r(i) = b(i) - r(i);
+        REQUIRE(two_norm(r) < 1e-9);
+    }
+}
+
+TEST_CASE("backward / symmetric Gauss-Seidel route through accumulator_traits (#269)",
+          "[itl][smoother][gauss_seidel][symmetric][accumulator]") {
+    vec::dense_vector<float> b = {1.0f, 2.0f, 3.0f, 4.0f};
+
+    SECTION("backward (dense) invokes the accumulator") {
+        auto A = make_dense_spd_f();
+        vec::dense_vector<float> x(4, 0.0f);
+        itl::smoother::backward_gauss_seidel<mat::dense2D<float>, counting_wide_acc> bwd(A);
+        g_jacobi_addproduct_calls = 0;
+        for (int s = 0; s < 30; ++s) bwd(x, b);
+        REQUIRE(g_jacobi_addproduct_calls > 0);
+        auto r = A * x;
+        for (std::size_t i = 0; i < 4; ++i) r(i) = b(i) - r(i);
+        REQUIRE(two_norm(r) < 1e-4f);
+    }
+
+    SECTION("symmetric (sparse) invokes the accumulator") {
+        auto A = make_sparse_spd_f();
+        vec::dense_vector<float> x(4, 0.0f);
+        itl::smoother::symmetric_gauss_seidel<mat::compressed2D<float>, counting_wide_acc> sgs(A);
+        g_jacobi_addproduct_calls = 0;
+        for (int s = 0; s < 30; ++s) sgs(x, b);
+        REQUIRE(g_jacobi_addproduct_calls > 0);
+        auto r = A * x;
+        for (std::size_t i = 0; i < 4; ++i) r(i) = b(i) - r(i);
+        REQUIRE(two_norm(r) < 1e-4f);
+    }
+}

--- a/tests/unit/itl/test_smoothers.cpp
+++ b/tests/unit/itl/test_smoothers.cpp
@@ -417,3 +417,39 @@ TEST_CASE("backward / symmetric Gauss-Seidel route through accumulator_traits (#
         REQUIRE(two_norm(r) < 1e-4f);
     }
 }
+
+TEST_CASE("backward / symmetric Gauss-Seidel edge cases: 1x1 and empty (#269)",
+          "[itl][smoother][gauss_seidel][edge]") {
+    // Smoothers operate on a square system (they invert the diagonal), so the
+    // relevant edge cases are the minimum 1x1 system and the empty system;
+    // rectangular input is not applicable.
+    SECTION("1x1 dense: one sweep is exact") {
+        mat::dense2D<double> A(1, 1); A(0, 0) = 4.0;
+        vec::dense_vector<double> b(1, 2.0);              // x = b/A = 0.5
+        vec::dense_vector<double> xb(1, 0.0), xs(1, 0.0);
+        itl::smoother::backward_gauss_seidel<mat::dense2D<double>> bwd(A);
+        itl::smoother::symmetric_gauss_seidel<mat::dense2D<double>> sgs(A);
+        bwd(xb, b); REQUIRE_THAT(xb(0), Catch::Matchers::WithinAbs(0.5, 1e-15));
+        sgs(xs, b); REQUIRE_THAT(xs(0), Catch::Matchers::WithinAbs(0.5, 1e-15));
+    }
+
+    SECTION("1x1 sparse: one sweep is exact") {
+        mat::compressed2D<double> A(1, 1);
+        { mat::inserter<mat::compressed2D<double>> ins(A); ins[0][0] << 4.0; }
+        vec::dense_vector<double> b(1, 2.0);
+        vec::dense_vector<double> xb(1, 0.0), xs(1, 0.0);
+        itl::smoother::backward_gauss_seidel<mat::compressed2D<double>> bwd(A);
+        itl::smoother::symmetric_gauss_seidel<mat::compressed2D<double>> sgs(A);
+        bwd(xb, b); REQUIRE_THAT(xb(0), Catch::Matchers::WithinAbs(0.5, 1e-15));
+        sgs(xs, b); REQUIRE_THAT(xs(0), Catch::Matchers::WithinAbs(0.5, 1e-15));
+    }
+
+    SECTION("empty system is a safe no-op") {
+        mat::dense2D<double> A(0, 0);
+        vec::dense_vector<double> b(0), xb(0), xs(0);
+        itl::smoother::backward_gauss_seidel<mat::dense2D<double>> bwd(A);
+        itl::smoother::symmetric_gauss_seidel<mat::dense2D<double>> sgs(A);
+        bwd(xb, b); REQUIRE(xb.size() == 0);
+        sgs(xs, b); REQUIRE(xs.size() == 0);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds **backward-sweep** and **symmetric Gauss-Seidel (SGS)** as first-class smoother types, so mp-iterative can study how sweep order interacts with low-precision error propagation (stillwater-sc/mp-iterative#4 follow-up).
- Refactors `gauss_seidel` (generic + `compressed2D`) into a direction-parameterized sweep exposing `forward()`/`backward()`; `operator()` stays a forward sweep — **behavior and codegen unchanged**.

## Design
- **Distinct types, not a runtime flag** — multigrid selects smoothers via a type-based `SmootherFactory`, and the issue wants SGS as a first-class preconditioner primitive. So `backward_gauss_seidel` and `symmetric_gauss_seidel` are thin wrappers over the shared `gauss_seidel` sweep (no duplicated sigma logic).
- **SGS** = one forward sweep then one backward sweep per application (symmetric, SPD-preserving).
- The optional `Accumulator` is carried through both new types, default `void` byte-identical — consistent with the forward variant (#263) and the cg/bicgstab pattern (#238/#255).
- The `compressed2D` reverse order uses the same O(nnz) raw-CRS access, descending.

## Changes
- `include/mtl/itl/smoother/gauss_seidel.hpp` — direction-parameterized sweep + `forward`/`backward`; new `backward_gauss_seidel` and `symmetric_gauss_seidel` types.
- `tests/unit/itl/test_smoothers.cpp` — forward/backward same fixed point (dense + sparse); one SGS == forward-then-backward; SGS order-symmetry (F+B ≡ B+F fixed point); accumulator routing for the new types.

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| itl_test_smoothers | OK | PASS (11 cases) | OK | PASS (11 cases) |
| itl_test_multigrid | OK | PASS (5 cases) | OK | PASS (5 cases) |

Multigrid is the regression check (drives the GS smoother) — unchanged.

## Scope note
**SSOR** (symmetric SOR) is the `sor.hpp` companion; scoped out to keep this PR focused on the Gauss-Seidel family and tracked as immediate follow-up **#291** (the issue explicitly permits this).

## Test plan
- [ ] Fast CI passes (gcc + clang)
- [ ] Promote to ready when satisfied: `gh pr ready`

Resolves #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit forward and backward sweep APIs for Gauss–Seidel smoothing.
  * Introduced `backward_gauss_seidel` and `symmetric_gauss_seidel` smoother variants.
  * Updated the default Gauss–Seidel application to use the forward sweep behavior internally.

* **Bug Fixes**
  * Improved sweep handling for sparse systems with accumulator-aware off-diagonal accumulation.

* **Tests**
  * Added unit tests covering backward/symmetric convergence, sweep order consistency, accumulator routing, and edge cases (1x1 and empty systems).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->