### PR TITLE
perf(operation): thread dense LU + Cholesky factorizations (#297 batch 1)

### DIFF
--- a/include/mtl/operation/cholesky.hpp
+++ b/include/mtl/operation/cholesky.hpp
@@ -2,13 +2,16 @@
 // MTL5 -- Cholesky factorization for symmetric positive definite matrices
 // A = L*L^T. In-place: lower triangle of A is overwritten with L.
 // Optional LAPACK dispatch when MTL5_HAS_LAPACK is defined and types qualify.
+#include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <cstddef>
 #include <mtl/concepts/matrix.hpp>
 #include <mtl/concepts/vector.hpp>
 #include <mtl/vec/dense_vector.hpp>
 #include <mtl/math/identity.hpp>
 #include <mtl/interface/dispatch_traits.hpp>
+#include <mtl/detail/thread_pool.hpp>
 #ifdef MTL5_HAS_LAPACK
 #include <mtl/interface/lapack.hpp>
 #endif
@@ -45,12 +48,26 @@ int cholesky_factor(M& A) {
             return static_cast<int>(j + 1);
         A(j, j) = sqrt(diag);
 
-        // Compute L(i,j) for i > j
-        for (size_type i = j + 1; i < n; ++i) {
-            sum = math::zero<value_type>();
-            for (size_type k = 0; k < j; ++k)
-                sum += A(i, k) * A(j, k);
-            A(i, j) = (A(i, j) - sum) / A(j, j);
+        // Compute L(i,j) for i > j -- parallelize over rows i (each A(i,j) is
+        // written by exactly one chunk and reads only already-finalized columns
+        // k < j and the shared column j, so contiguous chunking is bit-identical
+        // to the serial path). No-op team at MTL5_NUM_THREADS=1.
+        const size_type rows = n - j - 1;
+        if (rows > 0) {
+            const std::size_t inner = static_cast<std::size_t>(j == 0 ? 1 : j);
+            const std::size_t grain =
+                std::max<std::size_t>(std::size_t{1}, std::size_t{65536} / inner);
+            detail::thread_pool::instance().parallel_for(
+                static_cast<std::size_t>(rows), grain,
+                [&](std::size_t b, std::size_t e) {
+                    for (std::size_t t = b; t < e; ++t) {
+                        const size_type i = j + 1 + static_cast<size_type>(t);
+                        auto s = math::zero<value_type>();
+                        for (size_type k = 0; k < j; ++k)
+                            s += A(i, k) * A(j, k);
+                        A(i, j) = (A(i, j) - s) / A(j, j);
+                    }
+                });
         }
     }
     return 0;

--- a/include/mtl/operation/lu.hpp
+++ b/include/mtl/operation/lu.hpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <cstddef>
 #include <stdexcept>
 #include <vector>
 #include <mtl/concepts/matrix.hpp>
@@ -15,6 +16,7 @@
 #include <mtl/operation/lower_trisolve.hpp>
 #include <mtl/operation/upper_trisolve.hpp>
 #include <mtl/interface/dispatch_traits.hpp>
+#include <mtl/detail/thread_pool.hpp>
 #ifdef MTL5_HAS_LAPACK
 #include <mtl/interface/lapack.hpp>
 #endif
@@ -78,12 +80,26 @@ int lu_factor(M& A, std::vector<typename M::size_type>& pivot) {
         if (A(k, k) == math::zero<value_type>())
             return static_cast<int>(k + 1);
 
-        // Eliminate below diagonal
-        for (size_type i = k + 1; i < n; ++i) {
-            A(i, k) /= A(k, k);  // L multiplier
-            for (size_type j = k + 1; j < n; ++j) {
-                A(i, j) -= A(i, k) * A(k, j);
-            }
+        // Eliminate below diagonal -- parallelize the trailing-submatrix update
+        // over rows i (each row is written by exactly one chunk and reads only
+        // the shared pivot row k, so contiguous chunking is bit-identical to the
+        // serial path). No-op team at MTL5_NUM_THREADS=1.
+        const size_type trailing = n - k - 1;   // rows i in (k, n) and inner cols
+        if (trailing > 0) {
+            const std::size_t grain =
+                std::max<std::size_t>(std::size_t{1},
+                                      std::size_t{65536} / static_cast<std::size_t>(trailing));
+            detail::thread_pool::instance().parallel_for(
+                static_cast<std::size_t>(trailing), grain,
+                [&](std::size_t b, std::size_t e) {
+                    for (std::size_t t = b; t < e; ++t) {
+                        const size_type i = k + 1 + static_cast<size_type>(t);
+                        A(i, k) /= A(k, k);  // L multiplier
+                        for (size_type j = k + 1; j < n; ++j) {
+                            A(i, j) -= A(i, k) * A(k, j);
+                        }
+                    }
+                });
         }
     }
     return 0;

--- a/tests/unit/operation/test_factorization_mt.cpp
+++ b/tests/unit/operation/test_factorization_mt.cpp
@@ -179,3 +179,45 @@ TEST_CASE("Threaded Cholesky factorization is bit-identical to serial (#297)",
         }
     REQUIRE(resid < 1e-8);
 }
+
+TEST_CASE("Threaded factorizations degrade correctly at the single-chunk boundary (#297)",
+          "[operation][lu][cholesky][threading][mt][edge]") {
+    // n = 1 and n = 2: trailing/rows collapse to 0 or 1, so parallel_for takes
+    // its serial-fallback branch. The result must still match the serial
+    // reference bit-for-bit. Explicit (deterministic) tiny matrices so the SPD /
+    // diagonally-dominant property never depends on the RNG.
+
+    auto check_lu = [](mat::dense2D<double> A) {
+        auto Aref = A;
+        std::vector<mat::dense2D<double>::size_type> piv;
+        REQUIRE(lu_factor(A, piv) == 0);
+        std::vector<std::size_t> rpiv;
+        ref_lu(Aref, rpiv);
+        const std::size_t n = A.num_rows();
+        for (std::size_t i = 0; i < n; ++i) {
+            REQUIRE(static_cast<std::size_t>(piv[i]) == rpiv[i]);
+            for (std::size_t j = 0; j < n; ++j) REQUIRE(A(i, j) == Aref(i, j));
+        }
+    };
+    auto check_chol = [](mat::dense2D<double> A) {
+        auto Aref = A;
+        REQUIRE(cholesky_factor(A) == 0);
+        ref_chol(Aref);
+        const std::size_t n = A.num_rows();
+        for (std::size_t j = 0; j < n; ++j)
+            for (std::size_t i = j; i < n; ++i) REQUIRE(A(i, j) == Aref(i, j));
+    };
+
+    SECTION("1x1") {
+        mat::dense2D<double> A(1, 1); A(0, 0) = 4.0;
+        check_lu(A);
+        check_chol(A);
+    }
+    SECTION("2x2") {
+        mat::dense2D<double> A(2, 2);
+        A(0, 0) = 4.0; A(0, 1) = 1.0;
+        A(1, 0) = 1.0; A(1, 1) = 3.0;   // symmetric, SPD, diagonally dominant
+        check_lu(A);
+        check_chol(A);
+    }
+}

--- a/tests/unit/operation/test_factorization_mt.cpp
+++ b/tests/unit/operation/test_factorization_mt.cpp
@@ -1,0 +1,181 @@
+// Multithreaded dense factorizations (#297, batch 1): the LU trailing-submatrix
+// update and the Cholesky column update are partitioned across the persistent
+// thread pool over independent rows. Each output row is written by exactly one
+// chunk and reads only shared (read-only) pivot/column data, so the threaded
+// result is BIT-IDENTICAL to the serial path -- we assert exact equality (==)
+// against an in-test serial reference, plus a residual check for correctness.
+//
+// The library kernels use the env-sized singleton pool, so this file sets
+// MTL5_NUM_THREADS before the pool's first use (the only in-process way to
+// exercise the factorization threading -- CI otherwise runs serial). Run under
+// TSan (-DMTL5_SANITIZE=thread) to confirm race-freedom.
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <random>
+#include <vector>
+
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/operation/lu.hpp>
+#include <mtl/operation/cholesky.hpp>
+#include <mtl/detail/thread_pool.hpp>
+
+using namespace mtl;
+
+namespace {
+
+// Size the process-wide pool multithreaded before its first (lazy) use.
+const int g_set_threads = [] {
+#if defined(_WIN32)
+    _putenv_s("MTL5_NUM_THREADS", "4");
+#else
+    setenv("MTL5_NUM_THREADS", "4", /*overwrite=*/1);
+#endif
+    return 0;
+}();
+
+// Faithful serial copy of mtl::lu_factor's generic path -- the golden reference
+// the threaded factorization must match bit-for-bit.
+template <typename T>
+void ref_lu(mat::dense2D<T>& A, std::vector<std::size_t>& piv) {
+    const std::size_t n = A.num_rows();
+    piv.resize(n);
+    for (std::size_t k = 0; k < n; ++k) {
+        std::size_t max_row = k;
+        T max_val = std::abs(A(k, k));
+        for (std::size_t i = k + 1; i < n; ++i) {
+            T v = std::abs(A(i, k));
+            if (v > max_val) { max_val = v; max_row = i; }
+        }
+        piv[k] = max_row;
+        if (max_row != k)
+            for (std::size_t j = 0; j < n; ++j) { T t = A(k, j); A(k, j) = A(max_row, j); A(max_row, j) = t; }
+        for (std::size_t i = k + 1; i < n; ++i) {
+            A(i, k) /= A(k, k);
+            for (std::size_t j = k + 1; j < n; ++j)
+                A(i, j) -= A(i, k) * A(k, j);
+        }
+    }
+}
+
+// Faithful serial copy of mtl::cholesky_factor's generic path.
+template <typename T>
+void ref_chol(mat::dense2D<T>& A) {
+    const std::size_t n = A.num_rows();
+    for (std::size_t j = 0; j < n; ++j) {
+        T sum = T(0);
+        for (std::size_t k = 0; k < j; ++k) sum += A(j, k) * A(j, k);
+        A(j, j) = std::sqrt(A(j, j) - sum);
+        for (std::size_t i = j + 1; i < n; ++i) {
+            T s = T(0);
+            for (std::size_t k = 0; k < j; ++k) s += A(i, k) * A(j, k);
+            A(i, j) = (A(i, j) - s) / A(j, j);
+        }
+    }
+}
+
+// Row-major dense2D exercises the generic (parallelized) path even when LAPACK
+// is linked (the LAPACK LU/Cholesky dispatch fires only for column-major).
+template <typename T>
+mat::dense2D<T> random_diagdom(std::size_t n, std::uint64_t seed) {
+    mat::dense2D<T> A(n, n);
+    std::mt19937_64 rng(seed);
+    std::uniform_real_distribution<double> d(-1.0, 1.0);
+    for (std::size_t i = 0; i < n; ++i) {
+        double rowsum = 0.0;
+        for (std::size_t j = 0; j < n; ++j) {
+            if (i != j) { T v = static_cast<T>(d(rng)); A(i, j) = v; rowsum += std::abs(double(v)); }
+        }
+        A(i, i) = static_cast<T>(rowsum + 1.0);   // strictly diagonally dominant
+    }
+    return A;
+}
+
+// Symmetric positive definite: B = A + A^T + n*I on a random A.
+template <typename T>
+mat::dense2D<T> random_spd(std::size_t n, std::uint64_t seed) {
+    mat::dense2D<T> R(n, n);
+    std::mt19937_64 rng(seed);
+    std::uniform_real_distribution<double> d(-1.0, 1.0);
+    mat::dense2D<T> A(n, n);
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j) A(i, j) = static_cast<T>(d(rng));
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j)
+            R(i, j) = A(i, j) + A(j, i) + (i == j ? static_cast<T>(2 * n) : T(0));
+    return R;
+}
+
+} // namespace
+
+TEST_CASE("Threaded LU factorization is bit-identical to serial (#297)",
+          "[operation][lu][threading][mt]") {
+    // The pool must actually be multithreaded for this to mean anything.
+    if (detail::thread_pool::instance().size() < 2) {
+        WARN("single-core runner: threading not exercised");
+    }
+    const std::size_t n = 512;   // large enough that the trailing update splits
+    auto A = random_diagdom<double>(n, 12345);
+    auto Aref = A;               // copy for the serial reference
+
+    std::vector<mat::dense2D<double>::size_type> piv;
+    int info = lu_factor(A, piv);              // library (threaded) path
+    REQUIRE(info == 0);
+
+    std::vector<std::size_t> rpiv;
+    ref_lu(Aref, rpiv);                        // serial golden reference
+
+    // Bit-for-bit equality: exposes any race or ordering divergence.
+    for (std::size_t i = 0; i < n; ++i) {
+        REQUIRE(static_cast<std::size_t>(piv[i]) == rpiv[i]);
+        for (std::size_t j = 0; j < n; ++j)
+            REQUIRE(A(i, j) == Aref(i, j));
+    }
+
+    // Correctness: the factorization solves a system to a tiny residual.
+    vec::dense_vector<double> xexact(n), b(n, 0.0);
+    for (std::size_t i = 0; i < n; ++i) xexact[i] = 1.0 + 0.001 * double(i % 13);
+    auto A0 = random_diagdom<double>(n, 12345);
+    for (std::size_t i = 0; i < n; ++i) { double s = 0.0; for (std::size_t j = 0; j < n; ++j) s += A0(i, j) * xexact[j]; b[i] = s; }
+    vec::dense_vector<double> x(n, 0.0);
+    lu_solve(A, piv, x, b);
+    double err = 0.0;
+    for (std::size_t i = 0; i < n; ++i) err = std::max(err, std::abs(x[i] - xexact[i]));
+    REQUIRE(err < 1e-9);
+}
+
+TEST_CASE("Threaded Cholesky factorization is bit-identical to serial (#297)",
+          "[operation][cholesky][threading][mt]") {
+    if (detail::thread_pool::instance().size() < 2) {
+        WARN("single-core runner: threading not exercised");
+    }
+    const std::size_t n = 768;   // large enough that the column update splits
+    auto A = random_spd<double>(n, 6789);
+    auto Aref = A;
+
+    int info = cholesky_factor(A);             // library (threaded) path
+    REQUIRE(info == 0);
+
+    ref_chol(Aref);                            // serial golden reference
+
+    // Bit-for-bit equality over the lower triangle (where L is stored).
+    for (std::size_t j = 0; j < n; ++j)
+        for (std::size_t i = j; i < n; ++i)
+            REQUIRE(A(i, j) == Aref(i, j));
+
+    // Correctness: L*L^T reconstructs the original SPD matrix.
+    auto A0 = random_spd<double>(n, 6789);
+    double resid = 0.0;
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j <= i; ++j) {
+            double llt = 0.0;
+            for (std::size_t k = 0; k <= j; ++k) llt += A(i, k) * A(j, k);
+            resid = std::max(resid, std::abs(llt - double(A0(i, j))));
+        }
+    REQUIRE(resid < 1e-8);
+}


### PR DESCRIPTION
## Summary
First batch of extending on-node threading beyond the BLAS kernels (#297). Parallelizes the two dense factorization inner updates on the existing persistent `detail::thread_pool`:
- **LU** — the trailing-submatrix update (rows `i>k`) is partitioned over rows. Each row is written by exactly one chunk and reads only the shared pivot row `k`, so the contiguous chunking is **bit-identical to serial**.
- **Cholesky** — the column update (rows `i>j`) is partitioned over rows; each reads only already-finalized columns `k<j` and the shared column `j` → **bit-identical**.

Both use `parallel_for` with a 64K-work-per-chunk grain (the GEMV/`mult` convention), so the team is a **no-op at `MTL5_NUM_THREADS=1`** (default) — serial behavior and codegen unchanged. The LAPACK dispatch path (column-major float/double) is untouched; this threads the generic path (row-major / custom types).

## Changes
- `include/mtl/operation/lu.hpp` — parallelize the trailing update; `#include <detail/thread_pool.hpp>`
- `include/mtl/operation/cholesky.hpp` — parallelize the column update; includes
- `tests/unit/operation/test_factorization_mt.cpp` — new: sizes the pool to 4 before first use and asserts the library factorization is **bit-identical (`==`)** to an in-test serial reference (512×512 LU, 768×768 Cholesky — 557,956 assertions), plus residual checks

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| op_test_factorization_mt | OK | PASS (557,956 assertions, threaded on 20 cores) | OK | PASS |
| op_test_lu | OK | PASS | OK | PASS |
| op_test_cholesky | OK | PASS | OK | PASS |
| op_test_lu_iterative_refine | OK | PASS | — | — |

Also **race-free under ThreadSanitizer** (`-DMTL5_SANITIZE=thread`, clang) — the MT test runs clean.

## Scope
Batch 1 of #297. Remaining items stay open there: QR/Householder, supernodal sparse factorization panels, sparse triangular-solve level scheduling, BLIS-style multi-loop GEMM, general element-wise sweeps.

## Test plan
- [ ] Fast CI passes (gcc + clang)
- [ ] Promote to ready when satisfied: `gh pr ready`

Relates to #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved LU and Cholesky factorization speed by parallelizing the lower-triangular/off-diagonal and trailing-submatrix updates on multicore systems.

- **Bug Fixes**
  - Maintained identical factorization results and solve accuracy when switching from single-threaded to threaded execution.

- **Tests**
  - Added multithreaded regression tests that compare LU and Cholesky against in-test serial “golden” references with bit-for-bit equality, including coverage for small sizes (single-chunk boundary).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->