### PR TITLE
perf(operation): thread Householder reflector application (#297 batch 2)

### DIFF
--- a/include/mtl/operation/householder.hpp
+++ b/include/mtl/operation/householder.hpp
@@ -68,8 +68,10 @@ void apply_householder_left(M& A, const vec::dense_vector<T>& v, T beta,
     // only column j of A, writes only column j), so partitioning the columns
     // across the thread pool is bit-identical to serial. No-op at
     // MTL5_NUM_THREADS=1.
+    // Empty or beyond-end target column: no work (matches the serial loop, and
+    // avoids an unsigned underflow in n - col before deriving the work range).
+    if (col >= n) return;
     const size_type ncols = n - col;
-    if (ncols == 0) return;
     const std::size_t grain = std::max<std::size_t>(
         std::size_t{1}, std::size_t{65536} / (vlen ? static_cast<std::size_t>(vlen) : std::size_t{1}));
     detail::thread_pool::instance().parallel_for(
@@ -101,8 +103,10 @@ void apply_householder_right(M& A, const vec::dense_vector<T>& v, T beta,
     // its own vlen entries of A, writes only those), so partitioning the rows
     // across the thread pool is bit-identical to serial. No-op at
     // MTL5_NUM_THREADS=1.
+    // Empty or beyond-end target row: no work (matches the serial loop, and
+    // avoids an unsigned underflow in m - row before deriving the work range).
+    if (row >= m) return;
     const size_type nrows = m - row;
-    if (nrows == 0) return;
     const std::size_t grain = std::max<std::size_t>(
         std::size_t{1}, std::size_t{65536} / (vlen ? static_cast<std::size_t>(vlen) : std::size_t{1}));
     detail::thread_pool::instance().parallel_for(

--- a/include/mtl/operation/householder.hpp
+++ b/include/mtl/operation/householder.hpp
@@ -1,11 +1,14 @@
 #pragma once
 // MTL5 -- Householder reflections for QR factorization
 // Computes v, beta such that (I - beta*v*v^T)*x = ||x||*e_1
+#include <algorithm>
 #include <cmath>
 #include <cassert>
+#include <cstddef>
 #include <mtl/vec/dense_vector.hpp>
 #include <mtl/concepts/matrix.hpp>
 #include <mtl/math/identity.hpp>
+#include <mtl/detail/thread_pool.hpp>
 
 namespace mtl {
 
@@ -58,19 +61,31 @@ template <Matrix M, typename T>
 void apply_householder_left(M& A, const vec::dense_vector<T>& v, T beta,
                             typename M::size_type row, typename M::size_type col) {
     using size_type = typename M::size_type;
-    const size_type m = A.num_rows();
     const size_type n = A.num_cols();
     const size_type vlen = v.size();
 
-    for (size_type j = col; j < n; ++j) {
-        // w = v^T * A(:,j)
-        T w = math::zero<T>();
-        for (size_type i = 0; i < vlen; ++i)
-            w += v(i) * A(row + i, j);
-        // A(:,j) -= beta * v * w
-        for (size_type i = 0; i < vlen; ++i)
-            A(row + i, j) -= beta * v(i) * w;
-    }
+    // Each column j is updated independently (reads the shared reflector v and
+    // only column j of A, writes only column j), so partitioning the columns
+    // across the thread pool is bit-identical to serial. No-op at
+    // MTL5_NUM_THREADS=1.
+    const size_type ncols = n - col;
+    if (ncols == 0) return;
+    const std::size_t grain = std::max<std::size_t>(
+        std::size_t{1}, std::size_t{65536} / (vlen ? static_cast<std::size_t>(vlen) : std::size_t{1}));
+    detail::thread_pool::instance().parallel_for(
+        static_cast<std::size_t>(ncols), grain,
+        [&](std::size_t b, std::size_t e) {
+            for (std::size_t t = b; t < e; ++t) {
+                const size_type j = col + static_cast<size_type>(t);
+                // w = v^T * A(:,j)
+                T w = math::zero<T>();
+                for (size_type i = 0; i < vlen; ++i)
+                    w += v(i) * A(row + i, j);
+                // A(:,j) -= beta * v * w
+                for (size_type i = 0; i < vlen; ++i)
+                    A(row + i, j) -= beta * v(i) * w;
+            }
+        });
 }
 
 /// Apply Householder reflection on the right: A * (I - beta*v*v^T)
@@ -82,15 +97,28 @@ void apply_householder_right(M& A, const vec::dense_vector<T>& v, T beta,
     const size_type m = A.num_rows();
     const size_type vlen = v.size();
 
-    for (size_type i = row; i < m; ++i) {
-        // w = A(i,:) * v
-        T w = math::zero<T>();
-        for (size_type j = 0; j < vlen; ++j)
-            w += A(i, col + j) * v(j);
-        // A(i,:) -= beta * w * v^T
-        for (size_type j = 0; j < vlen; ++j)
-            A(i, col + j) -= beta * w * v(j);
-    }
+    // Each row i is updated independently (reads the shared reflector v and only
+    // its own vlen entries of A, writes only those), so partitioning the rows
+    // across the thread pool is bit-identical to serial. No-op at
+    // MTL5_NUM_THREADS=1.
+    const size_type nrows = m - row;
+    if (nrows == 0) return;
+    const std::size_t grain = std::max<std::size_t>(
+        std::size_t{1}, std::size_t{65536} / (vlen ? static_cast<std::size_t>(vlen) : std::size_t{1}));
+    detail::thread_pool::instance().parallel_for(
+        static_cast<std::size_t>(nrows), grain,
+        [&](std::size_t b, std::size_t e) {
+            for (std::size_t t = b; t < e; ++t) {
+                const size_type i = row + static_cast<size_type>(t);
+                // w = A(i,:) * v
+                T w = math::zero<T>();
+                for (size_type j = 0; j < vlen; ++j)
+                    w += A(i, col + j) * v(j);
+                // A(i,:) -= beta * w * v^T
+                for (size_type j = 0; j < vlen; ++j)
+                    A(i, col + j) -= beta * w * v(j);
+            }
+        });
 }
 
 } // namespace mtl

--- a/tests/unit/operation/test_factorization_mt.cpp
+++ b/tests/unit/operation/test_factorization_mt.cpp
@@ -341,3 +341,29 @@ TEST_CASE("Threaded Householder reflectors: single-chunk boundary (#297)",
             }
     }
 }
+
+TEST_CASE("Threaded Householder reflectors: empty / beyond-end target is a no-op (#297)",
+          "[operation][householder][threading][mt][edge]") {
+    // col >= n (left) and row >= m (right) must leave A unchanged, matching the
+    // serial loops -- guards against the unsigned n-col / m-row underflow.
+    const std::size_t m = 8, n = 8;
+    mat::dense2D<double> A(m, n), A0(m, n);
+    for (std::size_t i = 0; i < m; ++i)
+        for (std::size_t j = 0; j < n; ++j) { double x = 1.0 + double(i) + 0.5 * double(j); A(i, j) = x; A0(i, j) = x; }
+    vec::dense_vector<double> v(m, 0.5);
+    const double beta = 0.3;
+
+    auto unchanged = [&] {
+        for (std::size_t i = 0; i < m; ++i)
+            for (std::size_t j = 0; j < n; ++j) REQUIRE(A(i, j) == A0(i, j));
+    };
+
+    apply_householder_left(A, v, beta, /*row=*/0, /*col=*/n);       // target empty
+    unchanged();
+    apply_householder_left(A, v, beta, /*row=*/0, /*col=*/n + 3);   // beyond end
+    unchanged();
+    apply_householder_right(A, v, beta, /*row=*/m, /*col=*/0);      // target empty
+    unchanged();
+    apply_householder_right(A, v, beta, /*row=*/m + 3, /*col=*/0);  // beyond end
+    unchanged();
+}

--- a/tests/unit/operation/test_factorization_mt.cpp
+++ b/tests/unit/operation/test_factorization_mt.cpp
@@ -23,6 +23,8 @@
 #include <mtl/vec/dense_vector.hpp>
 #include <mtl/operation/lu.hpp>
 #include <mtl/operation/cholesky.hpp>
+#include <mtl/operation/householder.hpp>
+#include <mtl/operation/qr.hpp>
 #include <mtl/detail/thread_pool.hpp>
 
 using namespace mtl;
@@ -219,5 +221,123 @@ TEST_CASE("Threaded factorizations degrade correctly at the single-chunk boundar
         A(1, 0) = 1.0; A(1, 1) = 3.0;   // symmetric, SPD, diagonally dominant
         check_lu(A);
         check_chol(A);
+    }
+}
+
+// -- Householder reflector application (#297 batch 2) --------------------
+
+namespace {
+// Serial reference for apply_householder_left: update every column j >= col.
+template <typename T>
+void ref_hh_left(mat::dense2D<T>& A, const vec::dense_vector<T>& v, T beta,
+                 std::size_t row, std::size_t col) {
+    const std::size_t n = A.num_cols();
+    const std::size_t vlen = v.size();
+    for (std::size_t j = col; j < n; ++j) {
+        T w = T(0);
+        for (std::size_t i = 0; i < vlen; ++i) w += v(i) * A(row + i, j);
+        for (std::size_t i = 0; i < vlen; ++i) A(row + i, j) -= beta * v(i) * w;
+    }
+}
+// Serial reference for apply_householder_right: update every row i >= row.
+template <typename T>
+void ref_hh_right(mat::dense2D<T>& A, const vec::dense_vector<T>& v, T beta,
+                  std::size_t row, std::size_t col) {
+    const std::size_t m = A.num_rows();
+    const std::size_t vlen = v.size();
+    for (std::size_t i = row; i < m; ++i) {
+        T w = T(0);
+        for (std::size_t j = 0; j < vlen; ++j) w += A(i, col + j) * v(j);
+        for (std::size_t j = 0; j < vlen; ++j) A(i, col + j) -= beta * w * v(j);
+    }
+}
+} // namespace
+
+TEST_CASE("Threaded apply_householder_left is bit-identical to serial (#297)",
+          "[operation][householder][qr][threading][mt]") {
+    if (detail::thread_pool::instance().size() < 2) WARN("single-core runner: threading not exercised");
+    const std::size_t m = 512, n = 512;   // enough columns to split
+    mat::dense2D<double> A(m, n), Aref(m, n);
+    std::mt19937_64 rng(2024);
+    std::uniform_real_distribution<double> d(-1.0, 1.0);
+    for (std::size_t i = 0; i < m; ++i)
+        for (std::size_t j = 0; j < n; ++j) { double x = d(rng); A(i, j) = x; Aref(i, j) = x; }
+    vec::dense_vector<double> v(m);
+    v(0) = 1.0;
+    for (std::size_t i = 1; i < m; ++i) v(i) = d(rng);
+    const double beta = 0.37;
+
+    apply_householder_left(A, v, beta, /*row=*/0, /*col=*/0);   // threaded
+    ref_hh_left(Aref, v, beta, 0, 0);                           // serial reference
+    for (std::size_t i = 0; i < m; ++i)
+        for (std::size_t j = 0; j < n; ++j) REQUIRE(A(i, j) == Aref(i, j));
+}
+
+TEST_CASE("Threaded apply_householder_right is bit-identical to serial (#297)",
+          "[operation][householder][threading][mt]") {
+    if (detail::thread_pool::instance().size() < 2) WARN("single-core runner: threading not exercised");
+    const std::size_t m = 512, n = 512;   // enough rows to split
+    mat::dense2D<double> A(m, n), Aref(m, n);
+    std::mt19937_64 rng(4048);
+    std::uniform_real_distribution<double> d(-1.0, 1.0);
+    for (std::size_t i = 0; i < m; ++i)
+        for (std::size_t j = 0; j < n; ++j) { double x = d(rng); A(i, j) = x; Aref(i, j) = x; }
+    vec::dense_vector<double> v(n);
+    for (std::size_t j = 0; j < n; ++j) v(j) = d(rng);
+    const double beta = 0.51;
+
+    apply_householder_right(A, v, beta, /*row=*/0, /*col=*/0);  // threaded
+    ref_hh_right(Aref, v, beta, 0, 0);                          // serial reference
+    for (std::size_t i = 0; i < m; ++i)
+        for (std::size_t j = 0; j < n; ++j) REQUIRE(A(i, j) == Aref(i, j));
+}
+
+TEST_CASE("Threaded QR factorization reconstructs A = Q*R (#297)",
+          "[operation][qr][threading][mt]") {
+    if (detail::thread_pool::instance().size() < 2) WARN("single-core runner: threading not exercised");
+    const std::size_t m = 400, n = 300;   // overdetermined; exercises the threaded reflector loop
+    mat::dense2D<double> A(m, n), A0(m, n);
+    std::mt19937_64 rng(1234);
+    std::uniform_real_distribution<double> d(-1.0, 1.0);
+    for (std::size_t i = 0; i < m; ++i)
+        for (std::size_t j = 0; j < n; ++j) { double x = d(rng); A(i, j) = x; A0(i, j) = x; }
+
+    vec::dense_vector<double> tau;
+    REQUIRE(qr_factor(A, tau) == 0);         // threaded reflector applications
+    auto Q = qr_extract_Q(A, tau);           // m x m
+    auto R = qr_extract_R(A);                 // m x n
+
+    // Q*R must reconstruct the original A (correctness under threading).
+    double resid = 0.0;
+    for (std::size_t i = 0; i < m; ++i)
+        for (std::size_t j = 0; j < n; ++j) {
+            double qr = 0.0;
+            for (std::size_t l = 0; l < m; ++l) qr += Q(i, l) * R(l, j);
+            resid = std::max(resid, std::abs(qr - A0(i, j)));
+        }
+    REQUIRE(resid < 1e-10);
+}
+
+TEST_CASE("Threaded Householder reflectors: single-chunk boundary (#297)",
+          "[operation][householder][threading][mt][edge]") {
+    // Tiny sizes so the parallel_for takes its serial-fallback branch.
+    for (std::size_t nsz : {std::size_t{1}, std::size_t{2}}) {
+        mat::dense2D<double> A(nsz, nsz), Al(nsz, nsz), Ar(nsz, nsz);
+        for (std::size_t i = 0; i < nsz; ++i)
+            for (std::size_t j = 0; j < nsz; ++j) { double x = 1.0 + double(i) - 0.5 * double(j); A(i, j) = x; Al(i, j) = x; Ar(i, j) = x; }
+        vec::dense_vector<double> v(nsz);
+        v(0) = 1.0;
+        for (std::size_t i = 1; i < nsz; ++i) v(i) = 0.25 * double(i);
+        const double beta = 0.4;
+
+        auto Lref = Al; ref_hh_left(Lref, v, beta, 0, 0);
+        apply_householder_left(Al, v, beta, 0, 0);
+        auto Rref = Ar; ref_hh_right(Rref, v, beta, 0, 0);
+        apply_householder_right(Ar, v, beta, 0, 0);
+        for (std::size_t i = 0; i < nsz; ++i)
+            for (std::size_t j = 0; j < nsz; ++j) {
+                REQUIRE(Al(i, j) == Lref(i, j));
+                REQUIRE(Ar(i, j) == Rref(i, j));
+            }
     }
 }


### PR DESCRIPTION
## Summary
Batch 2 of the on-node threading rollout (#297): parallelizes the two Householder reflector primitives — the O(m·n) hot loops of the Householder-based dense factorizations.

- **`apply_householder_left`** — partitioned over columns `j`. Each column reads the shared reflector `v` and only column `j` of `A`, writing only column `j`, so contiguous chunking is **bit-identical to serial**. Speeds `qr_factor`/`qr_extract_Q` and the other left-application callers (`lq`, `hessenberg`, `eigenvalue_symmetric`).
- **`apply_householder_right`** — partitioned over rows `i` (same independence argument) — speeds `lq`/`hessenberg`/`eigenvalue_symmetric`.

Both use `parallel_for` with a 64K-work-per-chunk grain; **no-op team at `MTL5_NUM_THREADS=1`** (serial behavior/codegen unchanged). The LAPACK QR path (column-major float/double) is untouched.

## Changes
- `include/mtl/operation/householder.hpp` — parallelize both reflector applications; add `<algorithm>`, `<cstddef>`, `<detail/thread_pool.hpp>`
- `tests/unit/operation/test_factorization_mt.cpp` — add Householder/QR MT cases

## Test Results
| Target | gcc | clang |
|--------|-----|-------|
| op_test_factorization_mt (1,082,272 assertions, threaded on 20 cores) | PASS | PASS |
| op_test_qr | PASS | PASS |
| op_test_svd | PASS | PASS |
| op_test_eigenvalue | PASS | — |
| op_test_eigen_symmetric | PASS | PASS |

The MT test asserts both reflector primitives are **bit-identical (`==`)** to an in-test serial reference (512×512), a 400×300 QR reconstructs `A = Q·R`, and 1×1/2×2 boundary cases hit the serial-fallback branch. **Race-free under ThreadSanitizer** (`-DMTL5_SANITIZE=thread`, clang). The Householder-dependent factorization tests (QR/SVD/eigen) all pass unchanged, confirming the shared-primitive blast radius is safe.

## Scope
Batch 2 of #297. Remaining: supernodal sparse factorization panels, sparse triangular-solve level scheduling, BLIS-style multi-loop GEMM, general element-wise sweeps.

## Test plan
- [ ] Fast CI passes (gcc + clang)
- [ ] Promote to ready: `gh pr ready`

Relates to #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved matrix factorization performance by parallelizing Householder reflection operations across rows and columns.
  * Better utilizes available CPU resources for larger matrix workloads.

* **Reliability**
  * Preserved existing numerical results while validating parallel Householder operations and QR factorization.
  * Added coverage for small matrices and single-chunk execution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->