### PR TITLE
perf(sparse): level-scheduled parallel lower triangular solve (#297 batch 3 pilot)

### DIFF
--- a/docs-site/sync-content.mjs
+++ b/docs-site/sync-content.mjs
@@ -62,6 +62,7 @@ const FILE_MAP = {
   'position-mixed-precision-acceleration.md':   'design/mixed-precision-acceleration.md',
   'design/blas-kernel-architecture.md':         'design/blas-kernel-architecture.md',
   'design/multicore-scaling-investigation.md':  'design/multicore-scaling-investigation.md',
+  'design/parallelization-patterns-and-pitfalls.md': 'design/parallelization-patterns-and-pitfalls.md',
   'design/mixed-precision-custom-types-SIMD.md': 'design/mixed-precision-custom-types-SIMD.md',
 
   // ── Modernization ──────────────────────────────────────────────────────

--- a/docs/design/parallelization-patterns-and-pitfalls.md
+++ b/docs/design/parallelization-patterns-and-pitfalls.md
@@ -1,0 +1,121 @@
+# Parallelizing algorithms in MTL5: patterns and pitfalls
+
+A field guide distilled from the on-node threading rollout ([#297](https://github.com/stillwater-sc/mtl5/issues/297), building on the thread-pool epic [#221](https://github.com/stillwater-sc/mtl5/issues/221)). It records the parallelization *patterns* that worked, and — more valuably — the *correctness, caching, encapsulation, and exception-safety pitfalls* that code review surfaced, so the next algorithm we parallelize can reuse the insight instead of rediscovering it.
+
+The concrete case studies are:
+
+- **Batch 1 ([#298](https://github.com/stillwater-sc/mtl5/pull/298))** — dense LU trailing-submatrix update, Cholesky column update.
+- **Batch 2 ([#300](https://github.com/stillwater-sc/mtl5/pull/300))** — Householder reflector application (`apply_householder_left`/`_right`), which powers QR / LQ / Hessenberg / the symmetric eigensolver.
+- **Batch 3 pilot ([#301](https://github.com/stillwater-sc/mtl5/pull/301))** — sparse triangular solve via level scheduling.
+
+---
+
+## 1. The non-negotiable properties
+
+Every parallel kernel in MTL5 must hold these, in priority order:
+
+1. **Serial path unchanged.** At `MTL5_NUM_THREADS=1` (the default) the code runs the original serial path, byte-identical in behavior and codegen. The persistent `detail::thread_pool` makes this automatic: `parallel_for` runs a single `body(0, n)` when the team is size 1 or the work is below the grain, so *always calling `parallel_for`* is a zero-overhead no-op serially.
+2. **Bit-identical across thread counts** wherever the serial code is deterministic. Not just "close" — exactly `==`. This is what lets us assert equality in tests and makes threaded results reproducible.
+3. **Race-free**, proven under ThreadSanitizer.
+4. **Deterministic schedule.** The partition of work is a pure function of the input, so results never depend on scheduling timing.
+
+Determinism (2) is a *choice we design for*, not a given. See §3.
+
+---
+
+## 2. The two parallelism patterns
+
+### 2a. Embarrassingly parallel over independent outputs
+
+Most dense kernels reduce to: *"compute a set of outputs, each written once, each reading only shared read-only data or earlier-finalized outputs."* Partition the outputs into contiguous chunks; each chunk owns a disjoint output range.
+
+| Kernel | Parallelized over | Each unit writes | reads (shared, read-only) |
+|---|---|---|---|
+| LU trailing update | rows `i > k` | row `i` | pivot row `k`, `A(k,k)` |
+| Cholesky column update | rows `i > j` | `A(i,j)` | columns `< j`, column `j` |
+| `apply_householder_left` | columns `j ≥ col` | column `j` | reflector `v` |
+| `apply_householder_right` | rows `i ≥ row` | its `vlen` entries of row `i` | reflector `v` |
+
+Because each output is produced by exactly one chunk with the same arithmetic in the same order as serial, these are **bit-identical and race-free "for free."** This is the pattern to reach for first — if you can phrase the kernel this way, the parallelization is almost mechanical.
+
+### 2b. Dependency-structured parallelism → level scheduling
+
+When outputs depend on each other (triangular solve, factorization panels), you can't partition arbitrarily. Group work into **levels**: `level[i] = 1 + max(level of i's dependencies)`. All items in a level are mutually independent, so a level is an embarrassingly-parallel step (pattern 2a); levels run in sequence with an implicit barrier between them. Parallelism is bounded by the width of each level, not the total work — a chain (bandwidth-1 matrix) has one item per level and no parallelism; a block-diagonal or arrow structure has wide levels.
+
+Level scheduling needs a **preprocessing pass** (build the levels, O(nnz)) whose cost is comparable to one solve, so it only pays off when the schedule is **built once and reused** across many solves. That reuse requirement is the source of most of the pitfalls in §5.
+
+---
+
+## 3. Bit-identity is an ordering property — preserve the accumulation order
+
+The subtle lesson from the sparse batch: *the same math in a different order is not bit-identical in floating point.* Two mathematically-equal formulations can give different last-bit results.
+
+The sparse lower solve was a **CSC column-scatter**: `for each column j: x[j] /= L(j,j); for i>j: x[i] -= L(i,j)·x[j]`. Column `j` writes into many `x[i]`. Parallelizing columns is a double failure: (a) two columns write the same `x[i]` → **race**, and (b) their subtraction order is not fixed → **non-deterministic** and *not* bit-identical to serial.
+
+The fix was to switch to a **row-oriented gather**: `x[i] = (b[i] − Σ_{k<i} L(i,k)·x[k]) / L(i,i)`. Now each `x[i]` is written once (race-free), *and* — the key — if the row's entries are iterated in **increasing column order**, the accumulation is the exact same sequence of `b[i]` minus successive products that the CSC scatter performed. So the gather is **bit-identical to the scatter**, and level scheduling over it is bit-identical across thread counts.
+
+> **Rule:** to parallelize a reduction/accumulation deterministically, transform it into a form where each output is computed exactly once, **in the same operation order as the serial code**. Then contiguous chunking preserves that order per output.
+
+`thread_pool::parallel_for` uses contiguous, deterministic chunking precisely so element-wise callers stay bit-identical across thread counts. (`parallel_reduce` does *not* — chunked summation changes associativity — so it is deterministic per thread count but not serial-exact; don't use it where you need `==` to serial.)
+
+---
+
+## 4. Grain: keep small work serial
+
+Each kernel picks a grain so `parallel_for` stays serial until the work amortizes the hand-off, targeting ~64K flops per chunk: `grain = max(1, 65536 / work_per_unit)`, where `work_per_unit` is the inner-loop length (dot length for GEMV, `n-k` for the LU trailing row, average row nnz for the sparse solve). Consequence for tests: a matrix has to be genuinely large (and, for level scheduling, have wide levels) before the parallel path *splits* — see §6.
+
+---
+
+## 5. The pitfalls (mostly from reusable cached state)
+
+The dense batches (2a) were nearly pitfall-free. The sparse pilot — which caches a reusable schedule inside a factorization object — drew a chain of review findings that generalize to **any algorithm that caches derived state**:
+
+### 5a. Cache structure, not values (value-agnostic derived state)
+The first schedule copied `L`'s numeric values. But a same-pattern re-factorization (the transient / mp-spice path: same sparsity, new numbers, in place) then left the cache holding stale values. **Fix:** the schedule stores only *positions* into `L`'s arrays and reads the numbers from `L` at solve time. Derived state that caches *structure* survives a value refresh; state that caches *values* does not.
+
+### 5b. Bind cached state to its source; don't identify it with a weak key
+The next attempt guarded the cache with `L.nnz()` as a staleness key. **`nnz` is not a pattern identity** — two matrices can share dimension and nonzero count but differ structurally, so the cached positions could silently address the wrong matrix. Chasing a run-time "has the source changed?" key is a losing game (a full pattern compare is as expensive as rebuilding). **Fix:** build the derived state *at the authoritative moment* (factorization time, when the factor is first produced) and **bind it to that object** so it can never refer to a different source.
+
+### 5c. Enforce invariants; don't just document them
+Building at factor time still left `L` and the schedule as public, independently-mutable members — a caller could replace one without the other. Documentation ("treat as immutable") is not enforcement. **Fix:** make the coupled state **private and read-only**, installed only *together* through a single setter (`set_factor`) that rebuilds the schedule, with a read-only accessor (`factor()`) for reads. The two can no longer drift out of sync, so no run-time key is needed. (Blast radius for privatizing a long-public member was one line — check, but usually small.)
+
+### 5d. Validate before you mutate; be strongly exception-safe
+The setter accepted a factor whose dimensions didn't match the analysis, and it replaced the factor *before* building the schedule. **Two bugs:** (i) a dimension mismatch would, in release builds, index a smaller RHS with the larger factor's rows → out of bounds; (ii) if schedule construction threw, the object was left with a **new factor and a stale schedule**. **Fix:** validate dimensions first (throw), then **build into a local and commit both members with `noexcept` moves** — so a throw leaves the object unchanged (strong exception guarantee).
+
+### 5e. Asserts vanish in release — validate at the public boundary
+`assert` is right for an internal primitive whose caller already guarantees the contract (e.g. the low-level solve, whose only entry point validates sizes with a `throw`). It is *not* a substitute for validating **untrusted input at a public API boundary** — those checks must be `throw`s that survive `NDEBUG`.
+
+### 5f. Unsigned-index arithmetic underflows (dense batch)
+Deriving the work range as `n - offset` on unsigned `size_type` wraps to a huge count when `offset > n` — where the original serial loop simply did nothing. `parallel_for` then iterates out of bounds. **Fix:** guard `if (offset >= n) return;` *before* computing the range. Current callers may never pass an out-of-range offset, but a parallelized primitive is often more public than the loop it replaced.
+
+---
+
+## 6. Testing recipe
+
+The library kernels use the env-sized singleton pool, and **no CI lane currently sets `MTL5_NUM_THREADS`** (tracked in [#299](https://github.com/stillwater-sc/mtl5/issues/299)), so a threaded test must arrange its own threading and is the only thing exercising these paths today.
+
+- **Force a multithreaded pool in-process.** Set `MTL5_NUM_THREADS` in a namespace-scope initializer *before the pool's first (lazy) use*; the whole test binary then runs threaded. (Each `test_*.cpp` is its own executable, so this is local.)
+- **Assert bit-identity (`==`) against a serial reference.** Either a faithful in-test serial reimplementation (dense factorizations) or the existing serial routine the parallel one must match (`dense_lower_solve`). Exact equality catches races a tolerance check would hide.
+- **Include a case that actually *splits*.** Because of the grain (§4), pick sizes large enough that `parallel_for` partitions — for level scheduling, a structure with a **wide level** (e.g. an arrow matrix: one level of `n−1` independent rows). Guard with `if (pool.size() < 2) WARN(...)` so single-core runners don't silently pass a vacuous test.
+- **Run it under ThreadSanitizer** (`-DMTL5_SANITIZE=thread`). This is the actual race proof; the splitting case is what gives TSan something to find.
+- **Boundary cases:** `1×1`, empty (`0×0` / `n=0`), the fully-sequential structure (dense triangular = one item per level), the maximally-parallel structure (diagonal = all level 0), and out-of-range offsets (§5f).
+
+---
+
+## 7. Checklist for the next algorithm
+
+1. Can it be phrased as pattern 2a (independent outputs, each written once)? If so, partition the outputs, done — bit-identical and race-free by construction.
+2. If outputs depend on each other, is there exploitable level/wavefront parallelism (2b)? Build a deterministic schedule; parallelize within a level.
+3. Does parallelizing change the accumulation order? If yes, transform to a one-write-per-output form that **preserves the serial order** (§3), or accept non-bit-identical and document it.
+4. Pick a grain so small inputs stay serial (§4).
+5. If you cache reusable derived state: cache **structure not values** (5a); **bind it to its source** at the authoritative moment, no weak keys (5b); make the coupled state **private, set atomically** through a validating, **exception-safe** setter (5c–5d).
+6. Validate untrusted input at public boundaries with `throw`, not `assert` (5e); guard unsigned index arithmetic (5f).
+7. Test: env-thread the pool, `==` vs serial, a splitting case, TSan, boundaries (§6).
+
+---
+
+## References
+
+- Thread pool + kernel rollout: [#221](https://github.com/stillwater-sc/mtl5/issues/221) (batches [#239–#243]), extended in [#297](https://github.com/stillwater-sc/mtl5/issues/297) (batches [#298], [#300], [#301]).
+- Threaded CI coverage gap: [#299](https://github.com/stillwater-sc/mtl5/issues/299).
+- Design context: [`on-node-threading.md`](../algorithms/on-node-threading.md), [`multicore-scaling-investigation.md`](multicore-scaling-investigation.md).

--- a/include/mtl/sparse/factorization/level_schedule.hpp
+++ b/include/mtl/sparse/factorization/level_schedule.hpp
@@ -1,0 +1,151 @@
+#pragma once
+// MTL5 -- level scheduling for the sparse triangular solve (#297 batch 3).
+//
+// The dense_lower_solve in triangular_solve.hpp is a CSC column-scatter: column
+// j updates rows i>j (x[i] -= L(i,j)*x[j]). Two independent columns writing the
+// same x[i] would race, and their subtraction order is not fixed, so the CSC
+// form does not parallelize deterministically.
+//
+// This builds an equivalent ROW-oriented (gather) schedule that IS parallel and
+// bit-identical to the serial CSC solve:
+//
+//   * Transpose the strictly-lower part of L to CSR so each row i lists its
+//     entries (k, L(i,k)) with k<i in INCREASING k order -- the same order the
+//     CSC scatter accumulates them into x[i]. Then
+//         x[i] = (b[i] - sum_{k<i} L(i,k)*x[k]) / L(i,i)
+//     performs the identical floating-point operations in the identical order,
+//     so the result is bit-for-bit the same as dense_lower_solve.
+//   * Assign each row a level: level[i] = 1 + max level of its dependencies
+//     (rows k<i with L(i,k)!=0). Rows in the same level are mutually
+//     independent, so within a level every row writes its OWN x[i] (no race)
+//     while reading only x[k] from earlier levels (already finalized).
+//
+// The schedule is O(nnz) to build and is meant to be computed once and reused
+// across many solves (the factor-once / solve-many transient path), so the
+// build cost amortizes. Threading is off by default (MTL5_NUM_THREADS=1): the
+// solve then runs the levels serially and is byte-identical to dense_lower_solve.
+
+#include <algorithm>
+#include <cstddef>
+#include <vector>
+
+#include <mtl/sparse/util/csc.hpp>
+#include <mtl/detail/thread_pool.hpp>
+
+namespace mtl::sparse::factorization {
+
+/// Reusable schedule for a level-scheduled lower-triangular forward solve.
+/// Built from a lower-triangular L in CSC; equivalent to dense_lower_solve.
+template <typename Value>
+struct lower_solve_schedule {
+    std::size_t n = 0;
+    // CSR of the strictly-lower entries (k < i), increasing k within each row.
+    std::vector<std::size_t> row_ptr;   // length n+1
+    std::vector<std::size_t> col_ind;   // length nnz_offdiag
+    std::vector<Value>       val;       // length nnz_offdiag
+    std::vector<Value>       diag;      // length n, L(i,i)
+    // Level partition of the rows: order[level_ptr[l] .. level_ptr[l+1]) are the
+    // rows of level l (kept in increasing-row order for determinism).
+    std::vector<std::size_t> level_ptr; // length nlevels+1
+    std::vector<std::size_t> order;     // length n
+    std::size_t grain = 1;              // parallel_for grain (rows per chunk min)
+};
+
+/// Build the forward-solve schedule from a lower-triangular L (CSC). The first
+/// stored entry of each column must be the diagonal (row j), matching the layout
+/// dense_lower_solve expects.
+template <typename Value, typename SizeType>
+lower_solve_schedule<Value> build_lower_solve_schedule(
+    const util::csc_matrix<Value, SizeType>& L)
+{
+    const std::size_t n = static_cast<std::size_t>(L.ncols);
+    lower_solve_schedule<Value> s;
+    s.n = n;
+    s.diag.assign(n, Value{0});
+    s.row_ptr.assign(n + 1, std::size_t{0});
+
+    // Pass 1: diagonal + count strictly-lower entries per row (for the transpose).
+    std::size_t nnz_off = 0;
+    for (std::size_t j = 0; j < n; ++j) {
+        SizeType p = L.col_ptr[j];
+        if (p < L.col_ptr[j + 1]) s.diag[j] = L.values[p];   // first entry is the diagonal
+        for (SizeType q = p + 1; q < L.col_ptr[j + 1]; ++q) {
+            const std::size_t i = static_cast<std::size_t>(L.row_ind[q]);   // i > j
+            ++s.row_ptr[i + 1];
+            ++nnz_off;
+        }
+    }
+    for (std::size_t i = 0; i < n; ++i) s.row_ptr[i + 1] += s.row_ptr[i];
+    s.col_ind.resize(nnz_off);
+    s.val.resize(nnz_off);
+
+    // Pass 2: scatter into CSR. Iterating columns j in increasing order makes
+    // each row's entries land in increasing-column order.
+    std::vector<std::size_t> fill(s.row_ptr.begin(), s.row_ptr.end() - 1);
+    for (std::size_t j = 0; j < n; ++j) {
+        for (SizeType q = L.col_ptr[j] + 1; q < L.col_ptr[j + 1]; ++q) {
+            const std::size_t i = static_cast<std::size_t>(L.row_ind[q]);
+            const std::size_t dst = fill[i]++;
+            s.col_ind[dst] = j;
+            s.val[dst] = L.values[q];
+        }
+    }
+
+    // Pass 3: levels. level[i] = 1 + max level of its dependencies; rows i are
+    // processed in increasing order so every dependency k<i already has a level.
+    std::vector<std::size_t> level(n, 0);
+    std::size_t nlevels = 0;
+    for (std::size_t i = 0; i < n; ++i) {
+        std::size_t lv = 0;
+        for (std::size_t p = s.row_ptr[i]; p < s.row_ptr[i + 1]; ++p) {
+            const std::size_t k = s.col_ind[p];
+            if (level[k] + 1 > lv) lv = level[k] + 1;
+        }
+        level[i] = lv;
+        if (lv + 1 > nlevels) nlevels = lv + 1;
+    }
+
+    // Counting-sort the rows into level order.
+    s.level_ptr.assign(nlevels + 1, std::size_t{0});
+    for (std::size_t i = 0; i < n; ++i) ++s.level_ptr[level[i] + 1];
+    for (std::size_t l = 0; l < nlevels; ++l) s.level_ptr[l + 1] += s.level_ptr[l];
+    s.order.resize(n);
+    std::vector<std::size_t> cursor(s.level_ptr.begin(), s.level_ptr.end() - 1);
+    for (std::size_t i = 0; i < n; ++i) s.order[cursor[level[i]]++] = i;
+
+    // Grain: aim for ~64K flops per chunk, using the average row length as the
+    // per-row work estimate (2 flops per stored entry).
+    const std::size_t avg = n ? std::max<std::size_t>(1, nnz_off / n) : 1;
+    s.grain = std::max<std::size_t>(std::size_t{1}, std::size_t{32768} / avg);
+    return s;
+}
+
+/// Level-scheduled lower-triangular forward solve: solve L x = b with x holding
+/// b on entry and the solution on exit. Bit-identical to dense_lower_solve; the
+/// rows of each level are solved in parallel on the thread pool (serial when
+/// MTL5_NUM_THREADS=1).
+template <typename Value>
+void level_scheduled_lower_solve(const lower_solve_schedule<Value>& s,
+                                 std::vector<Value>& x)
+{
+    const std::size_t nlevels = s.level_ptr.empty() ? 0 : s.level_ptr.size() - 1;
+    for (std::size_t l = 0; l < nlevels; ++l) {
+        const std::size_t lb = s.level_ptr[l];
+        const std::size_t le = s.level_ptr[l + 1];
+        const std::size_t count = le - lb;
+        if (count == 0) continue;
+        detail::thread_pool::instance().parallel_for(
+            count, s.grain,
+            [&](std::size_t cb, std::size_t ce) {
+                for (std::size_t t = cb; t < ce; ++t) {
+                    const std::size_t i = s.order[lb + t];
+                    Value acc = x[i];   // b[i]
+                    for (std::size_t p = s.row_ptr[i]; p < s.row_ptr[i + 1]; ++p)
+                        acc -= s.val[p] * x[s.col_ind[p]];
+                    x[i] = acc / s.diag[i];
+                }
+            });
+    }
+}
+
+} // namespace mtl::sparse::factorization

--- a/include/mtl/sparse/factorization/level_schedule.hpp
+++ b/include/mtl/sparse/factorization/level_schedule.hpp
@@ -20,12 +20,18 @@
 //     independent, so within a level every row writes its OWN x[i] (no race)
 //     while reading only x[k] from earlier levels (already finalized).
 //
-// The schedule is O(nnz) to build and is meant to be computed once and reused
-// across many solves (the factor-once / solve-many transient path), so the
-// build cost amortizes. Threading is off by default (MTL5_NUM_THREADS=1): the
-// solve then runs the levels serially and is byte-identical to dense_lower_solve.
+// The schedule stores only STRUCTURE -- the positions of L's entries, not their
+// values -- and reads the numbers from L at solve time. So a same-pattern
+// re-factorization that overwrites L's values in place (the transient / mp-spice
+// path) can reuse the schedule with fresh values; only a pattern change needs a
+// rebuild (caught by comparing L.nnz(), and in normal use a pattern change comes
+// with a new symbolic analysis / object). The schedule is O(nnz) to build and is
+// meant to be computed once and reused across many solves, so the build cost
+// amortizes. Threading is off by default (MTL5_NUM_THREADS=1): the solve then
+// runs the levels serially and is byte-identical to dense_lower_solve.
 
 #include <algorithm>
+#include <cassert>
 #include <cstddef>
 #include <vector>
 
@@ -36,14 +42,16 @@ namespace mtl::sparse::factorization {
 
 /// Reusable schedule for a level-scheduled lower-triangular forward solve.
 /// Built from a lower-triangular L in CSC; equivalent to dense_lower_solve.
-template <typename Value>
+/// Stores positions into L's arrays (value-agnostic), so it survives an in-place
+/// same-pattern re-factorization of L.
 struct lower_solve_schedule {
     std::size_t n = 0;
+    std::size_t built_nnz = 0;          // L.nnz() when built (staleness guard)
     // CSR of the strictly-lower entries (k < i), increasing k within each row.
     std::vector<std::size_t> row_ptr;   // length n+1
-    std::vector<std::size_t> col_ind;   // length nnz_offdiag
-    std::vector<Value>       val;       // length nnz_offdiag
-    std::vector<Value>       diag;      // length n, L(i,i)
+    std::vector<std::size_t> col_ind;   // length nnz_offdiag: the column k
+    std::vector<std::size_t> val_pos;   // length nnz_offdiag: index of L(i,k) in L.values
+    std::vector<std::size_t> diag_pos;  // length n: index of L(i,i) in L.values
     // Level partition of the rows: order[level_ptr[l] .. level_ptr[l+1]) are the
     // rows of level l (kept in increasing-row order for determinism).
     std::vector<std::size_t> level_ptr; // length nlevels+1
@@ -55,20 +63,21 @@ struct lower_solve_schedule {
 /// stored entry of each column must be the diagonal (row j), matching the layout
 /// dense_lower_solve expects.
 template <typename Value, typename SizeType>
-lower_solve_schedule<Value> build_lower_solve_schedule(
+lower_solve_schedule build_lower_solve_schedule(
     const util::csc_matrix<Value, SizeType>& L)
 {
     const std::size_t n = static_cast<std::size_t>(L.ncols);
-    lower_solve_schedule<Value> s;
+    lower_solve_schedule s;
     s.n = n;
-    s.diag.assign(n, Value{0});
+    s.built_nnz = static_cast<std::size_t>(L.nnz());
+    s.diag_pos.assign(n, std::size_t{0});
     s.row_ptr.assign(n + 1, std::size_t{0});
 
-    // Pass 1: diagonal + count strictly-lower entries per row (for the transpose).
+    // Pass 1: diagonal position + count strictly-lower entries per row.
     std::size_t nnz_off = 0;
     for (std::size_t j = 0; j < n; ++j) {
         SizeType p = L.col_ptr[j];
-        if (p < L.col_ptr[j + 1]) s.diag[j] = L.values[p];   // first entry is the diagonal
+        if (p < L.col_ptr[j + 1]) s.diag_pos[j] = static_cast<std::size_t>(p);   // first entry is the diagonal
         for (SizeType q = p + 1; q < L.col_ptr[j + 1]; ++q) {
             const std::size_t i = static_cast<std::size_t>(L.row_ind[q]);   // i > j
             ++s.row_ptr[i + 1];
@@ -77,7 +86,7 @@ lower_solve_schedule<Value> build_lower_solve_schedule(
     }
     for (std::size_t i = 0; i < n; ++i) s.row_ptr[i + 1] += s.row_ptr[i];
     s.col_ind.resize(nnz_off);
-    s.val.resize(nnz_off);
+    s.val_pos.resize(nnz_off);
 
     // Pass 2: scatter into CSR. Iterating columns j in increasing order makes
     // each row's entries land in increasing-column order.
@@ -87,7 +96,7 @@ lower_solve_schedule<Value> build_lower_solve_schedule(
             const std::size_t i = static_cast<std::size_t>(L.row_ind[q]);
             const std::size_t dst = fill[i]++;
             s.col_ind[dst] = j;
-            s.val[dst] = L.values[q];
+            s.val_pos[dst] = static_cast<std::size_t>(q);
         }
     }
 
@@ -121,13 +130,19 @@ lower_solve_schedule<Value> build_lower_solve_schedule(
 }
 
 /// Level-scheduled lower-triangular forward solve: solve L x = b with x holding
-/// b on entry and the solution on exit. Bit-identical to dense_lower_solve; the
-/// rows of each level are solved in parallel on the thread pool (serial when
-/// MTL5_NUM_THREADS=1).
-template <typename Value>
-void level_scheduled_lower_solve(const lower_solve_schedule<Value>& s,
+/// b on entry and the solution on exit. Values are read from L (so a same-pattern
+/// re-factorization is picked up), using the positions cached in the schedule.
+/// Bit-identical to dense_lower_solve; the rows of each level are solved in
+/// parallel on the thread pool (serial when MTL5_NUM_THREADS=1).
+template <typename Value, typename SizeType>
+void level_scheduled_lower_solve(const util::csc_matrix<Value, SizeType>& L,
+                                 const lower_solve_schedule& s,
                                  std::vector<Value>& x)
 {
+    assert(s.n == static_cast<std::size_t>(L.ncols) &&
+           s.built_nnz == static_cast<std::size_t>(L.nnz()) &&
+           "schedule does not match L (rebuild after a pattern change)");
+    assert(x.size() >= s.n && "solution vector shorter than the system");
     const std::size_t nlevels = s.level_ptr.empty() ? 0 : s.level_ptr.size() - 1;
     for (std::size_t l = 0; l < nlevels; ++l) {
         const std::size_t lb = s.level_ptr[l];
@@ -141,8 +156,8 @@ void level_scheduled_lower_solve(const lower_solve_schedule<Value>& s,
                     const std::size_t i = s.order[lb + t];
                     Value acc = x[i];   // b[i]
                     for (std::size_t p = s.row_ptr[i]; p < s.row_ptr[i + 1]; ++p)
-                        acc -= s.val[p] * x[s.col_ind[p]];
-                    x[i] = acc / s.diag[i];
+                        acc -= L.values[s.val_pos[p]] * x[s.col_ind[p]];
+                    x[i] = acc / L.values[s.diag_pos[i]];
                 }
             });
     }

--- a/include/mtl/sparse/factorization/sparse_cholesky.hpp
+++ b/include/mtl/sparse/factorization/sparse_cholesky.hpp
@@ -25,7 +25,6 @@
 #include <cassert>
 #include <cmath>
 #include <cstddef>
-#include <memory>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -85,14 +84,11 @@ struct cholesky_numeric {
 
         // Step 2: Forward solve: L * y = w.
         // Level-scheduled (parallel, bit-identical to dense_lower_solve); the
-        // schedule is built once and reused (factor-once / solve-many). It stores
-        // only structure and reads L's values at solve time, so it is rebuilt
-        // only when L's pattern (nnz) changes. Serial and byte-identical at
-        // MTL5_NUM_THREADS=1.
-        if (!fwd_sched_ || fwd_sched_->built_nnz != static_cast<std::size_t>(L.nnz()))
-            fwd_sched_ = std::make_shared<const lower_solve_schedule>(
-                build_lower_solve_schedule(L));
-        level_scheduled_lower_solve(L, *fwd_sched_, w);
+        // schedule was built together with L at factorization time and is bound
+        // to it. It stores only structure and reads L's values at solve time, so
+        // an in-place same-pattern re-factorization is reflected automatically.
+        // Serial and byte-identical at MTL5_NUM_THREADS=1.
+        level_scheduled_lower_solve(L, fwd_sched, w);
 
         // Step 3: Back solve: L^T * z = y (serial; level scheduling of the
         // transpose solve is a follow-up in the #297 rollout).
@@ -103,13 +99,13 @@ struct cholesky_numeric {
             x(symbolic.perm[i]) = static_cast<typename VecX::value_type>(w[i]);
     }
 
-private:
-    // Forward-solve level schedule, built lazily on first solve() and reused;
-    // rebuilt if L's pattern (nnz) changes. Value-agnostic (reads L at solve),
-    // so an in-place same-pattern re-factorization is picked up automatically.
-    // shared_ptr so a copied cholesky_numeric shares the schedule. Not safe
-    // against concurrent solve() calls on the same object (never a supported use).
-    mutable std::shared_ptr<const lower_solve_schedule> fwd_sched_;
+    // Forward-solve level schedule, built with L at factorization time (by
+    // sparse_cholesky_numeric) and bound to it. Value-agnostic: it stores only
+    // the positions of L's entries and reads the numbers from L at solve time,
+    // so an in-place same-pattern re-factorization is reflected. Like L and
+    // symbolic, this is part of the immutable factorization result -- L must not
+    // be replaced with a different pattern independently of it.
+    lower_solve_schedule fwd_sched;
 };
 
 /// Perform symbolic Cholesky analysis on a symmetric sparse matrix.
@@ -419,6 +415,10 @@ cholesky_numeric<Value> sparse_cholesky_numeric(
     cholesky_numeric<Value> result;
     result.L = std::move(L);
     result.symbolic = sym;
+    // Build the forward-solve level schedule now, while L is authoritative, so it
+    // is bound to this factorization (no lazy build from a possibly-mutated L,
+    // and no need for a run-time staleness key).
+    result.fwd_sched = build_lower_solve_schedule(result.L);
     return result;
 }
 

--- a/include/mtl/sparse/factorization/sparse_cholesky.hpp
+++ b/include/mtl/sparse/factorization/sparse_cholesky.hpp
@@ -25,6 +25,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstddef>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -37,6 +38,7 @@
 #include <mtl/sparse/analysis/elimination_tree.hpp>
 #include <mtl/sparse/analysis/postorder.hpp>
 #include <mtl/sparse/factorization/triangular_solve.hpp>
+#include <mtl/sparse/factorization/level_schedule.hpp>
 
 namespace mtl::sparse::factorization {
 
@@ -81,16 +83,30 @@ struct cholesky_numeric {
         for (std::size_t i = 0; i < n; ++i)
             w[i] = static_cast<Value>(b(symbolic.perm[i]));
 
-        // Step 2: Forward solve: L * y = w
-        dense_lower_solve(L, w);
+        // Step 2: Forward solve: L * y = w.
+        // Level-scheduled (parallel, bit-identical to dense_lower_solve); the
+        // schedule is built once on first solve and reused (factor-once /
+        // solve-many). Serial and byte-identical at MTL5_NUM_THREADS=1.
+        if (!fwd_sched_)
+            fwd_sched_ = std::make_shared<const lower_solve_schedule<Value>>(
+                build_lower_solve_schedule(L));
+        level_scheduled_lower_solve(*fwd_sched_, w);
 
-        // Step 3: Back solve: L^T * z = y
+        // Step 3: Back solve: L^T * z = y (serial; level scheduling of the
+        // transpose solve is a follow-up in the #297 rollout).
         dense_lower_transpose_solve(L, w);
 
         // Step 4: Apply inverse permutation: x = P^T * z
         for (std::size_t i = 0; i < n; ++i)
             x(symbolic.perm[i]) = static_cast<typename VecX::value_type>(w[i]);
     }
+
+private:
+    // Forward-solve level schedule, built lazily on first solve() and reused.
+    // shared_ptr so a copied cholesky_numeric shares the (pattern-identical)
+    // schedule. Not safe against concurrent solve() calls on the same object,
+    // which was never a supported use.
+    mutable std::shared_ptr<const lower_solve_schedule<Value>> fwd_sched_;
 };
 
 /// Perform symbolic Cholesky analysis on a symmetric sparse matrix.

--- a/include/mtl/sparse/factorization/sparse_cholesky.hpp
+++ b/include/mtl/sparse/factorization/sparse_cholesky.hpp
@@ -72,10 +72,19 @@ struct cholesky_numeric {
     /// Install the numeric factor and (re)build the coupled forward-solve
     /// schedule from it. L and its schedule are always set together here, which
     /// enforces the invariant the level solve relies on -- the schedule's cached
-    /// entry positions always match L's pattern.
+    /// entry positions always match L's pattern. The factor must be square and
+    /// match the symbolic dimension (set symbolic first). Strongly exception
+    /// safe: the schedule is built before either member is replaced, so a throw
+    /// leaves the object unchanged.
     void set_factor(util::csc_matrix<Value> L) {
-        L_ = std::move(L);
-        fwd_sched_ = build_lower_solve_schedule(L_);
+        if (static_cast<std::size_t>(L.ncols) != symbolic.n ||
+            static_cast<std::size_t>(L.nrows) != symbolic.n)
+            throw std::invalid_argument(
+                "cholesky_numeric::set_factor: factor dimension does not match "
+                "the symbolic analysis");
+        lower_solve_schedule sched = build_lower_solve_schedule(L);   // may throw
+        L_ = std::move(L);                                            // noexcept
+        fwd_sched_ = std::move(sched);                               // noexcept
     }
 
     /// Solve A*x = b using the Cholesky factorization.

--- a/include/mtl/sparse/factorization/sparse_cholesky.hpp
+++ b/include/mtl/sparse/factorization/sparse_cholesky.hpp
@@ -55,15 +55,28 @@ struct cholesky_symbolic {
 };
 
 /// Result of numeric Cholesky factorization.
-/// Contains the lower triangular factor L in CSC format and the
-/// symbolic analysis used (for permutation information during solve).
+/// Holds the lower triangular factor L (CSC) and its forward-solve level
+/// schedule as coupled, read-only state: L is only ever installed together with
+/// the schedule built from it (via set_factor), so the two cannot drift out of
+/// sync. The symbolic analysis is exposed for permutation info during solve.
 template <typename Value>
 struct cholesky_numeric {
-    util::csc_matrix<Value> L;            // lower triangular Cholesky factor (CSC)
     cholesky_symbolic symbolic;           // symbolic analysis used
 
     std::size_t num_rows() const { return symbolic.n; }
     std::size_t num_cols() const { return symbolic.n; }
+
+    /// Read-only access to the lower Cholesky factor L (CSC).
+    const util::csc_matrix<Value>& factor() const { return L_; }
+
+    /// Install the numeric factor and (re)build the coupled forward-solve
+    /// schedule from it. L and its schedule are always set together here, which
+    /// enforces the invariant the level solve relies on -- the schedule's cached
+    /// entry positions always match L's pattern.
+    void set_factor(util::csc_matrix<Value> L) {
+        L_ = std::move(L);
+        fwd_sched_ = build_lower_solve_schedule(L_);
+    }
 
     /// Solve A*x = b using the Cholesky factorization.
     /// A = P^T L L^T P, so x = P^T L^{-T} L^{-1} P b
@@ -84,28 +97,24 @@ struct cholesky_numeric {
 
         // Step 2: Forward solve: L * y = w.
         // Level-scheduled (parallel, bit-identical to dense_lower_solve); the
-        // schedule was built together with L at factorization time and is bound
-        // to it. It stores only structure and reads L's values at solve time, so
-        // an in-place same-pattern re-factorization is reflected automatically.
+        // schedule is bound to L_ (built together with it in set_factor). It
+        // stores only structure and reads L_'s values at solve time, so an
+        // in-place same-pattern re-factorization is reflected automatically.
         // Serial and byte-identical at MTL5_NUM_THREADS=1.
-        level_scheduled_lower_solve(L, fwd_sched, w);
+        level_scheduled_lower_solve(L_, fwd_sched_, w);
 
         // Step 3: Back solve: L^T * z = y (serial; level scheduling of the
         // transpose solve is a follow-up in the #297 rollout).
-        dense_lower_transpose_solve(L, w);
+        dense_lower_transpose_solve(L_, w);
 
         // Step 4: Apply inverse permutation: x = P^T * z
         for (std::size_t i = 0; i < n; ++i)
             x(symbolic.perm[i]) = static_cast<typename VecX::value_type>(w[i]);
     }
 
-    // Forward-solve level schedule, built with L at factorization time (by
-    // sparse_cholesky_numeric) and bound to it. Value-agnostic: it stores only
-    // the positions of L's entries and reads the numbers from L at solve time,
-    // so an in-place same-pattern re-factorization is reflected. Like L and
-    // symbolic, this is part of the immutable factorization result -- L must not
-    // be replaced with a different pattern independently of it.
-    lower_solve_schedule fwd_sched;
+private:
+    util::csc_matrix<Value> L_;           // lower triangular Cholesky factor (CSC)
+    lower_solve_schedule    fwd_sched_;   // forward-solve level schedule, bound to L_
 };
 
 /// Perform symbolic Cholesky analysis on a symmetric sparse matrix.
@@ -413,12 +422,11 @@ cholesky_numeric<Value> sparse_cholesky_numeric(
     }
 
     cholesky_numeric<Value> result;
-    result.L = std::move(L);
     result.symbolic = sym;
-    // Build the forward-solve level schedule now, while L is authoritative, so it
-    // is bound to this factorization (no lazy build from a possibly-mutated L,
-    // and no need for a run-time staleness key).
-    result.fwd_sched = build_lower_solve_schedule(result.L);
+    // Installs L and builds its coupled forward-solve schedule atomically, so the
+    // schedule is bound to this factorization (no separately-mutable state, no
+    // run-time staleness key).
+    result.set_factor(std::move(L));
     return result;
 }
 

--- a/include/mtl/sparse/factorization/sparse_cholesky.hpp
+++ b/include/mtl/sparse/factorization/sparse_cholesky.hpp
@@ -85,12 +85,14 @@ struct cholesky_numeric {
 
         // Step 2: Forward solve: L * y = w.
         // Level-scheduled (parallel, bit-identical to dense_lower_solve); the
-        // schedule is built once on first solve and reused (factor-once /
-        // solve-many). Serial and byte-identical at MTL5_NUM_THREADS=1.
-        if (!fwd_sched_)
-            fwd_sched_ = std::make_shared<const lower_solve_schedule<Value>>(
+        // schedule is built once and reused (factor-once / solve-many). It stores
+        // only structure and reads L's values at solve time, so it is rebuilt
+        // only when L's pattern (nnz) changes. Serial and byte-identical at
+        // MTL5_NUM_THREADS=1.
+        if (!fwd_sched_ || fwd_sched_->built_nnz != static_cast<std::size_t>(L.nnz()))
+            fwd_sched_ = std::make_shared<const lower_solve_schedule>(
                 build_lower_solve_schedule(L));
-        level_scheduled_lower_solve(*fwd_sched_, w);
+        level_scheduled_lower_solve(L, *fwd_sched_, w);
 
         // Step 3: Back solve: L^T * z = y (serial; level scheduling of the
         // transpose solve is a follow-up in the #297 rollout).
@@ -102,11 +104,12 @@ struct cholesky_numeric {
     }
 
 private:
-    // Forward-solve level schedule, built lazily on first solve() and reused.
-    // shared_ptr so a copied cholesky_numeric shares the (pattern-identical)
-    // schedule. Not safe against concurrent solve() calls on the same object,
-    // which was never a supported use.
-    mutable std::shared_ptr<const lower_solve_schedule<Value>> fwd_sched_;
+    // Forward-solve level schedule, built lazily on first solve() and reused;
+    // rebuilt if L's pattern (nnz) changes. Value-agnostic (reads L at solve),
+    // so an in-place same-pattern re-factorization is picked up automatically.
+    // shared_ptr so a copied cholesky_numeric shares the schedule. Not safe
+    // against concurrent solve() calls on the same object (never a supported use).
+    mutable std::shared_ptr<const lower_solve_schedule> fwd_sched_;
 };
 
 /// Perform symbolic Cholesky analysis on a symmetric sparse matrix.

--- a/tests/unit/sparse/test_sparse_cholesky.cpp
+++ b/tests/unit/sparse/test_sparse_cholesky.cpp
@@ -89,7 +89,7 @@ TEST_CASE("Sparse Cholesky numeric: 3x3 SPD matrix", "[sparse][cholesky]") {
     auto num = factorization::sparse_cholesky_numeric(A, sym);
 
     // Verify L is lower triangular
-    const auto& L = num.L;
+    const auto& L = num.factor();
     REQUIRE(L.nrows == 3);
     REQUIRE(L.ncols == 3);
 

--- a/tests/unit/sparse/test_trisolve_level_schedule_mt.cpp
+++ b/tests/unit/sparse/test_trisolve_level_schedule_mt.cpp
@@ -1,0 +1,138 @@
+// Level-scheduled sparse lower-triangular forward solve (#297 batch 3, pilot).
+// build_lower_solve_schedule + level_scheduled_lower_solve must be BIT-IDENTICAL
+// to the serial dense_lower_solve: the row-gather accumulates each x[i] in the
+// same increasing-column order the CSC scatter uses. We assert exact equality
+// (==) against dense_lower_solve, on structures that span the level spectrum
+// (all-independent -> fully sequential) including a wide level that actually
+// splits across the pool. Run under TSan (-DMTL5_SANITIZE=thread) for races.
+//
+// Sets MTL5_NUM_THREADS before the pool's first use (the only in-process way to
+// exercise the threading -- CI otherwise runs serial).
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <random>
+#include <vector>
+
+#include <mtl/sparse/util/csc.hpp>
+#include <mtl/sparse/factorization/triangular_solve.hpp>
+#include <mtl/sparse/factorization/level_schedule.hpp>
+#include <mtl/detail/thread_pool.hpp>
+
+using namespace mtl::sparse;
+using mtl::sparse::util::csc_matrix;
+
+namespace {
+
+const int g_set_threads = [] {
+#if defined(_WIN32)
+    _putenv_s("MTL5_NUM_THREADS", "4");
+#else
+    setenv("MTL5_NUM_THREADS", "4", /*overwrite=*/1);
+#endif
+    return 0;
+}();
+
+// Block-diagonal lower triangular: B dense m x m lower-triangular blocks.
+// Row (b*m + r) depends on rows b*m .. b*m+r-1, so it sits at level r; each level
+// r holds B mutually independent rows -> genuinely parallel levels.
+csc_matrix<double> make_block_diag_lower(std::size_t B, std::size_t m, std::uint64_t seed) {
+    csc_matrix<double> L;
+    const std::size_t n = B * m;
+    L.nrows = n; L.ncols = n;
+    L.col_ptr.assign(n + 1, 0);
+    std::mt19937_64 rng(seed);
+    std::uniform_real_distribution<double> d(-0.5, 0.5);
+    for (std::size_t b = 0; b < B; ++b)
+        for (std::size_t cc = 0; cc < m; ++cc) {
+            const std::size_t j = b * m + cc;
+            L.col_ptr[j + 1] = L.col_ptr[j] + (m - cc);   // diagonal + entries below in block
+        }
+    L.row_ind.resize(L.col_ptr[n]);
+    L.values.resize(L.col_ptr[n]);
+    for (std::size_t b = 0; b < B; ++b)
+        for (std::size_t cc = 0; cc < m; ++cc) {
+            const std::size_t j = b * m + cc;
+            std::size_t p = L.col_ptr[j];
+            L.row_ind[p] = j; L.values[p] = double(m) + 1.0; ++p;   // diagonal first
+            for (std::size_t r = cc + 1; r < m; ++r) { L.row_ind[p] = b * m + r; L.values[p] = d(rng); ++p; }
+        }
+    return L;
+}
+
+// Arrow lower triangular: dense first column (rows 0..n-1), rest diagonal.
+// Rows 1..n-1 all depend only on row 0 -> one wide level of n-1 independent
+// rows, which splits across the pool.
+csc_matrix<double> make_arrow_lower(std::size_t n, std::uint64_t seed) {
+    csc_matrix<double> L;
+    L.nrows = n; L.ncols = n;
+    L.col_ptr.assign(n + 1, 0);
+    L.col_ptr[1] = n;                       // column 0 is dense
+    for (std::size_t j = 1; j < n; ++j) L.col_ptr[j + 1] = L.col_ptr[j] + 1;   // diagonal only
+    L.row_ind.resize(L.col_ptr[n]);
+    L.values.resize(L.col_ptr[n]);
+    std::mt19937_64 rng(seed);
+    std::uniform_real_distribution<double> d(-0.5, 0.5);
+    std::size_t p = 0;
+    L.row_ind[p] = 0; L.values[p] = double(n); ++p;                 // diagonal of col 0
+    for (std::size_t i = 1; i < n; ++i) { L.row_ind[p] = i; L.values[p] = d(rng); ++p; }
+    for (std::size_t j = 1; j < n; ++j) { L.row_ind[p] = j; L.values[p] = double(n); ++p; }
+    return L;
+}
+
+std::vector<double> random_rhs(std::size_t n, std::uint64_t seed) {
+    std::vector<double> b(n);
+    std::mt19937_64 rng(seed);
+    std::uniform_real_distribution<double> d(-1.0, 1.0);
+    for (auto& v : b) v = d(rng);
+    return b;
+}
+
+// Assert level_scheduled_lower_solve == dense_lower_solve, bit-for-bit.
+void require_bit_identical(const csc_matrix<double>& L, std::uint64_t rhs_seed) {
+    const std::size_t n = L.ncols;
+    auto ref = random_rhs(n, rhs_seed);
+    auto got = ref;
+    factorization::dense_lower_solve(L, ref);                        // serial reference
+    auto sched = factorization::build_lower_solve_schedule(L);
+    factorization::level_scheduled_lower_solve(sched, got);          // level-scheduled
+    for (std::size_t i = 0; i < n; ++i) REQUIRE(got[i] == ref[i]);
+}
+
+} // namespace
+
+TEST_CASE("level_scheduled_lower_solve == dense_lower_solve (block-diagonal)",
+          "[sparse][trisolve][threading][mt]") {
+    require_bit_identical(make_block_diag_lower(64, 8, 11), 101);    // narrow levels
+    require_bit_identical(make_block_diag_lower(1, 200, 22), 202);   // one dense block: fully sequential
+}
+
+TEST_CASE("level_scheduled_lower_solve == dense_lower_solve (wide level splits)",
+          "[sparse][trisolve][threading][mt]") {
+    if (mtl::detail::thread_pool::instance().size() < 2) WARN("single-core runner: threading not exercised");
+    // n large enough that the single wide level exceeds the parallel_for grain
+    // and is partitioned across the pool.
+    require_bit_identical(make_arrow_lower(80000, 33), 303);
+}
+
+TEST_CASE("level_scheduled_lower_solve boundary cases",
+          "[sparse][trisolve][threading][mt][edge]") {
+    // 1x1
+    {
+        csc_matrix<double> L; L.nrows = 1; L.ncols = 1;
+        L.col_ptr = {0, 1}; L.row_ind = {0}; L.values = {3.0};
+        require_bit_identical(L, 1);
+    }
+    // Purely diagonal: every row is level 0 (maximally parallel).
+    {
+        const std::size_t n = 50000;
+        csc_matrix<double> L; L.nrows = n; L.ncols = n;
+        L.col_ptr.resize(n + 1);
+        for (std::size_t j = 0; j <= n; ++j) L.col_ptr[j] = j;
+        L.row_ind.resize(n); L.values.resize(n);
+        for (std::size_t j = 0; j < n; ++j) { L.row_ind[j] = j; L.values[j] = 2.0 + double(j % 7); }
+        require_bit_identical(L, 7);
+    }
+}

--- a/tests/unit/sparse/test_trisolve_level_schedule_mt.cpp
+++ b/tests/unit/sparse/test_trisolve_level_schedule_mt.cpp
@@ -97,7 +97,7 @@ void require_bit_identical(const csc_matrix<double>& L, std::uint64_t rhs_seed) 
     auto got = ref;
     factorization::dense_lower_solve(L, ref);                        // serial reference
     auto sched = factorization::build_lower_solve_schedule(L);
-    factorization::level_scheduled_lower_solve(sched, got);          // level-scheduled
+    factorization::level_scheduled_lower_solve(L, sched, got);       // level-scheduled
     for (std::size_t i = 0; i < n; ++i) REQUIRE(got[i] == ref[i]);
 }
 
@@ -119,6 +119,15 @@ TEST_CASE("level_scheduled_lower_solve == dense_lower_solve (wide level splits)"
 
 TEST_CASE("level_scheduled_lower_solve boundary cases",
           "[sparse][trisolve][threading][mt][edge]") {
+    // Empty 0x0: build (zero levels) and solve must be no-ops.
+    {
+        csc_matrix<double> L; L.nrows = 0; L.ncols = 0; L.col_ptr = {0};
+        auto sched = factorization::build_lower_solve_schedule(L);
+        REQUIRE(sched.n == 0);
+        std::vector<double> x;   // empty
+        factorization::level_scheduled_lower_solve(L, sched, x);   // no-op
+        REQUIRE(x.empty());
+    }
     // 1x1
     {
         csc_matrix<double> L; L.nrows = 1; L.ncols = 1;


### PR DESCRIPTION
## Summary
Batch 3 of the on-node threading rollout (#297): parallelize the sparse triangular solve — on the hot path of every sparse direct solve, previously fully serial. **Pilot scoped to `sparse_cholesky`'s forward solve** (per maintainer decision), to validate the approach in review before rolling out to the other solvers.

## Why it needs a new form
The existing `dense_lower_solve` is a **CSC column-scatter** (`x[i] -= L(i,j)·x[j]`): two independent columns write the same `x[i]` and their subtraction order isn't fixed, so it can't be parallelized deterministically. This adds a **row-oriented gather** that is both parallel and **bit-identical to serial**:

- **`build_lower_solve_schedule(L)`** — transpose `L`'s strictly-lower part to CSR so each row lists `(k, L(i,k))`, `k<i`, in **increasing k order** (the same order the CSC scatter accumulates them), and partition rows into dependency levels (`level[i] = 1 + max level of its deps`). O(nnz), **built once and reused** across solves (factor-once / solve-many).
- **`level_scheduled_lower_solve(schedule, x)`** — for each level, solve its rows in parallel. Rows in a level are mutually independent — each writes its **own** `x[i]`, reading only earlier levels → **race-free**, and the identical accumulation order makes it **bit-identical to `dense_lower_solve`**. No-op team (serial, byte-identical) at `MTL5_NUM_THREADS=1`.

## Changes
- `include/mtl/sparse/factorization/level_schedule.hpp` — new: schedule + parallel solve
- `include/mtl/sparse/factorization/sparse_cholesky.hpp` — forward solve uses the level-scheduled path; schedule cached lazily in `cholesky_numeric`. Backward transpose solve stays serial (follow-up).
- `tests/unit/sparse/test_trisolve_level_schedule_mt.cpp` — new MT test

## Test Results
| Target | gcc | clang |
|--------|-----|-------|
| sparse_test_trisolve_level_schedule_mt (130,713 assertions) | PASS | PASS |
| sparse_test_sparse_cholesky | PASS | PASS |
| full sparse suite (30 tests) | PASS | — |

Bit-identity (`==`) to `dense_lower_solve` is asserted across the level spectrum — block-diagonal, a fully sequential dense block, a **wide arrow level that splits across the pool at n=80000**, diagonal, and 1×1. **Race-free under ThreadSanitizer** (`-DMTL5_SANITIZE=thread`, clang).

## Scope / rollout
Pilot. Follow-ups after review: the backward transpose solve (`dense_lower_transpose_solve` — schedulable directly on the CSC via column levels), and wiring into `sparse_lu` / `sparse_ldlt` / `supernodal_lu` / `supernodal_ldlt`.

## Test plan
- [ ] Fast CI passes (gcc + clang)
- [ ] Promote to ready: `gh pr ready`

Relates to #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deterministic level-scheduled sparse forward substitution for lower-triangular solves, enabling safe parallelism within dependency levels.
* **Performance**
  * Sparse Cholesky now precomputes and reuses a forward-solve plan for faster repeated `solve()` calls.
  * Forward-solve results remain bit-for-bit consistent with the existing dense reference.
* **Tests**
  * Added unit tests for threaded level-scheduled solves (including empty, 1×1, block-diagonal, arrow-shaped, and diagonal cases) with exact equality checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->