### PR TITLE
perf(sparse): level-schedule the transpose triangular solve (#297 batch 4)

### DIFF
--- a/include/mtl/sparse/factorization/level_schedule.hpp
+++ b/include/mtl/sparse/factorization/level_schedule.hpp
@@ -163,4 +163,107 @@ void level_scheduled_lower_solve(const util::csc_matrix<Value, SizeType>& L,
     }
 }
 
+// ---------------------------------------------------------------------------
+// Backward (transpose) solve: L^T x = b, L lower-triangular in CSC.
+//
+// dense_lower_transpose_solve processes columns in DECREASING order: for each
+// col it gathers x[col] -= L(i,col)*x[i] over the below-diagonal entries i>col
+// of column col (already stored in increasing-row order), then divides by the
+// diagonal. Those below-diagonal entries of column col are exactly row col of
+// L^T, so the transpose solve is a row-gather that reads L's CSC columns
+// directly -- no transpose of L is needed, unlike the forward solve.
+//
+// Dependencies run backward: x[col] depends on x[i] for i>col with L(i,col)!=0.
+// level[col] = 1 + max level of those i (computed by scanning columns in
+// decreasing order). Columns in a level are independent -- each writes its own
+// x[col] reading only later columns (earlier levels) -- so a level is solved in
+// parallel, and iterating each column's entries in the stored (increasing-row)
+// order reproduces the serial gather exactly: bit-identical to
+// dense_lower_transpose_solve.
+
+/// Reusable schedule for a level-scheduled lower-triangular TRANSPOSE solve.
+/// Value-agnostic: only the column-level partition is stored; L's values (and
+/// its column structure) are read at solve time.
+struct lower_transpose_solve_schedule {
+    std::size_t n = 0;
+    std::size_t built_nnz = 0;          // L.nnz() when built (staleness guard)
+    std::vector<std::size_t> level_ptr; // length nlevels+1
+    std::vector<std::size_t> order;     // length n: columns grouped by level
+    std::size_t grain = 1;
+};
+
+/// Build the transpose-solve schedule from a lower-triangular L (CSC).
+template <typename Value, typename SizeType>
+lower_transpose_solve_schedule build_lower_transpose_solve_schedule(
+    const util::csc_matrix<Value, SizeType>& L)
+{
+    const std::size_t n = static_cast<std::size_t>(L.ncols);
+    lower_transpose_solve_schedule s;
+    s.n = n;
+    s.built_nnz = static_cast<std::size_t>(L.nnz());
+
+    // level[col] = 1 + max level of its dependencies (rows i>col in column col).
+    // Scan columns in decreasing order so every dependency i>col is done first.
+    std::vector<std::size_t> level(n, 0);
+    std::size_t nlevels = 0, nnz_off = 0;
+    for (std::size_t col = n; col-- > 0; ) {
+        const SizeType diag = L.col_ptr[col];
+        std::size_t lv = 0;
+        for (SizeType p = diag + 1; p < L.col_ptr[col + 1]; ++p) {
+            const std::size_t i = static_cast<std::size_t>(L.row_ind[p]);   // i > col
+            if (level[i] + 1 > lv) lv = level[i] + 1;
+            ++nnz_off;
+        }
+        level[col] = lv;
+        if (lv + 1 > nlevels) nlevels = lv + 1;
+    }
+
+    // Counting-sort the columns into level order (increasing col within a level).
+    s.level_ptr.assign(nlevels + 1, std::size_t{0});
+    for (std::size_t c = 0; c < n; ++c) ++s.level_ptr[level[c] + 1];
+    for (std::size_t l = 0; l < nlevels; ++l) s.level_ptr[l + 1] += s.level_ptr[l];
+    s.order.resize(n);
+    std::vector<std::size_t> cursor(s.level_ptr.begin(), s.level_ptr.end() - 1);
+    for (std::size_t c = 0; c < n; ++c) s.order[cursor[level[c]]++] = c;
+
+    const std::size_t avg = n ? std::max<std::size_t>(1, nnz_off / n) : 1;
+    s.grain = std::max<std::size_t>(std::size_t{1}, std::size_t{32768} / avg);
+    return s;
+}
+
+/// Level-scheduled transpose solve: solve L^T x = b with x holding b on entry and
+/// the solution on exit. Reads L's values at solve time. Bit-identical to
+/// dense_lower_transpose_solve; each level's columns are solved in parallel
+/// (serial when MTL5_NUM_THREADS=1).
+template <typename Value, typename SizeType>
+void level_scheduled_lower_transpose_solve(const util::csc_matrix<Value, SizeType>& L,
+                                           const lower_transpose_solve_schedule& s,
+                                           std::vector<Value>& x)
+{
+    assert(s.n == static_cast<std::size_t>(L.ncols) &&
+           s.built_nnz == static_cast<std::size_t>(L.nnz()) &&
+           "schedule does not match L (rebuild after a pattern change)");
+    assert(x.size() >= s.n && "solution vector shorter than the system");
+    const std::size_t nlevels = s.level_ptr.empty() ? 0 : s.level_ptr.size() - 1;
+    for (std::size_t l = 0; l < nlevels; ++l) {
+        const std::size_t lb = s.level_ptr[l];
+        const std::size_t le = s.level_ptr[l + 1];
+        const std::size_t count = le - lb;
+        if (count == 0) continue;
+        detail::thread_pool::instance().parallel_for(
+            count, s.grain,
+            [&](std::size_t cb, std::size_t ce) {
+                for (std::size_t t = cb; t < ce; ++t) {
+                    const std::size_t col = s.order[lb + t];
+                    const SizeType diag = L.col_ptr[col];
+                    if (diag >= L.col_ptr[col + 1]) continue;   // empty column: skip (as serial)
+                    Value acc = x[col];
+                    for (SizeType p = diag + 1; p < L.col_ptr[col + 1]; ++p)
+                        acc -= L.values[p] * x[static_cast<std::size_t>(L.row_ind[p])];
+                    x[col] = acc / L.values[diag];
+                }
+            });
+    }
+}
+
 } // namespace mtl::sparse::factorization

--- a/include/mtl/sparse/factorization/sparse_cholesky.hpp
+++ b/include/mtl/sparse/factorization/sparse_cholesky.hpp
@@ -69,22 +69,24 @@ struct cholesky_numeric {
     /// Read-only access to the lower Cholesky factor L (CSC).
     const util::csc_matrix<Value>& factor() const { return L_; }
 
-    /// Install the numeric factor and (re)build the coupled forward-solve
-    /// schedule from it. L and its schedule are always set together here, which
-    /// enforces the invariant the level solve relies on -- the schedule's cached
-    /// entry positions always match L's pattern. The factor must be square and
-    /// match the symbolic dimension (set symbolic first). Strongly exception
-    /// safe: the schedule is built before either member is replaced, so a throw
-    /// leaves the object unchanged.
+    /// Install the numeric factor and (re)build the coupled forward and
+    /// transpose solve schedules from it. L and its schedules are always set
+    /// together here, which enforces the invariant the level solves rely on --
+    /// the schedules' cached structure always matches L's pattern. The factor
+    /// must be square and match the symbolic dimension (set symbolic first).
+    /// Strongly exception safe: both schedules are built into locals before any
+    /// member is replaced, so a throw leaves the object unchanged.
     void set_factor(util::csc_matrix<Value> L) {
         if (static_cast<std::size_t>(L.ncols) != symbolic.n ||
             static_cast<std::size_t>(L.nrows) != symbolic.n)
             throw std::invalid_argument(
                 "cholesky_numeric::set_factor: factor dimension does not match "
                 "the symbolic analysis");
-        lower_solve_schedule sched = build_lower_solve_schedule(L);   // may throw
-        L_ = std::move(L);                                            // noexcept
-        fwd_sched_ = std::move(sched);                               // noexcept
+        lower_solve_schedule           fsched = build_lower_solve_schedule(L);            // may throw
+        lower_transpose_solve_schedule bsched = build_lower_transpose_solve_schedule(L);  // may throw
+        L_ = std::move(L);                                                                // noexcept
+        fwd_sched_ = std::move(fsched);                                                   // noexcept
+        bwd_sched_ = std::move(bsched);                                                   // noexcept
     }
 
     /// Solve A*x = b using the Cholesky factorization.
@@ -112,9 +114,11 @@ struct cholesky_numeric {
         // Serial and byte-identical at MTL5_NUM_THREADS=1.
         level_scheduled_lower_solve(L_, fwd_sched_, w);
 
-        // Step 3: Back solve: L^T * z = y (serial; level scheduling of the
-        // transpose solve is a follow-up in the #297 rollout).
-        dense_lower_transpose_solve(L_, w);
+        // Step 3: Back solve: L^T * z = y.
+        // Level-scheduled (parallel, bit-identical to dense_lower_transpose_solve);
+        // the schedule is bound to L_ and reads its values at solve time. Serial
+        // and byte-identical at MTL5_NUM_THREADS=1.
+        level_scheduled_lower_transpose_solve(L_, bwd_sched_, w);
 
         // Step 4: Apply inverse permutation: x = P^T * z
         for (std::size_t i = 0; i < n; ++i)
@@ -122,8 +126,9 @@ struct cholesky_numeric {
     }
 
 private:
-    util::csc_matrix<Value> L_;           // lower triangular Cholesky factor (CSC)
-    lower_solve_schedule    fwd_sched_;   // forward-solve level schedule, bound to L_
+    util::csc_matrix<Value>        L_;          // lower triangular Cholesky factor (CSC)
+    lower_solve_schedule           fwd_sched_;  // forward-solve (L y = w) schedule, bound to L_
+    lower_transpose_solve_schedule bwd_sched_;  // transpose-solve (L^T z = y) schedule, bound to L_
 };
 
 /// Perform symbolic Cholesky analysis on a symmetric sparse matrix.

--- a/tests/unit/sparse/test_trisolve_level_schedule_mt.cpp
+++ b/tests/unit/sparse/test_trisolve_level_schedule_mt.cpp
@@ -145,3 +145,84 @@ TEST_CASE("level_scheduled_lower_solve boundary cases",
         require_bit_identical(L, 7);
     }
 }
+
+// -- transpose solve (#297 batch 4) --------------------------------------
+
+namespace {
+
+// Lower triangular whose last row is dense: column col (col < n-1) has its
+// diagonal plus one entry in row n-1. In the TRANSPOSE solve every such column
+// gathers from x[n-1], so columns 0..n-2 form one wide level that splits across
+// the pool (the arrow's transpose would instead collapse to a single column).
+csc_matrix<double> make_last_row_dense_lower(std::size_t n, std::uint64_t seed) {
+    csc_matrix<double> L;
+    L.nrows = n; L.ncols = n;
+    L.col_ptr.assign(n + 1, 0);
+    for (std::size_t col = 0; col + 1 < n; ++col) L.col_ptr[col + 1] = L.col_ptr[col] + 2;  // diag + row n-1
+    if (n) L.col_ptr[n] = L.col_ptr[n - 1] + 1;                                              // last col: diag only
+    L.row_ind.resize(L.col_ptr[n]);
+    L.values.resize(L.col_ptr[n]);
+    std::mt19937_64 rng(seed);
+    std::uniform_real_distribution<double> d(-0.5, 0.5);
+    std::size_t p = 0;
+    for (std::size_t col = 0; col + 1 < n; ++col) {
+        L.row_ind[p] = col;   L.values[p] = double(n); ++p;      // diagonal
+        L.row_ind[p] = n - 1; L.values[p] = d(rng);   ++p;       // entry in the dense last row
+    }
+    if (n) { L.row_ind[p] = n - 1; L.values[p] = double(n); }     // last diagonal
+    return L;
+}
+
+// Assert level_scheduled_lower_transpose_solve == dense_lower_transpose_solve.
+void require_transpose_bit_identical(const csc_matrix<double>& L, std::uint64_t rhs_seed) {
+    const std::size_t n = L.ncols;
+    auto ref = random_rhs(n, rhs_seed);
+    auto got = ref;
+    factorization::dense_lower_transpose_solve(L, ref);                    // serial reference
+    auto sched = factorization::build_lower_transpose_solve_schedule(L);
+    factorization::level_scheduled_lower_transpose_solve(L, sched, got);   // level-scheduled
+    for (std::size_t i = 0; i < n; ++i) REQUIRE(got[i] == ref[i]);
+}
+
+} // namespace
+
+TEST_CASE("level_scheduled_lower_transpose_solve == dense_lower_transpose_solve (block-diagonal)",
+          "[sparse][trisolve][transpose][threading][mt]") {
+    require_transpose_bit_identical(make_block_diag_lower(64, 8, 11), 401);
+    require_transpose_bit_identical(make_block_diag_lower(1, 200, 22), 402);   // one dense block: sequential
+}
+
+TEST_CASE("level_scheduled_lower_transpose_solve == dense_lower_transpose_solve (wide level splits)",
+          "[sparse][trisolve][transpose][threading][mt]") {
+    if (mtl::detail::thread_pool::instance().size() < 2) WARN("single-core runner: threading not exercised");
+    require_transpose_bit_identical(make_last_row_dense_lower(80000, 33), 403);   // level 1 splits across the pool
+}
+
+TEST_CASE("level_scheduled_lower_transpose_solve boundary cases",
+          "[sparse][trisolve][transpose][threading][mt][edge]") {
+    // Empty 0x0
+    {
+        csc_matrix<double> L; L.nrows = 0; L.ncols = 0; L.col_ptr = {0};
+        auto sched = factorization::build_lower_transpose_solve_schedule(L);
+        REQUIRE(sched.n == 0);
+        std::vector<double> x;
+        factorization::level_scheduled_lower_transpose_solve(L, sched, x);   // no-op
+        REQUIRE(x.empty());
+    }
+    // 1x1
+    {
+        csc_matrix<double> L; L.nrows = 1; L.ncols = 1;
+        L.col_ptr = {0, 1}; L.row_ind = {0}; L.values = {3.0};
+        require_transpose_bit_identical(L, 1);
+    }
+    // Diagonal: every column is level 0 (maximally parallel).
+    {
+        const std::size_t n = 50000;
+        csc_matrix<double> L; L.nrows = n; L.ncols = n;
+        L.col_ptr.resize(n + 1);
+        for (std::size_t j = 0; j <= n; ++j) L.col_ptr[j] = j;
+        L.row_ind.resize(n); L.values.resize(n);
+        for (std::size_t j = 0; j < n; ++j) { L.row_ind[j] = j; L.values[j] = 2.0 + double(j % 7); }
+        require_transpose_bit_identical(L, 7);
+    }
+}


### PR DESCRIPTION
## Summary
Batch 4 of the on-node threading rollout (#297): level-schedule the **backward transpose solve** (`L^T z = y`), completing the parallelization of the sparse Cholesky solve started in #301. `cholesky_numeric::solve` is now **fully parallel** (both the forward and transpose triangular solves).

## Design
The transpose solve is simpler than the forward: it gathers within each **CSC column directly** — column `col`'s below-diagonal entries are exactly row `col` of `L^T`, already in increasing-row order — so **no transpose of `L` is needed** (the forward solve needed a CSR transpose). Dependencies run backward (`x[col]` depends on `x[i]`, `i>col`), so levels are assigned by scanning columns in **decreasing** order; columns within a level are independent → solved in parallel. Iterating each column's entries in stored order reproduces the serial gather exactly → **bit-identical** to `dense_lower_transpose_solve`.

Both schedules are held as private, coupled state in `cholesky_numeric`, built together in the validating, exception-safe `set_factor` (per the pattern established in #301). No-op (serial) at `MTL5_NUM_THREADS=1`.

## Changes
- `include/mtl/sparse/factorization/level_schedule.hpp` — `lower_transpose_solve_schedule`, `build_lower_transpose_solve_schedule`, `level_scheduled_lower_transpose_solve`
- `include/mtl/sparse/factorization/sparse_cholesky.hpp` — build + use the transpose schedule; `set_factor` builds both (strong exception guarantee)
- `tests/unit/sparse/test_trisolve_level_schedule_mt.cpp` — transpose bit-identity tests

## Test Results
| Target | gcc | clang |
|--------|-----|-------|
| sparse_test_trisolve_level_schedule_mt (261,430 assertions) | PASS | PASS |
| sparse_test_sparse_cholesky (fully-parallel solve) | PASS | PASS |
| full sparse suite (30 tests) | PASS | — |

Transpose solve asserted **bit-identical (`==`)** to `dense_lower_transpose_solve` across block-diagonal, a sequential dense block, a wide "dense last row" level that **splits across the pool** (n=80000), diagonal, 1×1, and empty. **Race-free under ThreadSanitizer.**

## Scope
Follows `docs/design/parallelization-patterns-and-pitfalls.md`. Remaining #297 rollout: wire the schedules into `sparse_lu` / `sparse_ldlt` / `supernodal_lu` / `supernodal_ldlt`.

## Test plan
- [ ] Fast CI passes (gcc + clang)
- [ ] Promote to ready: `gh pr ready`

Relates to #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added parallel level-scheduled solving for transposed sparse triangular systems.
  * Sparse Cholesky solves now use the optimized parallel transpose-solving path.

* **Bug Fixes**
  * Improved consistency between factor data and cached solve scheduling after factor updates.
  * Preserved correct behavior for empty, diagonal, block-structured, and wide sparse matrices.

* **Tests**
  * Added coverage validating transpose solves against trusted reference results, including multi-threaded and boundary cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->