### PR TITLE
perf(sparse): level-schedule the sparse LU solve (#297 batch 5)

### DIFF
--- a/include/mtl/sparse/factorization/level_schedule.hpp
+++ b/include/mtl/sparse/factorization/level_schedule.hpp
@@ -266,4 +266,137 @@ void level_scheduled_lower_transpose_solve(const util::csc_matrix<Value, SizeTyp
     }
 }
 
+// ---------------------------------------------------------------------------
+// Upper triangular forward-of-the-backsolve: U x = b, U upper in CSC with the
+// diagonal stored LAST in each column (the layout dense_upper_solve expects).
+//
+// dense_upper_solve is a CSC column-scatter in DECREASING column order: for each
+// col it divides x[col] by the diagonal, then scatters x[i] -= U(i,col)*x[col]
+// over the above-diagonal entries i<col. As with the lower solve this scatter
+// does not parallelize deterministically, so we build the equivalent row-gather:
+//
+//   x[i] = (b[i] - sum_{k>i} U(i,k)*x[k]) / U(i,i)
+//
+// iterating each row's entries k>i in DECREASING k order -- the same order the
+// scatter accumulates them -- so the gather is bit-identical to
+// dense_upper_solve. Dependencies run backward (x[i] depends on x[k], k>i), so
+// levels are assigned scanning rows in decreasing order; a level's rows are
+// independent and solved in parallel.
+
+/// Reusable schedule for a level-scheduled UPPER-triangular solve U x = b.
+struct upper_solve_schedule {
+    std::size_t n = 0;
+    std::size_t built_nnz = 0;
+    // CSR of the strictly-upper entries (k > i), DECREASING k within each row.
+    std::vector<std::size_t> row_ptr;
+    std::vector<std::size_t> col_ind;   // the column k
+    std::vector<std::size_t> val_pos;   // index of U(i,k) in U.values
+    std::vector<std::size_t> diag_pos;  // index of U(i,i) in U.values (last in column i)
+    std::vector<std::size_t> level_ptr;
+    std::vector<std::size_t> order;
+    std::size_t grain = 1;
+};
+
+/// Build the upper-solve schedule from an upper-triangular U (CSC, diagonal last).
+template <typename Value, typename SizeType>
+upper_solve_schedule build_upper_solve_schedule(
+    const util::csc_matrix<Value, SizeType>& U)
+{
+    const std::size_t n = static_cast<std::size_t>(U.ncols);
+    upper_solve_schedule s;
+    s.n = n;
+    s.built_nnz = static_cast<std::size_t>(U.nnz());
+    s.diag_pos.assign(n, std::size_t{0});
+    s.row_ptr.assign(n + 1, std::size_t{0});
+
+    // Pass 1: diagonal position (last entry of each column) + count strictly-upper
+    // entries per row (rows i < col, i.e. all but the last entry of the column).
+    std::size_t nnz_off = 0;
+    for (std::size_t j = 0; j < n; ++j) {
+        if (U.col_ptr[j] < U.col_ptr[j + 1]) {
+            s.diag_pos[j] = static_cast<std::size_t>(U.col_ptr[j + 1] - 1);   // diagonal last
+            for (SizeType q = U.col_ptr[j]; q + 1 < U.col_ptr[j + 1]; ++q) {  // above-diagonal
+                ++s.row_ptr[static_cast<std::size_t>(U.row_ind[q]) + 1];
+                ++nnz_off;
+            }
+        }
+    }
+    for (std::size_t i = 0; i < n; ++i) s.row_ptr[i + 1] += s.row_ptr[i];
+    s.col_ind.resize(nnz_off);
+    s.val_pos.resize(nnz_off);
+
+    // Pass 2: scatter into CSR, iterating columns in DECREASING order so each
+    // row's entries land in decreasing-column order (matching the scatter).
+    std::vector<std::size_t> fill(s.row_ptr.begin(), s.row_ptr.end() - 1);
+    for (std::size_t j = n; j-- > 0; ) {
+        if (U.col_ptr[j] >= U.col_ptr[j + 1]) continue;
+        for (SizeType q = U.col_ptr[j]; q + 1 < U.col_ptr[j + 1]; ++q) {
+            const std::size_t i = static_cast<std::size_t>(U.row_ind[q]);   // i < j
+            const std::size_t dst = fill[i]++;
+            s.col_ind[dst] = j;
+            s.val_pos[dst] = static_cast<std::size_t>(q);
+        }
+    }
+
+    // Pass 3: levels. level[i] = 1 + max level of its dependencies (k>i in row i);
+    // scan rows i in decreasing order so every dependency k>i already has a level.
+    std::vector<std::size_t> level(n, 0);
+    std::size_t nlevels = 0;
+    for (std::size_t ii = 0; ii < n; ++ii) {
+        const std::size_t i = n - 1 - ii;
+        std::size_t lv = 0;
+        for (std::size_t p = s.row_ptr[i]; p < s.row_ptr[i + 1]; ++p) {
+            const std::size_t k = s.col_ind[p];
+            if (level[k] + 1 > lv) lv = level[k] + 1;
+        }
+        level[i] = lv;
+        if (lv + 1 > nlevels) nlevels = lv + 1;
+    }
+
+    s.level_ptr.assign(nlevels + 1, std::size_t{0});
+    for (std::size_t i = 0; i < n; ++i) ++s.level_ptr[level[i] + 1];
+    for (std::size_t l = 0; l < nlevels; ++l) s.level_ptr[l + 1] += s.level_ptr[l];
+    s.order.resize(n);
+    std::vector<std::size_t> cursor(s.level_ptr.begin(), s.level_ptr.end() - 1);
+    for (std::size_t i = 0; i < n; ++i) s.order[cursor[level[i]]++] = i;
+
+    const std::size_t avg = n ? std::max<std::size_t>(1, nnz_off / n) : 1;
+    s.grain = std::max<std::size_t>(std::size_t{1}, std::size_t{32768} / avg);
+    return s;
+}
+
+/// Level-scheduled upper-triangular solve: solve U x = b with x holding b on
+/// entry and the solution on exit. Reads U's values at solve time. Bit-identical
+/// to dense_upper_solve; each level's rows are solved in parallel (serial when
+/// MTL5_NUM_THREADS=1).
+template <typename Value, typename SizeType>
+void level_scheduled_upper_solve(const util::csc_matrix<Value, SizeType>& U,
+                                 const upper_solve_schedule& s,
+                                 std::vector<Value>& x)
+{
+    assert(s.n == static_cast<std::size_t>(U.ncols) &&
+           s.built_nnz == static_cast<std::size_t>(U.nnz()) &&
+           "schedule does not match U (rebuild after a pattern change)");
+    assert(x.size() >= s.n && "solution vector shorter than the system");
+    const std::size_t nlevels = s.level_ptr.empty() ? 0 : s.level_ptr.size() - 1;
+    for (std::size_t l = 0; l < nlevels; ++l) {
+        const std::size_t lb = s.level_ptr[l];
+        const std::size_t le = s.level_ptr[l + 1];
+        const std::size_t count = le - lb;
+        if (count == 0) continue;
+        detail::thread_pool::instance().parallel_for(
+            count, s.grain,
+            [&](std::size_t cb, std::size_t ce) {
+                for (std::size_t t = cb; t < ce; ++t) {
+                    const std::size_t i = s.order[lb + t];
+                    if (U.col_ptr[i] >= U.col_ptr[i + 1]) continue;   // empty column: skip (as serial)
+                    Value acc = x[i];
+                    for (std::size_t p = s.row_ptr[i]; p < s.row_ptr[i + 1]; ++p)
+                        acc -= U.values[s.val_pos[p]] * x[s.col_ind[p]];
+                    x[i] = acc / U.values[s.diag_pos[i]];
+                }
+            });
+    }
+}
+
 } // namespace mtl::sparse::factorization

--- a/include/mtl/sparse/factorization/sparse_lu.hpp
+++ b/include/mtl/sparse/factorization/sparse_lu.hpp
@@ -44,6 +44,7 @@
 #include <mtl/sparse/util/csc.hpp>
 #include <mtl/sparse/util/permutation.hpp>
 #include <mtl/sparse/factorization/triangular_solve.hpp>
+#include <mtl/sparse/factorization/level_schedule.hpp>
 
 namespace mtl::sparse::factorization {
 
@@ -62,8 +63,6 @@ struct lu_symbolic {
 /// plus the row and column permutations.
 template <typename Value>
 struct lu_numeric {
-    util::csc_matrix<Value> L;           // unit lower triangular factor (CSC)
-    util::csc_matrix<Value> U;           // upper triangular factor (CSC)
     std::vector<std::size_t> row_perm;   // row permutation from pivoting (p[new]=old)
     std::vector<std::size_t> row_pinv;   // inverse row permutation
     std::size_t num_perturbed = 0;       // pivots replaced by perturbation (0 = clean factor)
@@ -71,6 +70,30 @@ struct lu_numeric {
 
     std::size_t num_rows() const { return symbolic.n; }
     std::size_t num_cols() const { return symbolic.n; }
+
+    /// Read-only access to the factors (L unit lower, U upper; both CSC).
+    const util::csc_matrix<Value>& factorL() const { return L_; }
+    const util::csc_matrix<Value>& factorU() const { return U_; }
+
+    /// Install the factors and (re)build the coupled forward (L) and upper (U)
+    /// solve schedules from them. L, U and their schedules are always set
+    /// together here, so the schedules' cached structure always matches the
+    /// factors' patterns. Both must be square and match the symbolic dimension.
+    /// Strongly exception safe: both schedules are built into locals before any
+    /// member is replaced, so a throw leaves the object unchanged.
+    void set_factor(util::csc_matrix<Value> L, util::csc_matrix<Value> U) {
+        const std::size_t n = symbolic.n;
+        if (static_cast<std::size_t>(L.ncols) != n || static_cast<std::size_t>(L.nrows) != n ||
+            static_cast<std::size_t>(U.ncols) != n || static_cast<std::size_t>(U.nrows) != n)
+            throw std::invalid_argument(
+                "lu_numeric::set_factor: factor dimensions do not match the symbolic analysis");
+        lower_solve_schedule fsched = build_lower_solve_schedule(L);   // may throw
+        upper_solve_schedule usched = build_upper_solve_schedule(U);   // may throw
+        L_ = std::move(L);            // noexcept
+        U_ = std::move(U);            // noexcept
+        fwd_sched_ = std::move(fsched);  // noexcept
+        up_sched_  = std::move(usched);  // noexcept
+    }
 
     /// Solve A*x = b using the LU factorization.
     /// P*A*Q = L*U, so A = P^T * L * U * Q^T
@@ -96,17 +119,25 @@ struct lu_numeric {
         for (std::size_t i = 0; i < n; ++i)
             w[i] = static_cast<Value>(b(row_perm[i]));
 
-        // Step 2: Forward solve: L * z = w (L is unit lower triangular)
-        dense_lower_solve(L, w);
+        // Step 2: Forward solve: L * z = w. Level-scheduled (parallel,
+        // bit-identical to dense_lower_solve); serial at MTL5_NUM_THREADS=1.
+        level_scheduled_lower_solve(L_, fwd_sched_, w);
 
-        // Step 3: Back solve: U * y = z
-        dense_upper_solve(U, w);
+        // Step 3: Back solve: U * y = z. Level-scheduled (parallel, bit-identical
+        // to dense_upper_solve); serial at MTL5_NUM_THREADS=1.
+        level_scheduled_upper_solve(U_, up_sched_, w);
 
         // Step 4: Apply column permutation: x = Q * y
         // Q maps new col -> old col, so x[q[i]] = y[i]
         for (std::size_t i = 0; i < n; ++i)
             x(symbolic.col_perm[i]) = static_cast<typename VecX::value_type>(w[i]);
     }
+
+private:
+    util::csc_matrix<Value> L_;          // unit lower triangular factor (CSC), diagonal first
+    util::csc_matrix<Value> U_;          // upper triangular factor (CSC), diagonal last
+    lower_solve_schedule    fwd_sched_;  // forward (L z = w) schedule, bound to L_
+    upper_solve_schedule    up_sched_;   // upper  (U y = z) schedule, bound to U_
 };
 
 /// Perform symbolic LU analysis on a square sparse matrix.
@@ -458,8 +489,8 @@ lu_numeric<Value> sparse_lu_numeric(
         }
         return M;
     };
-    result.L = to_csc(Lp, Li, Lx);
-    result.U = to_csc(Up, Ui, Ux);
+    // Install the factors and build their coupled solve schedules atomically.
+    result.set_factor(to_csc(Lp, Li, Lx), to_csc(Up, Ui, Ux));
     return result;
 }
 
@@ -492,10 +523,11 @@ lu_numeric<Value> sparse_lu_refactor(
     auto C  = util::crs_to_csc(AQ);
 
     const auto& pinv = prev.row_pinv;    // original row -> pivot position (fixed)
-    lu_numeric<Value> result = prev;     // reuse pattern + perms + symbolic
-    result.num_perturbed = 0;            // refactor recomputes values without perturbing (throws on zero pivot)
-    auto& L = result.L;                  // overwrite values in place
-    auto& U = result.U;
+    // Local mutable copies of the prior factors: same pattern, values recomputed
+    // in place below, then installed via set_factor (which rebuilds the coupled
+    // solve schedules). refactor throws on a zero pivot; no perturbation.
+    auto L = prev.factorL();
+    auto U = prev.factorU();
 
     std::vector<Value> x(n, Value{0});
 
@@ -545,6 +577,14 @@ lu_numeric<Value> sparse_lu_refactor(
         for (size_type p = C.col_ptr[k]; p < C.col_ptr[k + 1]; ++p) x[pinv[C.row_ind[p]]] = Value{0};
     }
 
+    // Reuse the prior symbolic analysis and permutations; install the recomputed
+    // factors, which rebuilds the coupled solve schedules for the new values.
+    lu_numeric<Value> result;
+    result.symbolic = prev.symbolic;
+    result.row_perm = prev.row_perm;
+    result.row_pinv = prev.row_pinv;
+    result.num_perturbed = 0;   // refactor recomputes values without perturbing
+    result.set_factor(std::move(L), std::move(U));
     return result;
 }
 

--- a/tests/unit/sparse/test_column_etree.cpp
+++ b/tests/unit/sparse/test_column_etree.cpp
@@ -119,7 +119,7 @@ TEST_CASE("Predicted fill is a valid upper bound on actual LU fill",
         // Actual nnz(L)+nnz(U) from a real factorization (natural ordering).
         auto sym = factorization::sparse_lu_symbolic(A);
         auto num = factorization::sparse_lu_numeric(A, sym);
-        std::size_t actual = num.L.nnz() + num.U.nnz();
+        std::size_t actual = num.factorL().nnz() + num.factorU().nnz();
 
         REQUIRE(sa.fill_lu_bound >= actual);          // the static bound holds
         REQUIRE(sa.fill_chol_ata >= A.num_rows());    // at least the diagonal

--- a/tests/unit/sparse/test_native_klu.cpp
+++ b/tests/unit/sparse/test_native_klu.cpp
@@ -80,7 +80,7 @@ double relative_residual(const mat::compressed2D<double>& A,
 std::size_t factor_fill(const sparse::factorization::klu_numeric<double>& fac) {
     std::size_t fill = 0;
     for (const auto& blk : fac.block_numeric)
-        fill += blk.L.nnz() + blk.U.nnz();
+        fill += blk.factorL().nnz() + blk.factorU().nnz();
     return fill;
 }
 

--- a/tests/unit/sparse/test_sparse_lu_scaling.cpp
+++ b/tests/unit/sparse/test_sparse_lu_scaling.cpp
@@ -59,7 +59,7 @@ TEST_CASE("sparse LU fill stays linear on a banded matrix", "[sparse][lu][scalin
         auto A = make_unsym_tridiag(n);
         auto sym = sparse::factorization::sparse_lu_symbolic(A);   // natural
         auto num = sparse::factorization::sparse_lu_numeric(A, sym);
-        std::size_t fill = num.L.nnz() + num.U.nnz();
+        std::size_t fill = num.factorL().nnz() + num.factorU().nnz();
         REQUIRE(fill < 8 * n);   // ~4n expected; generous linear bound
     }
 }

--- a/tests/unit/sparse/test_trisolve_level_schedule_mt.cpp
+++ b/tests/unit/sparse/test_trisolve_level_schedule_mt.cpp
@@ -226,3 +226,106 @@ TEST_CASE("level_scheduled_lower_transpose_solve boundary cases",
         require_transpose_bit_identical(L, 7);
     }
 }
+
+// -- upper solve (#297 batch 5: sparse_lu rollout) -----------------------
+
+namespace {
+
+// Block-diagonal UPPER triangular: B dense m x m upper blocks, diagonal last in
+// each column. Narrow levels (width B), for correctness across the level range.
+csc_matrix<double> make_block_diag_upper(std::size_t B, std::size_t m, std::uint64_t seed) {
+    csc_matrix<double> U;
+    const std::size_t n = B * m;
+    U.nrows = n; U.ncols = n;
+    U.col_ptr.assign(n + 1, 0);
+    for (std::size_t b = 0; b < B; ++b)
+        for (std::size_t cc = 0; cc < m; ++cc)
+            U.col_ptr[b * m + cc + 1] = U.col_ptr[b * m + cc] + (cc + 1);  // rows b*m..b*m+cc
+    U.row_ind.resize(U.col_ptr[n]);
+    U.values.resize(U.col_ptr[n]);
+    std::mt19937_64 rng(seed);
+    std::uniform_real_distribution<double> d(-0.5, 0.5);
+    for (std::size_t b = 0; b < B; ++b)
+        for (std::size_t cc = 0; cc < m; ++cc) {
+            const std::size_t col = b * m + cc;
+            std::size_t p = U.col_ptr[col];
+            for (std::size_t r = 0; r < cc; ++r) { U.row_ind[p] = b * m + r; U.values[p] = d(rng); ++p; }
+            U.row_ind[p] = col; U.values[p] = double(m) + 1.0;   // diagonal LAST
+        }
+    return U;
+}
+
+// Upper triangular whose last COLUMN is dense: column n-1 has an entry in every
+// row 0..n-1. In the upper solve rows 0..n-2 all gather from x[n-1], forming one
+// wide level that splits across the pool.
+csc_matrix<double> make_last_col_dense_upper(std::size_t n, std::uint64_t seed) {
+    csc_matrix<double> U;
+    U.nrows = n; U.ncols = n;
+    U.col_ptr.assign(n + 1, 0);
+    for (std::size_t j = 0; j + 1 < n; ++j) U.col_ptr[j + 1] = U.col_ptr[j] + 1;   // diagonal only
+    if (n) U.col_ptr[n] = U.col_ptr[n - 1] + n;                                     // last col dense
+    U.row_ind.resize(U.col_ptr[n]);
+    U.values.resize(U.col_ptr[n]);
+    std::mt19937_64 rng(seed);
+    std::uniform_real_distribution<double> d(-0.5, 0.5);
+    std::size_t p = 0;
+    for (std::size_t j = 0; j + 1 < n; ++j) { U.row_ind[p] = j; U.values[p] = double(n); ++p; }  // diagonals
+    if (n) {
+        for (std::size_t i = 0; i + 1 < n; ++i) { U.row_ind[p] = i; U.values[p] = d(rng); ++p; }  // rows 0..n-2
+        U.row_ind[p] = n - 1; U.values[p] = double(n);                                            // diagonal LAST
+    }
+    return U;
+}
+
+void require_upper_bit_identical(const csc_matrix<double>& U, std::uint64_t rhs_seed) {
+    const std::size_t n = U.ncols;
+    auto ref = random_rhs(n, rhs_seed);
+    auto got = ref;
+    factorization::dense_upper_solve(U, ref);                     // serial reference
+    auto sched = factorization::build_upper_solve_schedule(U);
+    factorization::level_scheduled_upper_solve(U, sched, got);    // level-scheduled
+    for (std::size_t i = 0; i < n; ++i) REQUIRE(got[i] == ref[i]);
+}
+
+} // namespace
+
+TEST_CASE("level_scheduled_upper_solve == dense_upper_solve (block-diagonal)",
+          "[sparse][trisolve][upper][threading][mt]") {
+    require_upper_bit_identical(make_block_diag_upper(64, 8, 11), 501);
+    require_upper_bit_identical(make_block_diag_upper(1, 200, 22), 502);   // one dense block: sequential
+}
+
+TEST_CASE("level_scheduled_upper_solve == dense_upper_solve (wide level splits)",
+          "[sparse][trisolve][upper][threading][mt]") {
+    if (mtl::detail::thread_pool::instance().size() < 2) WARN("single-core runner: threading not exercised");
+    require_upper_bit_identical(make_last_col_dense_upper(80000, 33), 503);
+}
+
+TEST_CASE("level_scheduled_upper_solve boundary cases",
+          "[sparse][trisolve][upper][threading][mt][edge]") {
+    // Empty 0x0
+    {
+        csc_matrix<double> U; U.nrows = 0; U.ncols = 0; U.col_ptr = {0};
+        auto sched = factorization::build_upper_solve_schedule(U);
+        REQUIRE(sched.n == 0);
+        std::vector<double> x;
+        factorization::level_scheduled_upper_solve(U, sched, x);
+        REQUIRE(x.empty());
+    }
+    // 1x1
+    {
+        csc_matrix<double> U; U.nrows = 1; U.ncols = 1;
+        U.col_ptr = {0, 1}; U.row_ind = {0}; U.values = {3.0};
+        require_upper_bit_identical(U, 1);
+    }
+    // Diagonal: every row is level 0.
+    {
+        const std::size_t n = 50000;
+        csc_matrix<double> U; U.nrows = n; U.ncols = n;
+        U.col_ptr.resize(n + 1);
+        for (std::size_t j = 0; j <= n; ++j) U.col_ptr[j] = j;
+        U.row_ind.resize(n); U.values.resize(n);
+        for (std::size_t j = 0; j < n; ++j) { U.row_ind[j] = j; U.values[j] = 2.0 + double(j % 7); }
+        require_upper_bit_identical(U, 7);
+    }
+}


### PR DESCRIPTION
## Summary
Batch 5 of the on-node threading rollout (#297): parallelize `sparse_lu`'s solve. LU solves a forward `L z = w` then a backward `U y = z`, so `lu_numeric::solve` is now **fully parallel**.

- **Forward** `L z = w` — reuses the batch-3 `lower_solve_schedule` (L is stored with an explicit diagonal-first, like the Cholesky factor).
- **Upper** `U y = z` — **new** `upper_solve_schedule`. `dense_upper_solve` is a CSC column-scatter in *decreasing* order with the diagonal stored *last*, so the equivalent row-gather transposes U's strictly-upper part to CSR in **decreasing-column** order and assigns backward-dependency levels (scanning rows decreasing). Bit-identical to `dense_upper_solve`; value-agnostic.

`lu_numeric` now holds `L`, `U` and both schedules as **private, coupled** state, built together in a validating, exception-safe `set_factor(L, U)` (the pattern from #301), with `factorL()`/`factorU()` accessors. **`sparse_lu_refactor`** recomputes values on local copies of the prior factors and reinstalls via `set_factor` — same pattern, so the transient path keeps working. No-op (serial) at `MTL5_NUM_THREADS=1`.

## Changes
- `level_schedule.hpp` — `upper_solve_schedule` + build + solve
- `sparse_lu.hpp` — private coupled `L_`/`U_`/schedules, `set_factor`, `factorL()`/`factorU()`; level-scheduled solve; refactor restructured
- `test_trisolve_level_schedule_mt.cpp` — upper-solve bit-identity tests
- `test_column_etree.cpp`, `test_sparse_lu_scaling.cpp`, `test_native_klu.cpp` — updated the 3 readers of `lu_numeric.L`/`.U` (incl. KLU's per-block `lu_numeric`) to the accessors

## Test Results
| Target | gcc | clang |
|--------|-----|-------|
| sparse_test_trisolve_level_schedule_mt (392,145 assertions) | PASS | PASS |
| sparse_test_sparse_lu (parallel solve + refactor) | — | PASS |
| sparse_test_native_klu (per-block lu_numeric + refactor) | — | PASS |
| full sparse suite (30 tests) | PASS | — |

Upper solve **bit-identical (`==`)** to `dense_upper_solve` across block-diagonal, a sequential dense block, a wide "dense last column" level that **splits across the pool** (n=80000), diagonal, 1×1, empty. **Race-free under ThreadSanitizer.**

## Scope
Follows `docs/design/parallelization-patterns-and-pitfalls.md`. Rollout remaining: `sparse_ldlt` / `supernodal_lu` / `supernodal_ldlt`.

## Test plan
- [ ] Fast CI (incl. the new threaded + TSan lanes from #303) passes
- [ ] Promote to ready: `gh pr ready`

Relates to #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added parallel level-scheduled solving for sparse upper-triangular systems.
  * Sparse LU solves now use stored scheduling information to improve parallel execution.
  * Added read-only access to computed lower and upper factor matrices.

* **Bug Fixes**
  * Added validation to detect mismatched or outdated solve schedules.

* **Tests**
  * Added coverage for parallel, block-structured, wide-level, empty, single-element, and diagonal systems.
  * Verified results match existing dense solves exactly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->