### PR TITLE
perf(sparse): level-schedule the sparse LDL^T solve (#297 batch 6)

### DIFF
--- a/include/mtl/sparse/factorization/level_schedule.hpp
+++ b/include/mtl/sparse/factorization/level_schedule.hpp
@@ -399,4 +399,174 @@ void level_scheduled_upper_solve(const util::csc_matrix<Value, SizeType>& U,
     }
 }
 
+// ---------------------------------------------------------------------------
+// UNIT lower triangular solves (L D L^T factors): L is unit lower with an
+// IMPLICIT diagonal -- no diagonal entry is stored and the solves never divide.
+// dense_unit_lower_solve scatters x[i] -= L(i,j)*x[j] for i>j (columns
+// increasing); dense_unit_lower_transpose_solve gathers x[col] -= L(i,col)*x[i]
+// for i>col (columns decreasing). These mirror the non-unit lower / transpose
+// schedules but (a) identify the strictly-lower entries by row_ind > col rather
+// than by position (there is no stored diagonal to skip) and (b) omit the final
+// division. Bit-identical to the dense unit solves.
+
+/// Schedule for a level-scheduled UNIT lower forward solve L x = b.
+struct unit_lower_solve_schedule {
+    std::size_t n = 0;
+    std::size_t built_nnz = 0;
+    std::vector<std::size_t> row_ptr;   // CSR of strictly-lower entries, increasing k per row
+    std::vector<std::size_t> col_ind;
+    std::vector<std::size_t> val_pos;
+    std::vector<std::size_t> level_ptr;
+    std::vector<std::size_t> order;
+    std::size_t grain = 1;
+};
+
+template <typename Value, typename SizeType>
+unit_lower_solve_schedule build_unit_lower_solve_schedule(
+    const util::csc_matrix<Value, SizeType>& L)
+{
+    const std::size_t n = static_cast<std::size_t>(L.ncols);
+    unit_lower_solve_schedule s;
+    s.n = n;
+    s.built_nnz = static_cast<std::size_t>(L.nnz());
+    s.row_ptr.assign(n + 1, std::size_t{0});
+
+    std::size_t nnz_off = 0;
+    for (std::size_t j = 0; j < n; ++j)
+        for (SizeType q = L.col_ptr[j]; q < L.col_ptr[j + 1]; ++q)
+            if (static_cast<std::size_t>(L.row_ind[q]) > j) {   // strictly lower
+                ++s.row_ptr[static_cast<std::size_t>(L.row_ind[q]) + 1];
+                ++nnz_off;
+            }
+    for (std::size_t i = 0; i < n; ++i) s.row_ptr[i + 1] += s.row_ptr[i];
+    s.col_ind.resize(nnz_off);
+    s.val_pos.resize(nnz_off);
+
+    std::vector<std::size_t> fill(s.row_ptr.begin(), s.row_ptr.end() - 1);
+    for (std::size_t j = 0; j < n; ++j)   // columns increasing -> rows get increasing-k order
+        for (SizeType q = L.col_ptr[j]; q < L.col_ptr[j + 1]; ++q) {
+            const std::size_t i = static_cast<std::size_t>(L.row_ind[q]);
+            if (i > j) { const std::size_t dst = fill[i]++; s.col_ind[dst] = j; s.val_pos[dst] = static_cast<std::size_t>(q); }
+        }
+
+    std::vector<std::size_t> level(n, 0);
+    std::size_t nlevels = 0;
+    for (std::size_t i = 0; i < n; ++i) {
+        std::size_t lv = 0;
+        for (std::size_t p = s.row_ptr[i]; p < s.row_ptr[i + 1]; ++p)
+            if (level[s.col_ind[p]] + 1 > lv) lv = level[s.col_ind[p]] + 1;
+        level[i] = lv;
+        if (lv + 1 > nlevels) nlevels = lv + 1;
+    }
+    s.level_ptr.assign(nlevels + 1, std::size_t{0});
+    for (std::size_t i = 0; i < n; ++i) ++s.level_ptr[level[i] + 1];
+    for (std::size_t l = 0; l < nlevels; ++l) s.level_ptr[l + 1] += s.level_ptr[l];
+    s.order.resize(n);
+    std::vector<std::size_t> cursor(s.level_ptr.begin(), s.level_ptr.end() - 1);
+    for (std::size_t i = 0; i < n; ++i) s.order[cursor[level[i]]++] = i;
+
+    const std::size_t avg = n ? std::max<std::size_t>(1, nnz_off / n) : 1;
+    s.grain = std::max<std::size_t>(std::size_t{1}, std::size_t{32768} / avg);
+    return s;
+}
+
+/// Level-scheduled UNIT lower forward solve. Bit-identical to
+/// dense_unit_lower_solve (no diagonal division).
+template <typename Value, typename SizeType>
+void level_scheduled_unit_lower_solve(const util::csc_matrix<Value, SizeType>& L,
+                                      const unit_lower_solve_schedule& s,
+                                      std::vector<Value>& x)
+{
+    assert(s.n == static_cast<std::size_t>(L.ncols) &&
+           s.built_nnz == static_cast<std::size_t>(L.nnz()) && "schedule does not match L");
+    assert(x.size() >= s.n && "solution vector shorter than the system");
+    const std::size_t nlevels = s.level_ptr.empty() ? 0 : s.level_ptr.size() - 1;
+    for (std::size_t l = 0; l < nlevels; ++l) {
+        const std::size_t lb = s.level_ptr[l], le = s.level_ptr[l + 1];
+        if (le == lb) continue;
+        detail::thread_pool::instance().parallel_for(
+            le - lb, s.grain,
+            [&](std::size_t cb, std::size_t ce) {
+                for (std::size_t t = cb; t < ce; ++t) {
+                    const std::size_t i = s.order[lb + t];
+                    Value acc = x[i];
+                    for (std::size_t p = s.row_ptr[i]; p < s.row_ptr[i + 1]; ++p)
+                        acc -= L.values[s.val_pos[p]] * x[s.col_ind[p]];
+                    x[i] = acc;   // unit diagonal: no division
+                }
+            });
+    }
+}
+
+/// Schedule for a level-scheduled UNIT lower TRANSPOSE solve L^T x = b (gathers
+/// within CSC columns over the below-diagonal entries; no division).
+struct unit_lower_transpose_solve_schedule {
+    std::size_t n = 0;
+    std::size_t built_nnz = 0;
+    std::vector<std::size_t> level_ptr;
+    std::vector<std::size_t> order;
+    std::size_t grain = 1;
+};
+
+template <typename Value, typename SizeType>
+unit_lower_transpose_solve_schedule build_unit_lower_transpose_solve_schedule(
+    const util::csc_matrix<Value, SizeType>& L)
+{
+    const std::size_t n = static_cast<std::size_t>(L.ncols);
+    unit_lower_transpose_solve_schedule s;
+    s.n = n;
+    s.built_nnz = static_cast<std::size_t>(L.nnz());
+
+    std::vector<std::size_t> level(n, 0);
+    std::size_t nlevels = 0, nnz_off = 0;
+    for (std::size_t col = n; col-- > 0; ) {
+        std::size_t lv = 0;
+        for (SizeType p = L.col_ptr[col]; p < L.col_ptr[col + 1]; ++p) {
+            const std::size_t i = static_cast<std::size_t>(L.row_ind[p]);
+            if (i > col) { if (level[i] + 1 > lv) lv = level[i] + 1; ++nnz_off; }
+        }
+        level[col] = lv;
+        if (lv + 1 > nlevels) nlevels = lv + 1;
+    }
+    s.level_ptr.assign(nlevels + 1, std::size_t{0});
+    for (std::size_t c = 0; c < n; ++c) ++s.level_ptr[level[c] + 1];
+    for (std::size_t l = 0; l < nlevels; ++l) s.level_ptr[l + 1] += s.level_ptr[l];
+    s.order.resize(n);
+    std::vector<std::size_t> cursor(s.level_ptr.begin(), s.level_ptr.end() - 1);
+    for (std::size_t c = 0; c < n; ++c) s.order[cursor[level[c]]++] = c;
+
+    const std::size_t avg = n ? std::max<std::size_t>(1, nnz_off / n) : 1;
+    s.grain = std::max<std::size_t>(std::size_t{1}, std::size_t{32768} / avg);
+    return s;
+}
+
+/// Level-scheduled UNIT lower transpose solve. Bit-identical to
+/// dense_unit_lower_transpose_solve (no diagonal division).
+template <typename Value, typename SizeType>
+void level_scheduled_unit_lower_transpose_solve(const util::csc_matrix<Value, SizeType>& L,
+                                                const unit_lower_transpose_solve_schedule& s,
+                                                std::vector<Value>& x)
+{
+    assert(s.n == static_cast<std::size_t>(L.ncols) &&
+           s.built_nnz == static_cast<std::size_t>(L.nnz()) && "schedule does not match L");
+    assert(x.size() >= s.n && "solution vector shorter than the system");
+    const std::size_t nlevels = s.level_ptr.empty() ? 0 : s.level_ptr.size() - 1;
+    for (std::size_t l = 0; l < nlevels; ++l) {
+        const std::size_t lb = s.level_ptr[l], le = s.level_ptr[l + 1];
+        if (le == lb) continue;
+        detail::thread_pool::instance().parallel_for(
+            le - lb, s.grain,
+            [&](std::size_t cb, std::size_t ce) {
+                for (std::size_t t = cb; t < ce; ++t) {
+                    const std::size_t col = s.order[lb + t];
+                    Value acc = x[col];
+                    for (SizeType p = L.col_ptr[col]; p < L.col_ptr[col + 1]; ++p)
+                        if (static_cast<std::size_t>(L.row_ind[p]) > col)
+                            acc -= L.values[p] * x[static_cast<std::size_t>(L.row_ind[p])];
+                    x[col] = acc;   // unit diagonal: no division
+                }
+            });
+    }
+}
+
 } // namespace mtl::sparse::factorization

--- a/include/mtl/sparse/factorization/sparse_ldlt.hpp
+++ b/include/mtl/sparse/factorization/sparse_ldlt.hpp
@@ -61,8 +61,21 @@ struct ldlt_numeric {
     /// are always set together, so the schedules' cached structure always matches
     /// L's pattern. Strongly exception safe: the schedules are built into locals
     /// before any member is replaced.
+    ///
+    /// Precondition: the symbolic analysis (`symbolic`) MUST be installed first --
+    /// set_factor validates L and D against `symbolic.n`. Calling it while
+    /// `symbolic` is still default-constructed (n == 0) with a non-empty factor
+    /// throws (see the guard below), rather than silently accepting a factor that
+    /// no later solve could use.
     void set_factor(util::csc_matrix<Value> L, std::vector<Value> D) {
         const std::size_t n = symbolic.n;
+        // Guard the ordering hazard explicitly: n == 0 with a non-empty factor
+        // almost always means set_factor was called before `symbolic` was
+        // assigned, so point at that cause instead of the generic mismatch below.
+        if (n == 0 && (L.ncols != 0 || L.nrows != 0 || !D.empty()))
+            throw std::invalid_argument(
+                "ldlt_numeric::set_factor: symbolic analysis not installed (symbolic.n == 0); "
+                "assign `symbolic` before calling set_factor");
         if (static_cast<std::size_t>(L.ncols) != n || static_cast<std::size_t>(L.nrows) != n)
             throw std::invalid_argument(
                 "ldlt_numeric::set_factor: factor dimension does not match the symbolic analysis");

--- a/include/mtl/sparse/factorization/sparse_ldlt.hpp
+++ b/include/mtl/sparse/factorization/sparse_ldlt.hpp
@@ -33,6 +33,7 @@
 #include <mtl/sparse/analysis/elimination_tree.hpp>
 #include <mtl/sparse/analysis/postorder.hpp>
 #include <mtl/sparse/factorization/triangular_solve.hpp>
+#include <mtl/sparse/factorization/level_schedule.hpp>
 #include <mtl/sparse/factorization/sparse_cholesky.hpp>  // for cholesky_symbolic
 
 namespace mtl::sparse::factorization {
@@ -46,12 +47,35 @@ using ldlt_symbolic = cholesky_symbolic;
 /// the diagonal D, and the symbolic analysis (for permutation during solve).
 template <typename Value>
 struct ldlt_numeric {
-    util::csc_matrix<Value> L;            // unit lower triangular (CSC)
-    std::vector<Value>      D;            // diagonal entries
-    ldlt_symbolic           symbolic;     // symbolic analysis used
+    ldlt_symbolic symbolic;               // symbolic analysis used
 
     std::size_t num_rows() const { return symbolic.n; }
     std::size_t num_cols() const { return symbolic.n; }
+
+    /// Read-only access to the unit lower factor L (CSC) and the diagonal D.
+    const util::csc_matrix<Value>& factorL() const { return L_; }
+    const std::vector<Value>&      diagonal() const { return D_; }
+
+    /// Install the factor (unit lower L, diagonal D) and (re)build the coupled
+    /// unit forward and transpose solve schedules from L. L, D and the schedules
+    /// are always set together, so the schedules' cached structure always matches
+    /// L's pattern. Strongly exception safe: the schedules are built into locals
+    /// before any member is replaced.
+    void set_factor(util::csc_matrix<Value> L, std::vector<Value> D) {
+        const std::size_t n = symbolic.n;
+        if (static_cast<std::size_t>(L.ncols) != n || static_cast<std::size_t>(L.nrows) != n)
+            throw std::invalid_argument(
+                "ldlt_numeric::set_factor: factor dimension does not match the symbolic analysis");
+        if (D.size() != n)
+            throw std::invalid_argument(
+                "ldlt_numeric::set_factor: diagonal size does not match the symbolic analysis");
+        unit_lower_solve_schedule           fsched = build_unit_lower_solve_schedule(L);
+        unit_lower_transpose_solve_schedule bsched = build_unit_lower_transpose_solve_schedule(L);
+        L_ = std::move(L);            // noexcept
+        D_ = std::move(D);            // noexcept
+        fwd_sched_ = std::move(fsched);  // noexcept
+        bwd_sched_ = std::move(bsched);  // noexcept
+    }
 
     /// Solve A*x = b using the LDL^T factorization.
     /// A = P^T L D L^T P, so x = P^T L^{-T} D^{-1} L^{-1} P b
@@ -70,20 +94,29 @@ struct ldlt_numeric {
         for (std::size_t i = 0; i < n; ++i)
             w[i] = static_cast<Value>(b(symbolic.perm[i]));
 
-        // Step 2: Forward solve: L * y = w  (L is unit lower triangular)
-        dense_unit_lower_solve(L, w);
+        // Step 2: Forward solve: L * y = w (unit lower). Level-scheduled
+        // (parallel, bit-identical to dense_unit_lower_solve); serial at
+        // MTL5_NUM_THREADS=1.
+        level_scheduled_unit_lower_solve(L_, fwd_sched_, w);
 
         // Step 3: Diagonal solve: D * z = y
         for (std::size_t i = 0; i < n; ++i)
-            w[i] /= D[i];
+            w[i] /= D_[i];
 
-        // Step 4: Back solve: L^T * u = z  (L^T is unit upper triangular)
-        dense_unit_lower_transpose_solve(L, w);
+        // Step 4: Back solve: L^T * u = z (unit upper). Level-scheduled
+        // (parallel, bit-identical to dense_unit_lower_transpose_solve).
+        level_scheduled_unit_lower_transpose_solve(L_, bwd_sched_, w);
 
         // Step 5: Apply inverse permutation: x = P^T * u
         for (std::size_t i = 0; i < n; ++i)
             x(symbolic.perm[i]) = static_cast<typename VecX::value_type>(w[i]);
     }
+
+private:
+    util::csc_matrix<Value>             L_;          // unit lower triangular (CSC), no stored diagonal
+    std::vector<Value>                  D_;          // diagonal entries
+    unit_lower_solve_schedule           fwd_sched_;  // forward (L y = w) schedule, bound to L_
+    unit_lower_transpose_solve_schedule bwd_sched_;  // transpose (L^T u = z) schedule, bound to L_
 };
 
 /// Perform symbolic LDL^T analysis on a symmetric sparse matrix.
@@ -335,9 +368,9 @@ ldlt_numeric<Value> sparse_ldlt_numeric(
     }
 
     ldlt_numeric<Value> result;
-    result.L = std::move(L);
-    result.D = std::move(D);
     result.symbolic = sym;
+    // Install L and D and build the coupled solve schedules atomically.
+    result.set_factor(std::move(L), std::move(D));
     return result;
 }
 

--- a/tests/unit/sparse/test_sparse_ldlt.cpp
+++ b/tests/unit/sparse/test_sparse_ldlt.cpp
@@ -99,7 +99,7 @@ TEST_CASE("Sparse LDL^T numeric: 3x3 SPD matrix", "[sparse][ldlt]") {
     auto num = factorization::sparse_ldlt_numeric(A, sym);
 
     // Verify L structure: unit lower triangular with no diagonal stored
-    const auto& L = num.L;
+    const auto& L = num.factorL();
     REQUIRE(L.nrows == 3);
     REQUIRE(L.ncols == 3);
 
@@ -111,9 +111,9 @@ TEST_CASE("Sparse LDL^T numeric: 3x3 SPD matrix", "[sparse][ldlt]") {
     }
 
     // Verify D has positive entries (SPD matrix)
-    REQUIRE(num.D.size() == 3);
+    REQUIRE(num.diagonal().size() == 3);
     for (std::size_t j = 0; j < 3; ++j)
-        REQUIRE(num.D[j] > 0.0);
+        REQUIRE(num.diagonal()[j] > 0.0);
 }
 
 TEST_CASE("Sparse LDL^T solve: 3x3 tridiagonal", "[sparse][ldlt]") {

--- a/tests/unit/sparse/test_trisolve_level_schedule_mt.cpp
+++ b/tests/unit/sparse/test_trisolve_level_schedule_mt.cpp
@@ -329,3 +329,120 @@ TEST_CASE("level_scheduled_upper_solve boundary cases",
         require_upper_bit_identical(U, 7);
     }
 }
+
+// -- unit lower solves (#297 batch 6: sparse_ldlt rollout) ---------------
+// Unit lower: L has NO stored diagonal (strictly-lower entries only); the solves
+// never divide.
+
+namespace {
+
+// Block-diagonal strictly-lower (unit): B dense-strictly-lower m x m blocks.
+csc_matrix<double> make_unit_block_diag_lower(std::size_t B, std::size_t m, std::uint64_t seed) {
+    csc_matrix<double> L;
+    const std::size_t n = B * m;
+    L.nrows = n; L.ncols = n;
+    L.col_ptr.assign(n + 1, 0);
+    for (std::size_t b = 0; b < B; ++b)
+        for (std::size_t cc = 0; cc < m; ++cc)
+            L.col_ptr[b * m + cc + 1] = L.col_ptr[b * m + cc] + (m - cc - 1);   // rows below, no diagonal
+    L.row_ind.resize(L.col_ptr[n]);
+    L.values.resize(L.col_ptr[n]);
+    std::mt19937_64 rng(seed);
+    std::uniform_real_distribution<double> d(-0.5, 0.5);
+    std::size_t p = 0;
+    for (std::size_t b = 0; b < B; ++b)
+        for (std::size_t cc = 0; cc < m; ++cc)
+            for (std::size_t r = cc + 1; r < m; ++r) { L.row_ind[p] = b * m + r; L.values[p] = d(rng); ++p; }
+    return L;
+}
+
+// Strictly-lower arrow: column 0 has rows 1..n-1; the rest empty. Forward unit
+// solve: rows 1..n-1 all depend on row 0 -> one wide level that splits.
+csc_matrix<double> make_unit_arrow_lower(std::size_t n, std::uint64_t seed) {
+    csc_matrix<double> L;
+    L.nrows = n; L.ncols = n;
+    L.col_ptr.assign(n + 1, 0);
+    if (n) L.col_ptr[1] = n - 1;
+    for (std::size_t j = 1; j < n; ++j) L.col_ptr[j + 1] = L.col_ptr[j];   // empty
+    L.row_ind.resize(L.col_ptr[n]);
+    L.values.resize(L.col_ptr[n]);
+    std::mt19937_64 rng(seed);
+    std::uniform_real_distribution<double> d(-0.5, 0.5);
+    std::size_t p = 0;
+    for (std::size_t i = 1; i < n; ++i) { L.row_ind[p] = i; L.values[p] = d(rng); ++p; }
+    return L;
+}
+
+// Strictly-lower "dense last row": columns 0..n-2 each have an entry in row n-1.
+// TRANSPOSE unit solve: columns 0..n-2 all gather from x[n-1] -> wide level.
+csc_matrix<double> make_unit_last_row_dense_lower(std::size_t n, std::uint64_t seed) {
+    csc_matrix<double> L;
+    L.nrows = n; L.ncols = n;
+    L.col_ptr.assign(n + 1, 0);
+    for (std::size_t col = 0; col + 1 < n; ++col) L.col_ptr[col + 1] = L.col_ptr[col] + 1;
+    if (n) L.col_ptr[n] = L.col_ptr[n - 1];   // last column empty
+    L.row_ind.resize(L.col_ptr[n]);
+    L.values.resize(L.col_ptr[n]);
+    std::mt19937_64 rng(seed);
+    std::uniform_real_distribution<double> d(-0.5, 0.5);
+    std::size_t p = 0;
+    for (std::size_t col = 0; col + 1 < n; ++col) { L.row_ind[p] = n - 1; L.values[p] = d(rng); ++p; }
+    return L;
+}
+
+void require_unit_bit_identical(const csc_matrix<double>& L, std::uint64_t rhs_seed) {
+    const std::size_t n = L.ncols;
+    auto ref = random_rhs(n, rhs_seed);
+    auto got = ref;
+    factorization::dense_unit_lower_solve(L, ref);
+    auto sched = factorization::build_unit_lower_solve_schedule(L);
+    factorization::level_scheduled_unit_lower_solve(L, sched, got);
+    for (std::size_t i = 0; i < n; ++i) REQUIRE(got[i] == ref[i]);
+}
+
+void require_unit_transpose_bit_identical(const csc_matrix<double>& L, std::uint64_t rhs_seed) {
+    const std::size_t n = L.ncols;
+    auto ref = random_rhs(n, rhs_seed);
+    auto got = ref;
+    factorization::dense_unit_lower_transpose_solve(L, ref);
+    auto sched = factorization::build_unit_lower_transpose_solve_schedule(L);
+    factorization::level_scheduled_unit_lower_transpose_solve(L, sched, got);
+    for (std::size_t i = 0; i < n; ++i) REQUIRE(got[i] == ref[i]);
+}
+
+} // namespace
+
+TEST_CASE("level_scheduled_unit_lower_solve == dense_unit_lower_solve",
+          "[sparse][trisolve][unit][threading][mt]") {
+    require_unit_bit_identical(make_unit_block_diag_lower(64, 8, 11), 601);
+    if (mtl::detail::thread_pool::instance().size() < 2) WARN("single-core runner: threading not exercised");
+    require_unit_bit_identical(make_unit_arrow_lower(80000, 33), 602);   // wide level splits
+}
+
+TEST_CASE("level_scheduled_unit_lower_transpose_solve == dense_unit_lower_transpose_solve",
+          "[sparse][trisolve][unit][transpose][threading][mt]") {
+    require_unit_transpose_bit_identical(make_unit_block_diag_lower(64, 8, 22), 611);
+    if (mtl::detail::thread_pool::instance().size() < 2) WARN("single-core runner: threading not exercised");
+    require_unit_transpose_bit_identical(make_unit_last_row_dense_lower(80000, 44), 612);   // wide level splits
+}
+
+TEST_CASE("unit lower solves boundary cases",
+          "[sparse][trisolve][unit][threading][mt][edge]") {
+    // Empty 0x0
+    {
+        csc_matrix<double> L; L.nrows = 0; L.ncols = 0; L.col_ptr = {0};
+        auto fs = factorization::build_unit_lower_solve_schedule(L);
+        auto bs = factorization::build_unit_lower_transpose_solve_schedule(L);
+        REQUIRE(fs.n == 0); REQUIRE(bs.n == 0);
+        std::vector<double> x;
+        factorization::level_scheduled_unit_lower_solve(L, fs, x);
+        factorization::level_scheduled_unit_lower_transpose_solve(L, bs, x);
+        REQUIRE(x.empty());
+    }
+    // 1x1 (single implicit-unit diagonal, no stored entries)
+    {
+        csc_matrix<double> L; L.nrows = 1; L.ncols = 1; L.col_ptr = {0, 0};   // empty column
+        require_unit_bit_identical(L, 1);
+        require_unit_transpose_bit_identical(L, 2);
+    }
+}


### PR DESCRIPTION
## Summary
Batch 6 of the on-node threading rollout (#297): parallelize `sparse_ldlt`'s solve. It's a forward unit-lower `L y = w`, a diagonal `D z = y`, and a backward unit-lower transpose `L^T u = z`, so `ldlt_numeric::solve` is now **fully parallel** (the diagonal scale was already elementwise).

## Why new "unit" schedules
LDL^T's L is **unit lower with an implicit diagonal** — no diagonal entry is stored and the solves never divide — so the batch-3/4 schedules (which assume a stored diagonal and divide) don't apply. Added dedicated unit variants:
- **`unit_lower_solve_schedule`** — identifies the strictly-lower entries by `row_ind > col` (not by position, since there's no diagonal to skip), gathers in increasing-column order, no division.
- **`unit_lower_transpose_solve_schedule`** — gathers within each CSC column over the `i>col` entries, no division.

Both bit-identical to `dense_unit_lower_solve` / `dense_unit_lower_transpose_solve`; value-agnostic. `ldlt_numeric` holds `L`, `D` and both schedules as **private, coupled** state, built together in a validating, exception-safe `set_factor(L, D)` (the #301 pattern), with `factorL()`/`diagonal()` accessors. No-op (serial) at `MTL5_NUM_THREADS=1`.

## Changes
- `level_schedule.hpp` — `unit_lower_solve_schedule` + `unit_lower_transpose_solve_schedule` (+ builds + solves)
- `sparse_ldlt.hpp` — private coupled `L_`/`D_`/schedules, `set_factor`, accessors; level-scheduled solve
- `test_trisolve_level_schedule_mt.cpp` — unit-solve bit-identity tests
- `test_sparse_ldlt.cpp` — the one reader of `ldlt_numeric.L`/`.D` → accessors

## Test Results
| Target | gcc | clang |
|--------|-----|-------|
| sparse_test_trisolve_level_schedule_mt (553,174 assertions) | PASS | PASS |
| sparse_test_sparse_ldlt (parallel unit solves) | PASS | PASS |
| full sparse suite (30 tests) | PASS | — |

Unit solves **bit-identical (`==`)** across block-diagonal, wide arrow / dense-last-row levels that **split across the pool** (n=80000), 1×1, empty. **Race-free under ThreadSanitizer.** The new threaded + TSan CI lanes (#299) run on this PR.

## Scope
Follows `docs/design/parallelization-patterns-and-pitfalls.md`. Rollout remaining: `supernodal_lu` / `supernodal_ldlt`.

## Test plan
- [ ] Fast CI (incl. threaded + TSan lanes) passes
- [ ] Promote to ready: `gh pr ready`

Relates to #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added efficient level-scheduled forward and transpose solves for sparse unit-lower-triangular matrices.
  * Sparse LDLᵀ solves now use parallel level scheduling while preserving existing results.
  * Added accessors for LDLᵀ factors and diagonal values, with validation when factors are installed.

* **Bug Fixes**
  * Improved factor and solve consistency through automatic schedule validation and rebuilding.

* **Tests**
  * Added coverage for threaded execution, sparse matrix patterns, exact dense-solve equivalence, and empty or single-element matrices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->