### PR TITLE
perf(sparse): level-schedule the supernodal LDL^T solve (#297 batch 7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,6 +299,7 @@ jobs:
           cmake --build build-tsan --parallel 2
           --target op_test_gemm_mt op_test_factorization_mt
           sparse_test_trisolve_level_schedule_mt
+          sparse_test_supernodal_ldlt_mt
 
       - name: Run mt tests under TSan (MTL5_NUM_THREADS=4)
         run: ctest --test-dir build-tsan -R _mt --output-on-failure

--- a/include/mtl/sparse/factorization/supernodal_ldlt.hpp
+++ b/include/mtl/sparse/factorization/supernodal_ldlt.hpp
@@ -44,6 +44,7 @@
 #include <mtl/sparse/analysis/postorder.hpp>
 #include <mtl/sparse/analysis/supernodes.hpp>
 #include <mtl/sparse/factorization/triangular_solve.hpp>
+#include <mtl/sparse/factorization/level_schedule.hpp>
 #include <mtl/sparse/factorization/sparse_cholesky.hpp>  // sparse_cholesky_symbolic
 #include <mtl/sparse/iterative_refine.hpp>
 
@@ -66,12 +67,50 @@ struct supernodal_symbolic {
 /// in CSC (diagonal implicit) in the permuted space; D is the diagonal.
 template <typename Value>
 struct supernodal_ldlt_factor {
-    util::csc_matrix<Value> L;          // unit lower triangular (CSC, no diagonal)
-    std::vector<Value>      D;          // diagonal entries
-    supernodal_symbolic     symbolic;
+    supernodal_symbolic symbolic;
 
     std::size_t num_rows() const { return symbolic.n; }
     std::size_t num_cols() const { return symbolic.n; }
+
+    /// Read-only access to the unit lower factor L (CSC) and the diagonal D.
+    const util::csc_matrix<Value>& factorL() const { return L_; }
+    const std::vector<Value>&      diagonal() const { return D_; }
+
+    /// Install the factor (unit lower L, diagonal D) and (re)build the coupled
+    /// unit forward and transpose solve schedules from L. L, D and the schedules
+    /// are always set together, so the schedules' cached structure always matches
+    /// L's pattern. Strongly exception safe: the schedules are built into locals
+    /// before any member is replaced.
+    ///
+    /// Precondition: the symbolic analysis (`symbolic`) MUST be installed first --
+    /// set_factor validates L and D against `symbolic.n`. Calling it while
+    /// `symbolic` is still default-constructed (n == 0) with a non-empty factor
+    /// throws (see the guard below), rather than silently accepting a factor that
+    /// no later solve could use.
+    void set_factor(util::csc_matrix<Value> L, std::vector<Value> D) {
+        const std::size_t n = symbolic.n;
+        // Guard the ordering hazard explicitly: n == 0 with a non-empty factor
+        // almost always means set_factor was called before `symbolic` was
+        // assigned, so point at that cause instead of the generic mismatch below.
+        if (n == 0 && (L.ncols != 0 || L.nrows != 0 || !D.empty()))
+            throw std::invalid_argument(
+                "supernodal_ldlt_factor::set_factor: symbolic analysis not installed "
+                "(symbolic.n == 0); assign `symbolic` before calling set_factor");
+        if (static_cast<std::size_t>(L.ncols) != n || static_cast<std::size_t>(L.nrows) != n)
+            throw std::invalid_argument(
+                "supernodal_ldlt_factor::set_factor: factor dimension does not match "
+                "the symbolic analysis");
+        if (D.size() != n)
+            throw std::invalid_argument(
+                "supernodal_ldlt_factor::set_factor: diagonal size does not match "
+                "the symbolic analysis");
+        unit_lower_solve_schedule           fsched = build_unit_lower_solve_schedule(L);
+        unit_lower_transpose_solve_schedule bsched = build_unit_lower_transpose_solve_schedule(L);
+        L_ = std::move(L);               // noexcept
+        D_ = std::move(D);               // noexcept
+        fwd_sched_ = std::move(fsched);  // noexcept
+        bwd_sched_ = std::move(bsched);  // noexcept
+    }
 
     /// Solve A*x = b.  A = P^T L D L^T P, so x = P^T L^{-T} D^{-1} L^{-1} P b.
     template <typename VecX, typename VecB>
@@ -88,13 +127,23 @@ struct supernodal_ldlt_factor {
         std::vector<Value> w(n);
         for (std::size_t i = 0; i < n; ++i)
             w[i] = static_cast<Value>(b(p[i]));            // w = P b
-        dense_unit_lower_solve(L, w);                       // L y = w
+        // Forward solve L y = w (unit lower). Level-scheduled -- parallel and
+        // bit-identical to dense_unit_lower_solve; serial at MTL5_NUM_THREADS=1.
+        level_scheduled_unit_lower_solve(L_, fwd_sched_, w);
         for (std::size_t i = 0; i < n; ++i)
-            w[i] /= D[i];                                   // D z = y
-        dense_unit_lower_transpose_solve(L, w);             // L^T u = z
+            w[i] /= D_[i];                                 // D z = y
+        // Back solve L^T u = z (unit upper). Level-scheduled, bit-identical to
+        // dense_unit_lower_transpose_solve.
+        level_scheduled_unit_lower_transpose_solve(L_, bwd_sched_, w);
         for (std::size_t i = 0; i < n; ++i)
             x(p[i]) = static_cast<typename VecX::value_type>(w[i]);  // x = P^T u
     }
+
+private:
+    util::csc_matrix<Value>             L_;          // unit lower triangular (CSC), no stored diagonal
+    std::vector<Value>                  D_;          // diagonal entries
+    unit_lower_solve_schedule           fwd_sched_;  // forward (L y = w) schedule, bound to L_
+    unit_lower_transpose_solve_schedule bwd_sched_;  // transpose (L^T u = z) schedule, bound to L_
 };
 
 namespace detail {
@@ -313,9 +362,9 @@ supernodal_ldlt_factor<Value> supernodal_ldlt_numeric(
     }
 
     supernodal_ldlt_factor<Value> result;
-    result.L = std::move(L);
-    result.D = std::move(D);
     result.symbolic = sym;
+    // Install L and D and build the coupled solve schedules atomically.
+    result.set_factor(std::move(L), std::move(D));
     return result;
 }
 

--- a/include/mtl/sparse/factorization/supernodal_ldlt.hpp
+++ b/include/mtl/sparse/factorization/supernodal_ldlt.hpp
@@ -110,11 +110,19 @@ struct supernodal_ldlt_factor {
         D_ = std::move(D);               // noexcept
         fwd_sched_ = std::move(fsched);  // noexcept
         bwd_sched_ = std::move(bsched);  // noexcept
+        has_factor_ = true;              // commit last: solve() is now valid
     }
 
     /// Solve A*x = b.  A = P^T L D L^T P, so x = P^T L^{-T} D^{-1} L^{-1} P b.
     template <typename VecX, typename VecB>
     void solve(VecX& x, const VecB& b) const {
+        // A caller can set `symbolic` (n > 0) yet never install a factor; the
+        // divide by D_ below would then index an empty vector. Reject that
+        // explicitly instead of walking off the end.
+        if (!has_factor_)
+            throw std::logic_error(
+                "supernodal_ldlt_factor::solve: no factor installed (call set_factor "
+                "or supernodal_ldlt_numeric first)");
         const std::size_t n = symbolic.n;
         if (static_cast<std::size_t>(x.size()) != n ||
             static_cast<std::size_t>(b.size()) != n) {
@@ -144,6 +152,7 @@ private:
     std::vector<Value>                  D_;          // diagonal entries
     unit_lower_solve_schedule           fwd_sched_;  // forward (L y = w) schedule, bound to L_
     unit_lower_transpose_solve_schedule bwd_sched_;  // transpose (L^T u = z) schedule, bound to L_
+    bool                                has_factor_ = false;  // set by set_factor; solve() requires it
 };
 
 namespace detail {

--- a/tests/unit/sparse/test_supernodal_ldlt_mt.cpp
+++ b/tests/unit/sparse/test_supernodal_ldlt_mt.cpp
@@ -1,0 +1,136 @@
+// Threaded supernodal LDL^T solve (#297 batch 7). The supernodal factor's solve
+// routes its unit forward / transpose triangular solves through the
+// level-scheduled kernels (level_scheduled_unit_lower_solve /
+// _transpose_solve), which are proven bit-identical to the serial
+// dense_unit_lower_solve / dense_unit_lower_transpose_solve in batch 6. Here we
+// verify the composed supernodal solve is BIT-IDENTICAL to the same solve driven
+// by the dense kernels on the identical factor (same L, D, permutation), so the
+// parallel path changes nothing but the schedule. The permutation and diagonal
+// steps are unchanged serial loops, so exact equality (==) is the correct bar.
+//
+// Sets MTL5_NUM_THREADS before the pool's first use (the only in-process way to
+// exercise the threading -- CI otherwise runs serial). Run under TSan
+// (-DMTL5_SANITIZE=thread) to race-check the parallel levels.
+#include <catch2/catch_test_macros.hpp>
+
+#include <cmath>
+#include <cstddef>
+#include <cstdlib>
+#include <vector>
+
+#include <mtl/mat/compressed2D.hpp>
+#include <mtl/mat/inserter.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/sparse/factorization/supernodal_ldlt.hpp>
+#include <mtl/sparse/factorization/triangular_solve.hpp>
+#include <mtl/sparse/ordering/amd.hpp>
+#include <mtl/detail/thread_pool.hpp>
+
+using namespace mtl;
+using namespace mtl::sparse;
+
+namespace {
+
+const int g_set_threads = [] {
+#if defined(_WIN32)
+    _putenv_s("MTL5_NUM_THREADS", "4");
+#else
+    setenv("MTL5_NUM_THREADS", "4", /*overwrite=*/1);
+#endif
+    return 0;
+}();
+
+// SPD tridiagonal: A(i,i)=4, A(i,i+-1)=-1.
+mat::compressed2D<double> make_spd_tridiag(std::size_t n) {
+    mat::compressed2D<double> A(n, n);
+    mat::inserter<mat::compressed2D<double>> ins(A);
+    for (std::size_t i = 0; i < n; ++i) {
+        ins[i][i] << 4.0;
+        if (i + 1 < n) { ins[i][i + 1] << -1.0; ins[i + 1][i] << -1.0; }
+    }
+    return A;
+}
+
+// 5-point 2D Laplacian on a g x g grid (n = g*g): nontrivial fill / supernodes,
+// so the factor L has a genuine multi-level dependency structure.
+mat::compressed2D<double> make_laplacian2d(std::size_t g) {
+    std::size_t n = g * g;
+    mat::compressed2D<double> A(n, n);
+    mat::inserter<mat::compressed2D<double>> ins(A);
+    auto id = [g](std::size_t r, std::size_t c) { return r * g + c; };
+    for (std::size_t r = 0; r < g; ++r)
+        for (std::size_t c = 0; c < g; ++c) {
+            std::size_t i = id(r, c);
+            ins[i][i] << 4.0;
+            if (r + 1 < g) { ins[i][id(r + 1, c)] << -1.0; ins[id(r + 1, c)][i] << -1.0; }
+            if (c + 1 < g) { ins[i][id(r, c + 1)] << -1.0; ins[id(r, c + 1)][i] << -1.0; }
+        }
+    return A;
+}
+
+// Deterministic RHS.
+vec::dense_vector<double> make_rhs(std::size_t n) {
+    vec::dense_vector<double> b(n);
+    for (std::size_t i = 0; i < n; ++i)
+        b(static_cast<int>(i)) = 0.5 + std::sin(0.9 * static_cast<double>(i));
+    return b;
+}
+
+// Reference solve using the serial dense unit kernels on the SAME factor
+// (identical L, D, permutation) that the threaded solve uses.
+template <typename Value>
+std::vector<double> dense_reference_solve(
+    const factorization::supernodal_ldlt_factor<Value>& fac,
+    const vec::dense_vector<double>& b)
+{
+    const std::size_t n = fac.num_rows();
+    const auto& L = fac.factorL();
+    const auto& D = fac.diagonal();
+    const auto& p = fac.symbolic.sperm;
+
+    std::vector<Value> w(n);
+    for (std::size_t i = 0; i < n; ++i) w[i] = static_cast<Value>(b(static_cast<int>(p[i])));
+    factorization::dense_unit_lower_solve(L, w);
+    for (std::size_t i = 0; i < n; ++i) w[i] /= D[i];
+    factorization::dense_unit_lower_transpose_solve(L, w);
+
+    std::vector<double> x(n);
+    for (std::size_t i = 0; i < n; ++i) x[p[i]] = static_cast<double>(w[i]);
+    return x;
+}
+
+// Factor A, then assert the threaded solve == the dense-kernel reference,
+// bit-for-bit, for the same factor.
+void require_supernodal_solve_bit_identical(const mat::compressed2D<double>& A) {
+    const std::size_t n = A.num_rows();
+    auto b = make_rhs(n);
+
+    auto sym = factorization::supernodal_ldlt_symbolic(A, ordering::amd{});
+    auto fac = factorization::supernodal_ldlt_numeric(A, sym);
+
+    const auto ref = dense_reference_solve(fac, b);
+
+    vec::dense_vector<double> x(n);
+    fac.solve(x, b);
+
+    for (std::size_t i = 0; i < n; ++i)
+        REQUIRE(x(static_cast<int>(i)) == ref[i]);   // exact equality
+}
+
+} // namespace
+
+TEST_CASE("supernodal LDL^T threaded solve == dense-kernel reference",
+          "[sparse][supernodal][ldlt][threading][mt]") {
+    if (mtl::detail::thread_pool::instance().size() < 2)
+        WARN("single-core runner: threading not exercised");
+
+    require_supernodal_solve_bit_identical(make_spd_tridiag(500));
+    require_supernodal_solve_bit_identical(make_laplacian2d(40));   // n=1600, real supernodes
+    require_supernodal_solve_bit_identical(make_laplacian2d(60));   // n=3600, deeper levels
+}
+
+TEST_CASE("supernodal LDL^T threaded solve boundary cases",
+          "[sparse][supernodal][ldlt][threading][mt][edge]") {
+    require_supernodal_solve_bit_identical(make_spd_tridiag(1));    // 1x1
+    require_supernodal_solve_bit_identical(make_spd_tridiag(2));    // 2x2
+}

--- a/tests/unit/sparse/test_supernodal_ldlt_mt.cpp
+++ b/tests/unit/sparse/test_supernodal_ldlt_mt.cpp
@@ -16,6 +16,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdlib>
+#include <stdexcept>
 #include <vector>
 
 #include <mtl/mat/compressed2D.hpp>
@@ -133,4 +134,15 @@ TEST_CASE("supernodal LDL^T threaded solve boundary cases",
           "[sparse][supernodal][ldlt][threading][mt][edge]") {
     require_supernodal_solve_bit_identical(make_spd_tridiag(1));    // 1x1
     require_supernodal_solve_bit_identical(make_spd_tridiag(2));    // 2x2
+}
+
+// A factor with `symbolic` installed (n > 0) but no factor must reject solve
+// rather than index the empty diagonal.
+TEST_CASE("supernodal LDL^T solve rejects a missing factor",
+          "[sparse][supernodal][ldlt][edge]") {
+    factorization::supernodal_ldlt_factor<double> fac;
+    fac.symbolic.n = 3;                       // symbolic set, set_factor never called
+    vec::dense_vector<double> x(3), b(3);
+    for (int i = 0; i < 3; ++i) b(i) = 1.0;
+    REQUIRE_THROWS_AS(fac.solve(x, b), std::logic_error);
 }


### PR DESCRIPTION
## Summary
Batch 7 of the on-node threading rollout (#297): route the **supernodal** LDLᵀ solve through the level-scheduled unit triangular kernels landed in batch 6, and encapsulate the factor the same way as the point LDLᵀ.

- `supernodal_ldlt_factor::solve` now calls `level_scheduled_unit_lower_solve` / `level_scheduled_unit_lower_transpose_solve` instead of the serial `dense_unit_lower_solve` / `dense_unit_lower_transpose_solve`. The kernels are bit-identical to the dense solves, so the parallel path changes nothing but the schedule; the diagonal and permutation steps stay serial.
- `L`/`D` are now **private**, installed together with their coupled forward/transpose schedules via a validating, strongly-exception-safe `set_factor(L, D)`; `factorL()` / `diagonal()` give read-only access. `set_factor` also guards the "symbolic not installed" ordering hazard with an explicit message (same hardening as #305).

## Changes
- `include/mtl/sparse/factorization/supernodal_ldlt.hpp` — privatize `L_`/`D_` + schedules, add `set_factor` / `factorL` / `diagonal`, route `solve` through the level-scheduled kernels, install via `set_factor` in the numeric factory.
- `tests/unit/sparse/test_supernodal_ldlt_mt.cpp` — new: factor SPD systems (tridiagonal, 2D Laplacian n=1600/3600) with AMD, assert the threaded solve is **bit-identical (`==`)** to the dense-kernel reference on the same factor; plus 1×1 / 2×2 boundaries.
- `.github/workflows/ci.yml` — register `sparse_test_supernodal_ldlt_mt` in the ThreadSanitizer lane.

## Test Results (local)
| Target | gcc build | gcc test | clang | TSan |
|--------|-----------|----------|-------|------|
| sparse_test_supernodal_ldlt | OK | PASS | syntax OK | — |
| sparse_test_supernodal_ldlt_mt | OK | PASS (MTL5_NUM_THREADS=4) | syntax OK | clean, 5703 assertions |

Full sparse suite (30 tests) passes at `MTL5_NUM_THREADS=4`.

## Test plan
- [ ] Fast CI (8 platforms) + threaded + TSan lanes pass
- [ ] Promote to ready: `gh pr ready`

Relates to #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved threaded sparse LDLᵀ solves with level-scheduled triangular operations.

* **Reliability**
  * Added validation when installing factorization data.
  * Improved support for accessing factorization dimensions and components.

* **Bug Fixes**
  * Corrected threaded sparse solve coverage, including small matrices and multi-threaded workloads.

* **Tests**
  * Added coverage comparing threaded sparse results with trusted dense reference solutions across multiple matrix sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->