### PR TITLE
fix(sparse): reject solve before a factor is installed across factor types

### DIFF
--- a/include/mtl/sparse/factorization/sparse_cholesky.hpp
+++ b/include/mtl/sparse/factorization/sparse_cholesky.hpp
@@ -87,12 +87,20 @@ struct cholesky_numeric {
         L_ = std::move(L);                                                                // noexcept
         fwd_sched_ = std::move(fsched);                                                   // noexcept
         bwd_sched_ = std::move(bsched);                                                   // noexcept
+        has_factor_ = true;                            // commit last: solve() is now valid
     }
 
     /// Solve A*x = b using the Cholesky factorization.
     /// A = P^T L L^T P, so x = P^T L^{-T} L^{-1} P b
     template <typename VecX, typename VecB>
     void solve(VecX& x, const VecB& b) const {
+        // A caller can set `symbolic` (n > 0) yet never install a factor; the
+        // triangular solves below would then read an empty factor. Reject that
+        // explicitly instead of walking off the end.
+        if (!has_factor_)
+            throw std::logic_error(
+                "cholesky_numeric::solve: no factor installed (call set_factor "
+                "or sparse_cholesky_numeric first)");
         std::size_t n = symbolic.n;
         if (static_cast<std::size_t>(x.size()) != n ||
             static_cast<std::size_t>(b.size()) != n) {
@@ -129,6 +137,7 @@ private:
     util::csc_matrix<Value>        L_;          // lower triangular Cholesky factor (CSC)
     lower_solve_schedule           fwd_sched_;  // forward-solve (L y = w) schedule, bound to L_
     lower_transpose_solve_schedule bwd_sched_;  // transpose-solve (L^T z = y) schedule, bound to L_
+    bool                           has_factor_ = false;  // set by set_factor; solve() requires it
 };
 
 /// Perform symbolic Cholesky analysis on a symmetric sparse matrix.

--- a/include/mtl/sparse/factorization/sparse_ldlt.hpp
+++ b/include/mtl/sparse/factorization/sparse_ldlt.hpp
@@ -88,12 +88,20 @@ struct ldlt_numeric {
         D_ = std::move(D);            // noexcept
         fwd_sched_ = std::move(fsched);  // noexcept
         bwd_sched_ = std::move(bsched);  // noexcept
+        has_factor_ = true;              // commit last: solve() is now valid
     }
 
     /// Solve A*x = b using the LDL^T factorization.
     /// A = P^T L D L^T P, so x = P^T L^{-T} D^{-1} L^{-1} P b
     template <typename VecX, typename VecB>
     void solve(VecX& x, const VecB& b) const {
+        // A caller can set `symbolic` (n > 0) yet never install a factor; the
+        // divide by D_ below would then index an empty vector. Reject that
+        // explicitly instead of walking off the end.
+        if (!has_factor_)
+            throw std::logic_error(
+                "ldlt_numeric::solve: no factor installed (call set_factor "
+                "or sparse_ldlt_numeric first)");
         std::size_t n = symbolic.n;
         if (static_cast<std::size_t>(x.size()) != n ||
             static_cast<std::size_t>(b.size()) != n) {
@@ -130,6 +138,7 @@ private:
     std::vector<Value>                  D_;          // diagonal entries
     unit_lower_solve_schedule           fwd_sched_;  // forward (L y = w) schedule, bound to L_
     unit_lower_transpose_solve_schedule bwd_sched_;  // transpose (L^T u = z) schedule, bound to L_
+    bool                                has_factor_ = false;  // set by set_factor; solve() requires it
 };
 
 /// Perform symbolic LDL^T analysis on a symmetric sparse matrix.

--- a/include/mtl/sparse/factorization/sparse_lu.hpp
+++ b/include/mtl/sparse/factorization/sparse_lu.hpp
@@ -93,6 +93,7 @@ struct lu_numeric {
         U_ = std::move(U);            // noexcept
         fwd_sched_ = std::move(fsched);  // noexcept
         up_sched_  = std::move(usched);  // noexcept
+        has_factor_ = true;              // commit last: solve() is now valid
     }
 
     /// Solve A*x = b using the LU factorization.
@@ -106,6 +107,13 @@ struct lu_numeric {
     /// 4. x = Q * y
     template <typename VecX, typename VecB>
     void solve(VecX& x, const VecB& b) const {
+        // A caller can set `symbolic` (n > 0) yet never install a factor; the
+        // triangular solves below would then read empty factor arrays. Reject
+        // that explicitly instead of walking off the end.
+        if (!has_factor_)
+            throw std::logic_error(
+                "lu_numeric::solve: no factor installed (call set_factor "
+                "or sparse_lu_numeric first)");
         std::size_t n = symbolic.n;
         if (static_cast<std::size_t>(x.size()) != n ||
             static_cast<std::size_t>(b.size()) != n) {
@@ -138,6 +146,7 @@ private:
     util::csc_matrix<Value> U_;          // upper triangular factor (CSC), diagonal last
     lower_solve_schedule    fwd_sched_;  // forward (L z = w) schedule, bound to L_
     upper_solve_schedule    up_sched_;   // upper  (U y = z) schedule, bound to U_
+    bool                    has_factor_ = false;  // set by set_factor; solve() requires it
 };
 
 /// Perform symbolic LU analysis on a square sparse matrix.

--- a/tests/unit/sparse/test_sparse_cholesky.cpp
+++ b/tests/unit/sparse/test_sparse_cholesky.cpp
@@ -265,3 +265,13 @@ TEST_CASE("Sparse Cholesky solve: larger 10x10 system", "[sparse][cholesky]") {
     double rr = relative_residual(A, x, b);
     REQUIRE(rr < 1e-12);
 }
+
+// A factor with `symbolic` installed (n > 0) but no factor must reject solve
+// rather than index the empty factor (#307).
+TEST_CASE("Sparse Cholesky solve rejects a missing factor", "[sparse][cholesky][edge]") {
+    factorization::cholesky_numeric<double> num;
+    num.symbolic.n = 3;                       // symbolic set, set_factor never called
+    vec::dense_vector<double> x(3), b(3);
+    for (int i = 0; i < 3; ++i) b(i) = 1.0;
+    REQUIRE_THROWS_AS(num.solve(x, b), std::logic_error);
+}

--- a/tests/unit/sparse/test_sparse_ldlt.cpp
+++ b/tests/unit/sparse/test_sparse_ldlt.cpp
@@ -292,3 +292,13 @@ TEST_CASE("Sparse LDL^T handles symmetric indefinite matrix", "[sparse][ldlt]") 
     double rr = relative_residual(A, x, b);
     REQUIRE(rr < 1e-12);
 }
+
+// A factor with `symbolic` installed (n > 0) but no factor must reject solve
+// rather than index the empty diagonal (#307).
+TEST_CASE("Sparse LDL^T solve rejects a missing factor", "[sparse][ldlt][edge]") {
+    factorization::ldlt_numeric<double> num;
+    num.symbolic.n = 3;                       // symbolic set, set_factor never called
+    vec::dense_vector<double> x(3), b(3);
+    for (int i = 0; i < 3; ++i) b(i) = 1.0;
+    REQUIRE_THROWS_AS(num.solve(x, b), std::logic_error);
+}

--- a/tests/unit/sparse/test_sparse_lu.cpp
+++ b/tests/unit/sparse/test_sparse_lu.cpp
@@ -396,3 +396,13 @@ TEST_CASE("Sparse LU zero-pivot perturbation (#123)", "[sparse][lu][perturb]") {
         REQUIRE(std::isfinite(xf(1)));
     }
 }
+
+// A factor with `symbolic` installed (n > 0) but no factor must reject solve
+// rather than read empty factor arrays (#307).
+TEST_CASE("Sparse LU solve rejects a missing factor", "[sparse][lu][edge]") {
+    factorization::lu_numeric<double> num;
+    num.symbolic.n = 3;                       // symbolic set, set_factor never called
+    vec::dense_vector<double> x(3), b(3);
+    for (int i = 0; i < 3; ++i) b(i) = 1.0;
+    REQUIRE_THROWS_AS(num.solve(x, b), std::logic_error);
+}


### PR DESCRIPTION
## Summary
Applies the solve-before-factor guard from PR #306 (supernodal LDLᵀ) uniformly to the three point sparse factors, which share the same latent hazard: a caller can install `symbolic` (n > 0) but never call `set_factor`, and `solve()` would then read empty factor arrays (divide by an empty `D_`, gather from an empty `L_`/`U_`) — out-of-bounds UB in a release build.

The fix is pure hardening — no behavior change on the correct `factor → solve` path.

## Changes
Per factor type (`ldlt_numeric`, `lu_numeric`, `cholesky_numeric`):
- Add a private `bool has_factor_ = false;`
- Set it `= true` as the **last** statement of `set_factor(...)`, after the noexcept moves commit (a throwing schedule build leaves it false).
- Throw `std::logic_error` from `solve(...)` before any factor access when no factor is installed.
- Add a `... solve rejects a missing factor` regression test.

Files:
- `include/mtl/sparse/factorization/sparse_ldlt.hpp`
- `include/mtl/sparse/factorization/sparse_lu.hpp`
- `include/mtl/sparse/factorization/sparse_cholesky.hpp`
- `tests/unit/sparse/test_sparse_ldlt.cpp`
- `tests/unit/sparse/test_sparse_lu.cpp`
- `tests/unit/sparse/test_sparse_cholesky.cpp`

## Test Results (local)
| Target | gcc build | gcc test | clang |
|--------|-----------|----------|-------|
| sparse_test_sparse_ldlt | OK | PASS | syntax OK |
| sparse_test_sparse_lu | OK | PASS | syntax OK |
| sparse_test_sparse_cholesky | OK | PASS | syntax OK |

Full sparse suite (30 tests) passes at `MTL5_NUM_THREADS=4`.

## Test plan
- [ ] Fast CI (8 platforms) + threaded + TSan lanes pass
- [ ] Promote to ready: `gh pr ready`

Resolves #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)