### PR TITLE
perf(sparse): level-schedule the supernodal LU solve (#297 batch 8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,6 +300,7 @@ jobs:
           --target op_test_gemm_mt op_test_factorization_mt
           sparse_test_trisolve_level_schedule_mt
           sparse_test_supernodal_ldlt_mt
+          sparse_test_supernodal_lu_mt
 
       - name: Run mt tests under TSan (MTL5_NUM_THREADS=4)
         run: ctest --test-dir build-tsan -R _mt --output-on-failure

--- a/include/mtl/sparse/factorization/supernodal_lu.hpp
+++ b/include/mtl/sparse/factorization/supernodal_lu.hpp
@@ -42,6 +42,7 @@
 #include <mtl/sparse/util/permutation.hpp>
 #include <mtl/sparse/analysis/column_etree.hpp>
 #include <mtl/sparse/factorization/triangular_solve.hpp>
+#include <mtl/sparse/factorization/level_schedule.hpp>
 #include <mtl/sparse/factorization/sparse_lu.hpp>   // lu_symbolic conventions, accumulator_traits
 #include <mtl/sparse/iterative_refine.hpp>
 
@@ -61,8 +62,6 @@ struct supernodal_lu_symbolic {
 /// lu_numeric, plus the dynamic L-supernode boundaries).
 template <typename Value>
 struct supernodal_lu_factor {
-    util::csc_matrix<Value>  L;            // unit lower (CSC), diagonal first
-    util::csc_matrix<Value>  U;            // upper (CSC), diagonal last
     std::vector<std::size_t> row_perm;     // pivoting row order (p[new]=old)
     std::vector<std::size_t> row_pinv;     // inverse
     std::vector<std::size_t> lsuper_first; // dynamic L-supernode boundaries (size nsuper+1)
@@ -74,9 +73,42 @@ struct supernodal_lu_factor {
     std::size_t num_cols() const { return symbolic.n; }
     std::size_t nsuper()   const { return lsuper_first.empty() ? 0 : lsuper_first.size() - 1; }
 
+    /// Read-only access to the unit lower factor L and the upper factor U (CSC).
+    const util::csc_matrix<Value>& factorL() const { return L_; }
+    const util::csc_matrix<Value>& factorU() const { return U_; }
+
+    /// Install the factors (unit lower L diagonal-first, upper U diagonal-last)
+    /// and (re)build the coupled forward (L z = w) and upper (U y = z) solve
+    /// schedules from them. L, U and the schedules are always set together, so the
+    /// schedules' cached structure always matches the factors' patterns. Strongly
+    /// exception safe: the schedules are built into locals before any member is
+    /// replaced. Requires `symbolic` installed first (validates against symbolic.n).
+    void set_factor(util::csc_matrix<Value> L, util::csc_matrix<Value> U) {
+        const std::size_t n = symbolic.n;
+        if (static_cast<std::size_t>(L.ncols) != n || static_cast<std::size_t>(L.nrows) != n ||
+            static_cast<std::size_t>(U.ncols) != n || static_cast<std::size_t>(U.nrows) != n)
+            throw std::invalid_argument(
+                "supernodal_lu_factor::set_factor: factor dimensions do not match "
+                "the symbolic analysis");
+        lower_solve_schedule fsched = build_lower_solve_schedule(L);   // may throw
+        upper_solve_schedule usched = build_upper_solve_schedule(U);   // may throw
+        L_ = std::move(L);            // noexcept
+        U_ = std::move(U);            // noexcept
+        fwd_sched_ = std::move(fsched);  // noexcept
+        up_sched_  = std::move(usched);  // noexcept
+        has_factor_ = true;              // commit last: solve() is now valid
+    }
+
     /// Solve A*x = b.  P*A*Q = L*U (identical to lu_numeric::solve).
     template <typename VecX, typename VecB>
     void solve(VecX& x, const VecB& b) const {
+        // A caller can set `symbolic` (n > 0) yet never install factors; the
+        // triangular solves below would then read empty factor arrays. Reject
+        // that explicitly instead of walking off the end.
+        if (!has_factor_)
+            throw std::logic_error(
+                "supernodal_lu_factor::solve: no factor installed (call set_factor "
+                "or supernodal_lu_numeric first)");
         const std::size_t n = symbolic.n;
         if (static_cast<std::size_t>(x.size()) != n ||
             static_cast<std::size_t>(b.size()) != n) {
@@ -92,11 +124,20 @@ struct supernodal_lu_factor {
             const std::size_t orow = row_perm[i];
             w[i] = static_cast<Value>(b(orow)) * (scaled ? row_scale[orow] : Value{1});
         }
-        dense_lower_solve(L, w);                               // L z = P (R b)
-        dense_upper_solve(U, w);                               // U y = z
+        // L z = P (R b), then U y = z. Level-scheduled (parallel, bit-identical to
+        // dense_lower_solve / dense_upper_solve); serial at MTL5_NUM_THREADS=1.
+        level_scheduled_lower_solve(L_, fwd_sched_, w);
+        level_scheduled_upper_solve(U_, up_sched_, w);
         for (std::size_t i = 0; i < n; ++i)
             x(symbolic.col_perm[i]) = static_cast<typename VecX::value_type>(w[i]);
     }
+
+private:
+    util::csc_matrix<Value> L_;          // unit lower (CSC), diagonal first
+    util::csc_matrix<Value> U_;          // upper (CSC), diagonal last
+    lower_solve_schedule    fwd_sched_;  // forward (L z = w) schedule, bound to L_
+    upper_solve_schedule    up_sched_;   // upper  (U y = z) schedule, bound to U_
+    bool                    has_factor_ = false;  // set by set_factor; solve() requires it
 };
 
 /// Symbolic supernodal LU analysis with a fill-reducing column ordering.
@@ -480,8 +521,8 @@ supernodal_lu_factor<Value> supernodal_lu_numeric(
         }
         return M;
     };
-    result.L = to_csc(Lp, Li, Lx);
-    result.U = to_csc(Up, Ui, Ux);
+    // Install L and U and build the coupled solve schedules atomically.
+    result.set_factor(to_csc(Lp, Li, Lx), to_csc(Up, Ui, Ux));
     return result;
 }
 
@@ -511,26 +552,28 @@ supernodal_lu_factor<Value> supernodal_lu_refactor(
     using std::abs;
     auto C = util::crs_to_csc(util::column_permute(A, prev.symbolic.col_perm));
     const auto& pinv = prev.row_pinv;        // original row -> pivot position (fixed)
-    supernodal_lu_factor<Value> result = prev;   // reuse pattern + perms + symbolic + supernodes
-    result.num_perturbed = 0;                    // refactor replays values without perturbing (throws on zero pivot)
 
     // If the prior factorization was row-equilibrated, re-equilibrate the new
     // values (same pattern) and factor R*A; solve() row-scales the RHS by R.
+    std::vector<Value> row_scale;            // empty unless prev was equilibrated
     if (!prev.row_scale.empty()) {
         std::vector<Value> rmax(n, Value{0});
         for (size_type p = 0; p < C.values.size(); ++p) {
             Value a = abs(C.values[p]);
             if (a > rmax[C.row_ind[p]]) rmax[C.row_ind[p]] = a;
         }
-        result.row_scale.assign(n, Value{1});
+        row_scale.assign(n, Value{1});
         for (size_type r = 0; r < n; ++r)
-            if (rmax[r] > Value{0}) result.row_scale[r] = Value{1} / rmax[r];
+            if (rmax[r] > Value{0}) row_scale[r] = Value{1} / rmax[r];
         for (size_type p = 0; p < C.values.size(); ++p)
-            C.values[p] *= result.row_scale[C.row_ind[p]];
+            C.values[p] *= row_scale[C.row_ind[p]];
     }
 
-    auto& L = result.L;                      // overwrite values in place
-    auto& U = result.U;
+    // Local mutable copies of the prior factors: same pattern, values recomputed
+    // in place below, then installed via set_factor (which rebuilds the coupled
+    // solve schedules). refactor throws on a zero pivot; no perturbation.
+    auto L = prev.factorL();
+    auto U = prev.factorU();
 
     std::vector<Value> x(n, Value{0});
     for (size_type k = 0; k < n; ++k) {
@@ -568,6 +611,17 @@ supernodal_lu_factor<Value> supernodal_lu_refactor(
         for (size_type p = L.col_ptr[k]; p < L.col_ptr[k + 1]; ++p) x[L.row_ind[p]] = Value{0};
         for (size_type p = C.col_ptr[k]; p < C.col_ptr[k + 1]; ++p) x[pinv[C.row_ind[p]]] = Value{0};
     }
+
+    // Reuse the prior symbolic analysis, permutations, and supernode boundaries;
+    // install the recomputed factors, which rebuilds the coupled solve schedules.
+    supernodal_lu_factor<Value> result;
+    result.symbolic = prev.symbolic;
+    result.row_perm = prev.row_perm;
+    result.row_pinv = prev.row_pinv;
+    result.lsuper_first = prev.lsuper_first;
+    result.row_scale = std::move(row_scale);
+    result.num_perturbed = 0;    // refactor replays values without perturbing (throws on zero pivot)
+    result.set_factor(std::move(L), std::move(U));
     return result;
 }
 

--- a/tests/unit/sparse/test_supernodal_lu.cpp
+++ b/tests/unit/sparse/test_supernodal_lu.cpp
@@ -114,8 +114,8 @@ TEST_CASE("Supernodal LU refactor reuses the pattern", "[sparse][lu][supernodal]
     REQUIRE(rel_residual(A2, xr, b) < 1e-11);
 
     // Pattern preserved and result matches a fresh factor of A2.
-    REQUIRE(re.L.col_ptr == fac.L.col_ptr);
-    REQUIRE(re.U.col_ptr == fac.U.col_ptr);
+    REQUIRE(re.factorL().col_ptr == fac.factorL().col_ptr);
+    REQUIRE(re.factorU().col_ptr == fac.factorU().col_ptr);
     auto fresh = factorization::supernodal_lu_numeric(A2, sym);
     vec::dense_vector<double> xf(n, 0.0); fresh.solve(xf, b);
     for (std::size_t i = 0; i < n; ++i)

--- a/tests/unit/sparse/test_supernodal_lu_mt.cpp
+++ b/tests/unit/sparse/test_supernodal_lu_mt.cpp
@@ -1,0 +1,159 @@
+// Threaded supernodal LU solve (#297 batch 8). The supernodal LU factor's solve
+// routes its lower / upper triangular solves through the level-scheduled kernels
+// (level_scheduled_lower_solve / level_scheduled_upper_solve), which are proven
+// bit-identical to the serial dense_lower_solve / dense_upper_solve in batches
+// 3/5. Here we verify the composed supernodal solve is BIT-IDENTICAL to the same
+// solve driven by the dense kernels on the identical factor (same L, U, row and
+// column permutations, row scaling), so the parallel path changes nothing but
+// the schedule. The permutation / scaling steps are unchanged serial loops, so
+// exact equality (==) is the correct bar.
+//
+// Sets MTL5_NUM_THREADS before the pool's first use (the only in-process way to
+// exercise the threading -- CI otherwise runs serial). Run under TSan
+// (-DMTL5_SANITIZE=thread) to race-check the parallel levels.
+#include <catch2/catch_test_macros.hpp>
+
+#include <cmath>
+#include <cstddef>
+#include <cstdlib>
+#include <stdexcept>
+#include <vector>
+
+#include <mtl/mat/compressed2D.hpp>
+#include <mtl/mat/inserter.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/sparse/factorization/supernodal_lu.hpp>
+#include <mtl/sparse/factorization/triangular_solve.hpp>
+#include <mtl/sparse/ordering/colamd.hpp>
+#include <mtl/detail/thread_pool.hpp>
+
+using namespace mtl;
+using namespace mtl::sparse;
+
+namespace {
+
+const int g_set_threads = [] {
+#if defined(_WIN32)
+    _putenv_s("MTL5_NUM_THREADS", "4");
+#else
+    setenv("MTL5_NUM_THREADS", "4", /*overwrite=*/1);
+#endif
+    return 0;
+}();
+
+// Unsymmetric, diagonally dominant banded matrix (nonsingular, LU-stable):
+// diag 8, sub-diagonals -1 and -0.5, super-diagonal -2. |off| = 3.5 < 8.
+mat::compressed2D<double> make_unsym_banded(std::size_t n) {
+    mat::compressed2D<double> A(n, n);
+    mat::inserter<mat::compressed2D<double>> ins(A);
+    for (std::size_t i = 0; i < n; ++i) {
+        ins[i][i] << 8.0;
+        if (i >= 1)     ins[i][i - 1] << -1.0;
+        if (i >= 2)     ins[i][i - 2] << -0.5;
+        if (i + 1 < n)  ins[i][i + 1] << -2.0;
+    }
+    return A;
+}
+
+// Unsymmetric 5-point-style stencil on a g x g grid (n = g*g): asymmetric
+// neighbor weights so L != U^T, with genuine fill / multi-level structure.
+// diag 8; up -1, down -2, left -1, right -2 => |off| <= 6 < 8 (dominant).
+mat::compressed2D<double> make_unsym_grid(std::size_t g) {
+    std::size_t n = g * g;
+    mat::compressed2D<double> A(n, n);
+    mat::inserter<mat::compressed2D<double>> ins(A);
+    auto id = [g](std::size_t r, std::size_t c) { return r * g + c; };
+    for (std::size_t r = 0; r < g; ++r)
+        for (std::size_t c = 0; c < g; ++c) {
+            std::size_t i = id(r, c);
+            ins[i][i] << 8.0;
+            if (r >= 1)     ins[i][id(r - 1, c)] << -1.0;
+            if (r + 1 < g)  ins[i][id(r + 1, c)] << -2.0;
+            if (c >= 1)     ins[i][id(r, c - 1)] << -1.0;
+            if (c + 1 < g)  ins[i][id(r, c + 1)] << -2.0;
+        }
+    return A;
+}
+
+vec::dense_vector<double> make_rhs(std::size_t n) {
+    vec::dense_vector<double> b(n);
+    for (std::size_t i = 0; i < n; ++i)
+        b(static_cast<int>(i)) = 0.5 + std::sin(0.9 * static_cast<double>(i));
+    return b;
+}
+
+// Reference solve using the serial dense kernels on the SAME factor (identical
+// L, U, permutations, row scaling) that the threaded solve uses.
+template <typename Value>
+std::vector<double> dense_reference_solve(
+    const factorization::supernodal_lu_factor<Value>& fac,
+    const vec::dense_vector<double>& b)
+{
+    const std::size_t n = fac.num_rows();
+    const auto& L  = fac.factorL();
+    const auto& U  = fac.factorU();
+    const auto& rp = fac.row_perm;
+    const auto& rs = fac.row_scale;
+    const auto& cp = fac.symbolic.col_perm;
+
+    std::vector<Value> w(n);
+    const bool scaled = !rs.empty();
+    for (std::size_t i = 0; i < n; ++i) {
+        const std::size_t orow = rp[i];
+        w[i] = static_cast<Value>(b(static_cast<int>(orow))) * (scaled ? rs[orow] : Value{1});
+    }
+    factorization::dense_lower_solve(L, w);
+    factorization::dense_upper_solve(U, w);
+
+    std::vector<double> x(n);
+    for (std::size_t i = 0; i < n; ++i) x[cp[i]] = static_cast<double>(w[i]);
+    return x;
+}
+
+// Factor A, then assert the threaded solve == the dense-kernel reference,
+// bit-for-bit, for the same factor.
+void require_supernodal_lu_solve_bit_identical(const mat::compressed2D<double>& A) {
+    const std::size_t n = A.num_rows();
+    auto b = make_rhs(n);
+
+    auto sym = factorization::supernodal_lu_symbolic_analyze(A, ordering::colamd{});
+    auto fac = factorization::supernodal_lu_numeric(A, sym);
+
+    const auto ref = dense_reference_solve(fac, b);
+
+    vec::dense_vector<double> x(n);
+    fac.solve(x, b);
+
+    for (std::size_t i = 0; i < n; ++i)
+        REQUIRE(x(static_cast<int>(i)) == ref[i]);   // exact equality
+}
+
+} // namespace
+
+TEST_CASE("supernodal LU threaded solve == dense-kernel reference",
+          "[sparse][supernodal][lu][threading][mt]") {
+    if (mtl::detail::thread_pool::instance().size() < 2)
+        WARN("single-core runner: threading not exercised");
+
+    require_supernodal_lu_solve_bit_identical(make_unsym_banded(500));
+    require_supernodal_lu_solve_bit_identical(make_unsym_grid(40));   // n=1600, real fill
+    require_supernodal_lu_solve_bit_identical(make_unsym_grid(60));   // n=3600, deeper levels
+}
+
+TEST_CASE("supernodal LU threaded solve boundary cases",
+          "[sparse][supernodal][lu][threading][mt][edge]") {
+    require_supernodal_lu_solve_bit_identical(make_unsym_banded(1));  // 1x1
+    require_supernodal_lu_solve_bit_identical(make_unsym_banded(2));  // 2x2
+}
+
+// A factor with `symbolic` installed (n > 0) but no factor must reject solve
+// rather than read empty factor arrays (#307 pattern).
+TEST_CASE("supernodal LU solve rejects a missing factor",
+          "[sparse][supernodal][lu][edge]") {
+    factorization::supernodal_lu_factor<double> fac;
+    fac.symbolic.n = 3;                       // symbolic set, set_factor never called
+    fac.row_perm = {0, 1, 2};                 // present but irrelevant: guard fires first
+    vec::dense_vector<double> x(3), b(3);
+    for (int i = 0; i < 3; ++i) b(i) = 1.0;
+    REQUIRE_THROWS_AS(fac.solve(x, b), std::logic_error);
+}


### PR DESCRIPTION
## Summary
Batch 8 of the on-node threading rollout (#297): route the **supernodal** LU solve through the level-scheduled lower/upper triangular kernels (from batches 3/5), and encapsulate the factor the same way as the point LU (#304).

- `supernodal_lu_factor::solve` now calls `level_scheduled_lower_solve` / `level_scheduled_upper_solve` instead of the serial `dense_lower_solve` / `dense_upper_solve`. The kernels are bit-identical to the dense solves, so the parallel path changes nothing but the schedule; the row/column permutation and row-scaling steps stay serial.
- `L`/`U` are now **private**, installed together with their coupled forward/upper schedules via a validating, strongly-exception-safe `set_factor(L, U)`; `factorL()` / `factorU()` give read-only access. `solve()` also carries the #307 guard (a `std::logic_error` when no factor is installed, before any factor access).
- `supernodal_lu_refactor` is restructured to recompute values on local copies of the prior pattern, then re-install via `set_factor` — the value-agnostic schedules are rebuilt for the new values (mirrors `sparse_lu_refactor`).

## Changes
- `include/mtl/sparse/factorization/supernodal_lu.hpp` — privatize `L_`/`U_` + schedules, add `set_factor`/`factorL`/`factorU`, route `solve` through the level-scheduled kernels + guard, install via `set_factor` in the numeric factory, restructure `supernodal_lu_refactor`.
- `tests/unit/sparse/test_supernodal_lu_mt.cpp` — new: factor unsymmetric diagonally-dominant systems (banded, 2D asymmetric stencil n=1600/3600) with COLAMD, assert the threaded solve is **bit-identical (`==`)** to the dense-kernel reference; plus 1×1/2×2 boundaries and the missing-factor guard.
- `tests/unit/sparse/test_supernodal_lu.cpp` — use the `factorL()`/`factorU()` accessors.
- `.github/workflows/ci.yml` — register `sparse_test_supernodal_lu_mt` in the ThreadSanitizer lane.

## Test Results (local)
| Target | gcc build | gcc test | clang | TSan |
|--------|-----------|----------|-------|------|
| sparse_test_supernodal_lu | OK | PASS | syntax OK | — |
| sparse_test_supernodal_lu_mt | OK | PASS (MTL5_NUM_THREADS=4) | syntax OK | clean, 5704 assertions |

Full sparse suite (31 tests) passes at `MTL5_NUM_THREADS=4`.

## Test plan
- [ ] Fast CI (8 platforms) + threaded + TSan lanes pass
- [ ] Promote to ready: `gh pr ready`

Relates to #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)