### PR TITLE
perf(operation): BLIS multi-loop (2D) GEMM parallelism (#297 batch 9)

### DIFF
--- a/include/mtl/detail/gemm_blocked.hpp
+++ b/include/mtl/detail/gemm_blocked.hpp
@@ -20,18 +20,26 @@
 // Edge tiles (trailing rows < mr or cols < nr) are accumulated through a zeroed
 // mr x nr temporary so the micro-kernel only ever writes full tiles.
 //
-// Multithreading (#92, no OpenMP -- the C++ standard concurrency runtime): the
-// `ic` loop is partitioned across a std::thread team. For a fixed (jc, pc) the
-// ic-blocks write DISJOINT C row ranges and only READ the shared packed B panel,
-// so there is no race; each thread keeps its own packed-A buffer. Because every
-// C block receives the same FMAs in the same order regardless of which thread
-// runs it (and the pc loop stays sequential), the threaded result is
-// BIT-IDENTICAL to the single-thread result. Thread count comes from
-// gemm_default_threads() (env MTL5_NUM_THREADS; default 1 = unchanged).
+// Multithreading (#92 + #297 batch 9, no OpenMP -- the C++ standard concurrency
+// runtime): BLIS "multi-loop" 2D parallelism over a jc_nt x ic_nt thread grid.
+// The n-dimension jc-blocks are partitioned across jc_nt teams; within each team
+// the m-dimension ic-blocks are partitioned across ic_nt threads. A team's
+// designated leader (ic_id == 0) packs the shared B panel B(pc,jc) once; the team
+// members synchronize on a per-team barrier, then each packs its own A block and
+// writes its DISJOINT C rows -- no race on C, one packed-B per team instead of
+// per ic-block. The grid degenerates to the pure ic-parallel case (jc_nt == 1)
+// for tall/square problems and to pure jc-parallel (ic_nt == 1) for wide/short
+// ones, whichever the shape can fill. Because every C macro-block receives the
+// same FMAs in the same order regardless of which (jc_id, ic_id) thread runs it,
+// and the pc loop stays sequential per block, the threaded result is
+// BIT-IDENTICAL to the single-thread result for ANY grid shape. Thread count
+// comes from gemm_default_threads() (env MTL5_NUM_THREADS; default 1 = serial).
 
 #include <algorithm>
+#include <atomic>
 #include <cstddef>
 #include <cstdlib>
+#include <memory>
 #include <thread>
 #include <vector>
 
@@ -54,6 +62,34 @@ using packed_buffer = std::vector<T, aligned_allocator<T>>;
 inline unsigned gemm_default_threads() {
     return thread_pool::instance().size();
 }
+
+/// Reusable sense-reversing barrier for a fixed party count. Used to synchronize
+/// the ic-threads of one jc-team around their shared packed-B panel: the leader
+/// packs B, all wait (publish), the team computes, all wait again (so the leader
+/// does not overwrite B for the next pc while members still read it). The
+/// release/acquire on `sense_` establishes happens-before from the leader's pack
+/// to the members' reads (and from members' reads back to the leader's repack).
+/// parties <= 1 makes wait() a no-op (single-member team). The pool never nests,
+/// so this is the only synchronization inside a GEMM parallel region.
+class gemm_barrier {
+public:
+    explicit gemm_barrier(unsigned parties) noexcept : parties_(parties) {}
+    void wait() noexcept {
+        if (parties_ <= 1) return;
+        const unsigned s = sense_.load(std::memory_order_relaxed);
+        if (arrived_.fetch_add(1, std::memory_order_acq_rel) + 1 == parties_) {
+            arrived_.store(0, std::memory_order_relaxed);   // reset BEFORE the flip
+            sense_.store(s + 1, std::memory_order_release); // publish + release spinners
+        } else {
+            while (sense_.load(std::memory_order_acquire) == s)
+                std::this_thread::yield();
+        }
+    }
+private:
+    const unsigned parties_;
+    std::atomic<unsigned> arrived_{0};
+    std::atomic<unsigned> sense_{0};
+};
 
 /// C[m x n] (row-major, leading dim ldc) := beta*C + alpha * A[m x k] * B[k x n].
 /// A,B addressed by generic strides (see file header). ldc must be >= n.
@@ -87,96 +123,144 @@ void gemm_blocked(std::size_t m, std::size_t n, std::size_t k,
 
     if (m == 0 || n == 0 || k == 0) return;
 
-    // Scratch for one packed A block (mc x kc) and one packed B panel (kc x nc),
-    // sized to the largest block actually used (clamped to the problem) so small
-    // problems don't allocate full-MC/KC/NC buffers. Reused across the nest.
     const std::size_t kc_max = std::min(KC, k);
     const std::size_t mc_max = std::min(MC, m);
     const std::size_t nc_max = std::min(NC, n);
-    packed_buffer<TAB> Ac(packed_A_size(mc_max, kc_max, MR));
-    packed_buffer<TAB> Bc(packed_B_size(kc_max, nc_max, NR));
 
-    for (std::size_t jc = 0; jc < n; jc += NC) {
-        const std::size_t nci = std::min(NC, n - jc);
-        const std::size_t npanels = (nci + NR - 1) / NR;
-        for (std::size_t pc = 0; pc < k; pc += KC) {
-            const std::size_t kci = std::min(KC, k - pc);
-            pack_B<TAB, NR>(B + static_cast<std::ptrdiff_t>(pc) * b_rs
-                              + static_cast<std::ptrdiff_t>(jc) * b_cs,
-                            b_rs, b_cs, kci, nci, Bc.data());
+    // One ic-block: pack A(ic,pc) into `Acbuf`, then run the jr/ir macro over the
+    // shared packed-B panel `Bpack` into this block's (disjoint) C rows. `Acbuf`
+    // and `Bpack` are caller-owned so each thread/team passes its own buffers.
+    auto do_ic_block = [&](std::size_t ic, std::size_t jc, std::size_t nci,
+                           std::size_t npanels, std::size_t kci, std::size_t pc,
+                           const TAB* Bpack, TAB* Acbuf) {
+        const std::size_t mci = std::min(MC, m - ic);
+        pack_A<TAB, MR>(A + static_cast<std::ptrdiff_t>(ic) * a_rs
+                          + static_cast<std::ptrdiff_t>(pc) * a_cs,
+                        a_rs, a_cs, mci, kci, Acbuf);
+        if (!(alpha == TC(1))) {                          // fold alpha into A panel (operand precision)
+            const std::size_t na = packed_A_size(mci, kci, MR);
+            for (std::size_t t = 0; t < na; ++t)
+                Acbuf[t] = static_cast<TAB>(alpha * static_cast<TC>(Acbuf[t]));
+        }
 
-            // One ic-block: pack A(ic,pc) into `Acbuf`, then run the jr/ir macro
-            // over the shared Bc into this block's (disjoint) C rows. `Acbuf` is
-            // caller-owned so each thread can pass its own buffer.
-            auto do_ic_block = [&](std::size_t ic, TAB* Acbuf) {
-                const std::size_t mci = std::min(MC, m - ic);
-                pack_A<TAB, MR>(A + static_cast<std::ptrdiff_t>(ic) * a_rs
-                                  + static_cast<std::ptrdiff_t>(pc) * a_cs,
-                                a_rs, a_cs, mci, kci, Acbuf);
-                if (!(alpha == TC(1))) {                      // fold alpha into A panel (operand precision)
-                    const std::size_t na = packed_A_size(mci, kci, MR);
-                    for (std::size_t t = 0; t < na; ++t)
-                        Acbuf[t] = static_cast<TAB>(alpha * static_cast<TC>(Acbuf[t]));
+        const std::size_t mpanels = (mci + MR - 1) / MR;
+        TC* Cmacro = C + static_cast<std::ptrdiff_t>(ic) * static_cast<std::ptrdiff_t>(ldc)
+                       + static_cast<std::ptrdiff_t>(jc);
+        for (std::size_t jr = 0; jr < npanels; ++jr) {
+            const std::size_t nr_eff = std::min(NR, nci - jr * NR);
+            const TAB* Bpanel = Bpack + jr * (NR * kci);
+            for (std::size_t ir = 0; ir < mpanels; ++ir) {
+                const std::size_t mr_eff = std::min(MR, mci - ir * MR);
+                const TAB* Apanel = Acbuf + ir * (MR * kci);
+                TC* Cblock = Cmacro + (ir * MR) * ldc + jr * NR;
+                if (mr_eff == MR && nr_eff == NR) {
+                    gemm_microkernel<TC, TAB, MR, NR>(kci, Apanel, Bpanel, Cblock, ldc);
+                } else {
+                    // Edge: accumulate through a zeroed full mr x nr tile so the
+                    // micro-kernel's full-tile load/store stays in bounds.
+                    TC tile[MR * NR];
+                    for (std::size_t t = 0; t < MR * NR; ++t) tile[t] = TC(0);
+                    for (std::size_t i = 0; i < mr_eff; ++i)
+                        for (std::size_t j = 0; j < nr_eff; ++j)
+                            tile[i * NR + j] = Cblock[i * ldc + j];
+                    gemm_microkernel<TC, TAB, MR, NR>(kci, Apanel, Bpanel, tile, NR);
+                    for (std::size_t i = 0; i < mr_eff; ++i)
+                        for (std::size_t j = 0; j < nr_eff; ++j)
+                            Cblock[i * ldc + j] = tile[i * NR + j];
                 }
-
-                const std::size_t mpanels = (mci + MR - 1) / MR;
-                TC* Cmacro = C + static_cast<std::ptrdiff_t>(ic) * static_cast<std::ptrdiff_t>(ldc)
-                               + static_cast<std::ptrdiff_t>(jc);
-                for (std::size_t jr = 0; jr < npanels; ++jr) {
-                    const std::size_t nr_eff = std::min(NR, nci - jr * NR);
-                    const TAB* Bpanel = Bc.data() + jr * (NR * kci);
-                    for (std::size_t ir = 0; ir < mpanels; ++ir) {
-                        const std::size_t mr_eff = std::min(MR, mci - ir * MR);
-                        const TAB* Apanel = Acbuf + ir * (MR * kci);
-                        TC* Cblock = Cmacro + (ir * MR) * ldc + jr * NR;
-                        if (mr_eff == MR && nr_eff == NR) {
-                            gemm_microkernel<TC, TAB, MR, NR>(kci, Apanel, Bpanel, Cblock, ldc);
-                        } else {
-                            // Edge: accumulate through a zeroed full mr x nr tile so
-                            // the micro-kernel's full-tile load/store stays in bounds.
-                            TC tile[MR * NR];
-                            for (std::size_t t = 0; t < MR * NR; ++t) tile[t] = TC(0);
-                            for (std::size_t i = 0; i < mr_eff; ++i)
-                                for (std::size_t j = 0; j < nr_eff; ++j)
-                                    tile[i * NR + j] = Cblock[i * ldc + j];
-                            gemm_microkernel<TC, TAB, MR, NR>(kci, Apanel, Bpanel, tile, NR);
-                            for (std::size_t i = 0; i < mr_eff; ++i)
-                                for (std::size_t j = 0; j < nr_eff; ++j)
-                                    Cblock[i * ldc + j] = tile[i * NR + j];
-                        }
-                    }
-                }
-            };
-
-            if (nthreads <= 1) {
-                for (std::size_t ic = 0; ic < m; ic += MC)   // single-thread: shared Ac (unchanged)
-                    do_ic_block(ic, Ac.data());
-            } else {
-                // Parallel over ic-blocks: disjoint C rows, shared read-only Bc,
-                // per-thread A buffer. Static round-robin assignment, dispatched
-                // on the persistent thread pool -- one condition-variable handoff
-                // per (jc,pc) region instead of spawning a fresh std::thread team.
-                // The static tid->ic-block partition is unchanged, so the result
-                // stays BIT-IDENTICAL across thread counts. An exception in any
-                // ic-block propagates after all workers join (see thread_pool).
-                std::vector<std::size_t> ic_starts;
-                for (std::size_t ic = 0; ic < m; ic += MC) ic_starts.push_back(ic);
-                // team is BOTH the round-robin stride and the count handed to the
-                // pool, so it must not exceed the pool size -- otherwise run()
-                // would clamp the worker count while the stride still skipped the
-                // higher-tid ic-blocks. Capping keeps every block covered.
-                thread_pool& pool = thread_pool::instance();
-                const unsigned team = static_cast<unsigned>(std::min<std::size_t>(
-                    {static_cast<std::size_t>(nthreads), ic_starts.size(),
-                     static_cast<std::size_t>(pool.size())}));
-                pool.run(team, [&](unsigned tid) {
-                    packed_buffer<TAB> Aloc(packed_A_size(mc_max, kc_max, MR));
-                    for (std::size_t b = tid; b < ic_starts.size(); b += team)
-                        do_ic_block(ic_starts[b], Aloc.data());
-                });
             }
         }
-    }
+    };
+
+    // Serial nest (also the fallback when the grid degenerates to one worker):
+    // shared Ac/Bc buffers, jc -> pc -> ic exactly as the classic 5-loop order.
+    auto serial_nest = [&]() {
+        packed_buffer<TAB> Ac(packed_A_size(mc_max, kc_max, MR));
+        packed_buffer<TAB> Bc(packed_B_size(kc_max, nc_max, NR));
+        for (std::size_t jc = 0; jc < n; jc += NC) {
+            const std::size_t nci = std::min(NC, n - jc);
+            const std::size_t npanels = (nci + NR - 1) / NR;
+            for (std::size_t pc = 0; pc < k; pc += KC) {
+                const std::size_t kci = std::min(KC, k - pc);
+                pack_B<TAB, NR>(B + static_cast<std::ptrdiff_t>(pc) * b_rs
+                                  + static_cast<std::ptrdiff_t>(jc) * b_cs,
+                                b_rs, b_cs, kci, nci, Bc.data());
+                for (std::size_t ic = 0; ic < m; ic += MC)
+                    do_ic_block(ic, jc, nci, npanels, kci, pc, Bc.data(), Ac.data());
+            }
+        }
+    };
+
+    if (nthreads <= 1) { serial_nest(); return; }
+
+    // Block-start lists for the m (ic) and n (jc) dimensions.
+    std::vector<std::size_t> ic_starts, jc_starts;
+    for (std::size_t ic = 0; ic < m; ic += MC) ic_starts.push_back(ic);
+    for (std::size_t jc = 0; jc < n; jc += NC) jc_starts.push_back(jc);
+    const std::size_t nib = ic_starts.size();
+    const std::size_t njb = jc_starts.size();
+
+    // Thread budget: never exceed the pool. pool.run() clamps its worker count to
+    // the pool size, so a grid sized past the pool would leave team members that
+    // never run -- and their barrier would wait forever (deadlock). Cap here.
+    thread_pool& pool = thread_pool::instance();
+    const unsigned budget = std::min(nthreads, pool.size());
+    if (budget <= 1) { serial_nest(); return; }
+
+    // 2D grid factorization (deterministic; affects performance, not results).
+    // Fill the ic loop first (keeps the shared B panel resident and maximizes its
+    // reuse), then hand any leftover threads to the jc loop. Re-expand ic with
+    // whatever remains so the grid uses as many threads as the shape allows.
+    // grid = ic_nt * jc_nt <= budget <= pool size (surplus threads stay idle).
+    unsigned ic_nt = static_cast<unsigned>(std::min<std::size_t>(budget, nib));
+    if (ic_nt < 1) ic_nt = 1;
+    unsigned jc_nt = static_cast<unsigned>(std::min<std::size_t>(budget / ic_nt, njb));
+    if (jc_nt < 1) jc_nt = 1;
+    ic_nt = static_cast<unsigned>(std::min<std::size_t>(budget / jc_nt, nib));
+    if (ic_nt < 1) ic_nt = 1;
+    const unsigned grid = ic_nt * jc_nt;
+
+    if (grid <= 1) { serial_nest(); return; }
+
+    // Pre-allocate ALL scratch outside the parallel region: one packed-B per
+    // jc-team (shared within the team), one packed-A per grid thread, and one
+    // barrier per team. Doing every allocation here means the region itself
+    // never allocates -- so for the float/double fast path it cannot throw, and
+    // a thread can never miss a barrier (which would deadlock the team).
+    std::vector<packed_buffer<TAB>> team_B;   team_B.reserve(jc_nt);
+    for (unsigned j = 0; j < jc_nt; ++j) team_B.emplace_back(packed_B_size(kc_max, nc_max, NR));
+    std::vector<packed_buffer<TAB>> thr_A;    thr_A.reserve(grid);
+    for (unsigned t = 0; t < grid; ++t) thr_A.emplace_back(packed_A_size(mc_max, kc_max, MR));
+    std::vector<std::unique_ptr<gemm_barrier>> team_bar(jc_nt);
+    for (unsigned j = 0; j < jc_nt; ++j) team_bar[j] = std::make_unique<gemm_barrier>(ic_nt);
+
+    // tid -> (jc_id, ic_id): threads sharing jc_id form one jc-team of ic_nt
+    // members. Teams take jc-blocks round-robin by jc_id; members take ic-blocks
+    // round-robin by ic_id. Every (ic-block, jc-block) C macro-block is owned by
+    // exactly one thread -> disjoint writes, bit-identical to serial.
+    pool.run(grid, [&](unsigned tid) {
+        const unsigned jc_id = tid / ic_nt;
+        const unsigned ic_id = tid % ic_nt;
+        TAB* Aloc = thr_A[tid].data();
+        TAB* Bteam = team_B[jc_id].data();
+        gemm_barrier& bar = *team_bar[jc_id];
+        for (std::size_t jb = jc_id; jb < njb; jb += jc_nt) {
+            const std::size_t jc = jc_starts[jb];
+            const std::size_t nci = std::min(NC, n - jc);
+            const std::size_t npanels = (nci + NR - 1) / NR;
+            for (std::size_t pc = 0; pc < k; pc += KC) {
+                const std::size_t kci = std::min(KC, k - pc);
+                if (ic_id == 0)                                   // team leader packs shared B once
+                    pack_B<TAB, NR>(B + static_cast<std::ptrdiff_t>(pc) * b_rs
+                                      + static_cast<std::ptrdiff_t>(jc) * b_cs,
+                                    b_rs, b_cs, kci, nci, Bteam);
+                bar.wait();                                       // publish B to the team
+                for (std::size_t ib = ic_id; ib < nib; ib += ic_nt)
+                    do_ic_block(ic_starts[ib], jc, nci, npanels, kci, pc, Bteam, Aloc);
+                bar.wait();                                       // all done reading B before repack
+            }
+        }
+    });
 }
 
 } // namespace mtl::detail

--- a/include/mtl/detail/gemm_blocked.hpp
+++ b/include/mtl/detail/gemm_blocked.hpp
@@ -39,6 +39,7 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdlib>
+#include <exception>
 #include <memory>
 #include <thread>
 #include <vector>
@@ -234,6 +235,23 @@ void gemm_blocked(std::size_t m, std::size_t n, std::size_t k,
     std::vector<std::unique_ptr<gemm_barrier>> team_bar(jc_nt);
     for (unsigned j = 0; j < jc_nt; ++j) team_bar[j] = std::make_unique<gemm_barrier>(ic_nt);
 
+    // Exception safety across the barrier: a Scalar element type may throw in
+    // pack_B / do_ic_block (float/double cannot, and no allocation happens in the
+    // region, but the template is Scalar-general -- posit/LNS etc.). A worker that
+    // unwound out of the region would skip its remaining bar.wait() calls and its
+    // teammates would spin forever. So we CATCH inside the region, record the
+    // first failure atomically, skip only the *compute* on failure, and keep
+    // every bar.wait() UNCONDITIONAL so barrier participation never desyncs. The
+    // first exception is rethrown after the region joins. `first_exc` has a single
+    // writer (the CAS winner) and is published to the caller by the pool's join.
+    std::atomic<bool> failed{false};
+    std::exception_ptr first_exc;
+    auto record_failure = [&](std::exception_ptr e) noexcept {
+        bool expected = false;
+        if (failed.compare_exchange_strong(expected, true, std::memory_order_relaxed))
+            first_exc = e;   // single-writer; visible to the caller after run() joins
+    };
+
     // tid -> (jc_id, ic_id): threads sharing jc_id form one jc-team of ic_nt
     // members. Teams take jc-blocks round-robin by jc_id; members take ic-blocks
     // round-robin by ic_id. Every (ic-block, jc-block) C macro-block is owned by
@@ -250,17 +268,25 @@ void gemm_blocked(std::size_t m, std::size_t n, std::size_t k,
             const std::size_t npanels = (nci + NR - 1) / NR;
             for (std::size_t pc = 0; pc < k; pc += KC) {
                 const std::size_t kci = std::min(KC, k - pc);
-                if (ic_id == 0)                                   // team leader packs shared B once
-                    pack_B<TAB, NR>(B + static_cast<std::ptrdiff_t>(pc) * b_rs
-                                      + static_cast<std::ptrdiff_t>(jc) * b_cs,
-                                    b_rs, b_cs, kci, nci, Bteam);
+                if (ic_id == 0 && !failed.load(std::memory_order_relaxed)) {
+                    try {                                         // team leader packs shared B once
+                        pack_B<TAB, NR>(B + static_cast<std::ptrdiff_t>(pc) * b_rs
+                                          + static_cast<std::ptrdiff_t>(jc) * b_cs,
+                                        b_rs, b_cs, kci, nci, Bteam);
+                    } catch (...) { record_failure(std::current_exception()); }
+                }
                 bar.wait();                                       // publish B to the team
-                for (std::size_t ib = ic_id; ib < nib; ib += ic_nt)
-                    do_ic_block(ic_starts[ib], jc, nci, npanels, kci, pc, Bteam, Aloc);
+                if (!failed.load(std::memory_order_relaxed)) {
+                    try {
+                        for (std::size_t ib = ic_id; ib < nib; ib += ic_nt)
+                            do_ic_block(ic_starts[ib], jc, nci, npanels, kci, pc, Bteam, Aloc);
+                    } catch (...) { record_failure(std::current_exception()); }
+                }
                 bar.wait();                                       // all done reading B before repack
             }
         }
     });
+    if (first_exc) std::rethrow_exception(first_exc);
 }
 
 } // namespace mtl::detail

--- a/tests/unit/operation/test_gemm_mt.cpp
+++ b/tests/unit/operation/test_gemm_mt.cpp
@@ -96,3 +96,41 @@ TEMPLATE_TEST_CASE("MT GEMM: crosses mc/kc blocks", "[operation][gemm][mt]", flo
     CHECK(mt_matches<TestType>(m, n, k, true, true, 4, TestType(1), TestType(0), 7));
     CHECK(mt_matches<TestType>(m, n, k, true, true, 8, TestType(1.25), TestType(-0.5), 9));
 }
+
+// #297 batch 9: BLIS multi-loop (2D jc_nt x ic_nt grid). A wide/short matrix has
+// few ic (mc) blocks, so the ic-only parallelization can't use all threads --
+// the jc loop must be partitioned too. Bit-identity must hold for ANY grid shape.
+TEMPLATE_TEST_CASE("MT GEMM 2D grid: wide/short spans few ic-blocks -> jc-parallel",
+                   "[operation][gemm][mt]", float, double) {
+    constexpr auto bp = mtl::simd::default_blocking<TestType>;
+    // m spans a single ic-block (nib == 1): with ic-only this would run 1 thread;
+    // the 2D grid must fall to pure jc-parallelism. n crosses nc (njb == 2) so the
+    // jc loop actually partitions (nc is L3-sized, so one crossing is plenty).
+    const std::size_t m = bp.mr + 1;               // < mc -> one ic-block
+    const std::size_t n = bp.nc + bp.nr + 1;       // 2 nc (jc) blocks
+    const std::size_t k = bp.kc + 3;               // multiple pc iterations
+    INFO("m=" << m << " n=" << n << " k=" << k << " (mc=" << bp.mc << " nc=" << bp.nc << ")");
+    for (unsigned nt : {2u, 4u}) {
+        CHECK(mt_matches<TestType>(m, n, k, true,  true,  nt, TestType(1),    TestType(0),   100 + nt));
+        CHECK(mt_matches<TestType>(m, n, k, false, true,  nt, TestType(1.5),  TestType(-0.5),200 + nt));
+    }
+}
+
+// A problem with TWO ic-blocks AND TWO jc-blocks forces a genuine 2D grid
+// (ic_nt > 1 AND jc_nt > 1 when the budget is >= 4), exercising the per-team
+// barrier and the shared packed-B panel with multi-member teams. Kept small: nc
+// is L3-sized, so just crossing it once (njb == 2) is already a wide panel;
+// nib == 2 keeps ic_nt <= 2 so the budget spills into jc_nt. Bit-identity vs
+// single-thread must hold for the resulting grid.
+TEMPLATE_TEST_CASE("MT GEMM 2D grid: rectangular exercises ic_nt>1 && jc_nt>1",
+                   "[operation][gemm][mt]", float, double) {
+    constexpr auto bp = mtl::simd::default_blocking<TestType>;
+    const std::size_t m = bp.mc + bp.mr + 1;   // 2 ic-blocks (nib == 2)
+    const std::size_t n = bp.nc + bp.nr + 1;   // 2 jc-blocks (njb == 2)
+    const std::size_t k = bp.kc + 7;           // 2 pc iterations (leader repacks B)
+    INFO("m=" << m << " n=" << n << " k=" << k << " (mc=" << bp.mc << " nc=" << bp.nc << ")");
+    for (unsigned nt : {4u, 8u}) {   // budget>=4 -> 2x2 grid; pool caps to its size
+        CHECK(mt_matches<TestType>(m, n, k, true,  true,  nt, TestType(1),    TestType(0),    300 + nt));
+        CHECK(mt_matches<TestType>(m, n, k, true,  false, nt, TestType(-0.75),TestType(1.25), 400 + nt));
+    }
+}

--- a/tests/unit/operation/test_gemm_mt.cpp
+++ b/tests/unit/operation/test_gemm_mt.cpp
@@ -110,6 +110,10 @@ TEMPLATE_TEST_CASE("MT GEMM 2D grid: wide/short spans few ic-blocks -> jc-parall
     const std::size_t n = bp.nc + bp.nr + 1;       // 2 nc (jc) blocks
     const std::size_t k = bp.kc + 3;               // multiple pc iterations
     INFO("m=" << m << " n=" << n << " k=" << k << " (mc=" << bp.mc << " nc=" << bp.nc << ")");
+    // gemm_blocked caps the grid to the pool size, so a pool < 2 would exercise
+    // only the serial fallback -- flag that the jc-parallel path went untested.
+    if (mtl::detail::thread_pool::instance().size() < 2)
+        WARN("pool < 2 workers: jc-parallel path not exercised (set MTL5_NUM_THREADS)");
     for (unsigned nt : {2u, 4u}) {
         CHECK(mt_matches<TestType>(m, n, k, true,  true,  nt, TestType(1),    TestType(0),   100 + nt));
         CHECK(mt_matches<TestType>(m, n, k, false, true,  nt, TestType(1.5),  TestType(-0.5),200 + nt));
@@ -129,6 +133,10 @@ TEMPLATE_TEST_CASE("MT GEMM 2D grid: rectangular exercises ic_nt>1 && jc_nt>1",
     const std::size_t n = bp.nc + bp.nr + 1;   // 2 jc-blocks (njb == 2)
     const std::size_t k = bp.kc + 7;           // 2 pc iterations (leader repacks B)
     INFO("m=" << m << " n=" << n << " k=" << k << " (mc=" << bp.mc << " nc=" << bp.nc << ")");
+    // A genuine 2x2 grid needs >= 4 pool workers; below that the grid degenerates
+    // (1D or serial) and the multi-member-team barrier path goes untested.
+    if (mtl::detail::thread_pool::instance().size() < 4)
+        WARN("pool < 4 workers: 2x2 grid not formed (set MTL5_NUM_THREADS>=4)");
     for (unsigned nt : {4u, 8u}) {   // budget>=4 -> 2x2 grid; pool caps to its size
         CHECK(mt_matches<TestType>(m, n, k, true,  true,  nt, TestType(1),    TestType(0),    300 + nt));
         CHECK(mt_matches<TestType>(m, n, k, true,  false, nt, TestType(-0.75),TestType(1.25), 400 + nt));


### PR DESCRIPTION
## Summary
Batch 9 of the on-node threading rollout (#297). The blocked GEMM already parallelized the **`ic` loop** (m-dimension) bit-identically (#92); this extends it to **BLIS multi-loop 2D parallelism** over a `jc_nt × ic_nt` thread grid so wide/short matrices — which have too few `ic`-blocks to fill the pool — scale by also partitioning the `jc` loop (n-dimension).

- The n-dimension jc-blocks are split across `jc_nt` teams; within a team the m-dimension ic-blocks are split across `ic_nt` threads.
- A team's **leader** (`ic_id == 0`) packs the shared **B panel** `B(pc,jc)` once; the team synchronizes on a per-team barrier, computes into **disjoint C rows**, then barriers again before the leader repacks for the next `pc`. One packed-B per team instead of per ic-block.
- The grid degenerates to pure `ic` parallelism (`jc_nt == 1`, tall/square) or pure `jc` (`ic_nt == 1`, wide/short), whichever the shape can fill.

**Bit-identity holds for any grid shape**: every `(ic-block, jc-block)` C macro-block is owned by exactly one thread and accumulated over `pc` sequentially → same FMAs, same order as the serial nest. The MT test asserts exact equality (`==`) vs single-thread.

## Implementation notes
The persistent pool has **no nested dispatch and no barrier primitive**, so:
- The grid runs as one flat `run(grid)` with `tid → (jc_id, ic_id)` and a hand-rolled **sense-reversing `gemm_barrier`** per jc-team. Release/acquire on the barrier publishes the leader's packed B to the team and orders the WAR hazard on the shared buffer for the next `pc`.
- The grid is **capped to the pool size** — `pool.run()` clamps its worker count, so a grid sized past the pool would leave a team member that never runs and its barrier would wait forever. (Caught during testing: an un-capped grid deadlocked at `nt > pool`.)
- **All scratch** (per-team B, per-thread A, barriers) is allocated *before* the region, so the float/double region never allocates → cannot throw → a thread can never miss a barrier.

## Changes
- `include/mtl/detail/gemm_blocked.hpp` — 2D grid nest + `gemm_barrier`; serial path factored into a `serial_nest` lambda reused when the grid degenerates to one worker.
- `tests/unit/operation/test_gemm_mt.cpp` — new cases: wide/short (pure jc-parallel) and rectangular (2 ic × 2 jc, true 2D grid, multi-member teams exercising the barrier + shared B).

The TSan CI lane already builds `op_test_gemm_mt` (unchanged target), so it picks up the new cases with no workflow change.

## Test Results (local)
| Check | Result |
|---|---|
| GCC full unit suite (153 tests, MTL5_NUM_THREADS=4) | PASS |
| GEMM/mult operation tests | PASS |
| Clang 18 syntax (test + umbrella header) | OK |
| ThreadSanitizer on `gemm_mt` (546 assertions incl. 2D multi-member teams) | clean |
| Bit-identity `==` single-thread across grid shapes & thread counts | holds |

## Test plan
- [ ] Fast CI (8 platforms) + threaded + TSan lanes pass
- [ ] Promote to ready: `gh pr ready`

Relates to #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved multithreaded matrix multiplication by distributing work across both row and column dimensions.
  * Reduced redundant data preparation during parallel calculations.

* **Bug Fixes**
  * Improved consistency and reliability of multithreaded GEMM results across different matrix shapes, thread counts, and operation settings.
  * Added coverage for wide, short, and fully two-dimensional workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->