### PR TITLE
bench(ewise): element-wise expression sweep suite (#297 phase 3)

### DIFF
--- a/benchmarks/bench_all.cpp
+++ b/benchmarks/bench_all.cpp
@@ -131,6 +131,7 @@ static void print_usage() {
         "Suites: all, blas (=l1+l2+l3), lapack,\n"
         "        l1 (dot+nrm2+axpy+scal), l2 (gemv+ger+symv+trmv+trsv), l3 (gemm+trmm+trsm+symm+syrk+syr2k),\n"
         "        gemm-rect (rectangular GEMM shapes: multi-loop 2D grid, #297),\n"
+        "        ewise (element-wise vector/matrix expression sweeps, #297),\n"
         "        dot, nrm2, axpy, scal, gemv, ger, symv, trmv, trsv,\n        gemm, trmm, trsm, symm, syrk, syr2k,\n"
         "        lu, qr, cholesky, eig\n";
 }
@@ -254,6 +255,8 @@ int main(int argc, char* argv[]) {
         b::bench_gemm(rep, label, blas_sizes);
     } else if (suite == "gemm-rect") {
         b::bench_gemm_rect(rep, label);
+    } else if (suite == "ewise") {
+        b::bench_ewise(rep, label);
     } else if (suite == "trmm") {
         b::bench_trmm(rep, label, blas_sizes);
     } else if (suite == "trsm") {

--- a/benchmarks/harness/runner.hpp
+++ b/benchmarks/harness/runner.hpp
@@ -37,6 +37,8 @@
 #include <mtl/operation/qr.hpp>
 #include <mtl/operation/cholesky.hpp>
 #include <mtl/operation/eigenvalue_symmetric.hpp>
+#include <mtl/vec/operators.hpp>   // element-wise vector expressions (a + b)
+#include <mtl/mat/operators.hpp>   // element-wise matrix expressions (A + B)
 
 namespace mtl::bench {
 
@@ -213,6 +215,45 @@ inline void bench_gemm_rect(reporter& rep, const std::string& label,
                              + std::to_string(s.n) + "x" + std::to_string(s.k);
         auto t = measure([&]{ mtl::mult(A, B, C); },
                          op, label, s.n, flops, warmup, iterations);
+        rep.add(t);
+    }
+}
+
+// Element-wise expression sweeps (#297 batch 10 / #312): y = a + b (vector) and
+// C = A + B (matrix). Pure per-index writes routed through detail::parallel_ewise
+// -- memory-bandwidth bound, so scaling ceilings at the bandwidth, not the core
+// count. The vector sweep is over the element index; the matrix sweep is
+// row-parallel, so a WIDE/short matrix (few rows) cannot split (documents the
+// #313 gap) while TALL/square shapes scale. The "gflops" column carries element
+// throughput (elements/ns), whose ratio across thread counts is the speedup.
+inline void bench_ewise(reporter& rep, const std::string& label,
+                        std::size_t warmup = 3, std::size_t iterations = 20) {
+    // Vectors: y = a + b.
+    for (std::size_t n : {std::size_t{100000}, std::size_t{1000000}, std::size_t{10000000}}) {
+        auto a = make_random_vector<double>(n);
+        auto b = make_random_vector<double>(n, 456);
+        vec::dense_vector<double> c(n);
+        const double work = static_cast<double>(n);           // 1 add / element
+        auto t = measure([&]{ c = a + b; }, "ewise-vec", label, n, work, warmup, iterations);
+        rep.add(t);
+    }
+    // Matrices: C = A + B (row-parallel sweep). Distinct nrows so analyze_scaling
+    // keys each shape separately; kind + RxC in the operation field.
+    struct shape { std::size_t r, c; const char* kind; };
+    static const shape shapes[] = {
+        {1024, 1024,   "square"},
+        {4096, 4096,   "square"},
+        {2000000,  8,  "tall"},   // many rows -> splits across the pool
+        {1, 16000000,  "wide"},   // ONE row -> row-parallel sweep runs serial (#313)
+    };
+    for (const auto& s : shapes) {
+        auto A = make_random_matrix<double>(s.r, s.c);
+        auto B = make_random_matrix<double>(s.r, s.c, 99);
+        mat::dense2D<double> C(s.r, s.c);
+        const double work = static_cast<double>(s.r) * static_cast<double>(s.c);
+        const std::string op = std::string("ewise-mat-") + s.kind + " "
+                             + std::to_string(s.r) + "x" + std::to_string(s.c);
+        auto t = measure([&]{ C = A + B; }, op, label, s.r, work, warmup, iterations);
         rep.add(t);
     }
 }

--- a/benchmarks/harness/runner.hpp
+++ b/benchmarks/harness/runner.hpp
@@ -228,13 +228,17 @@ inline void bench_gemm_rect(reporter& rep, const std::string& label,
 // throughput (elements/ns), whose ratio across thread counts is the speedup.
 inline void bench_ewise(reporter& rep, const std::string& label,
                         std::size_t warmup = 3, std::size_t iterations = 20) {
-    // Vectors: y = a + b.
+    // Vectors: y = a + b. A volatile sink reads the last element inside the timed
+    // region so an optimizer cannot elide the sweep (the output is otherwise
+    // never consumed) or hoist the loop-invariant assignment out of the loop.
+    volatile double sink = 0.0;
     for (std::size_t n : {std::size_t{100000}, std::size_t{1000000}, std::size_t{10000000}}) {
         auto a = make_random_vector<double>(n);
         auto b = make_random_vector<double>(n, 456);
         vec::dense_vector<double> c(n);
         const double work = static_cast<double>(n);           // 1 add / element
-        auto t = measure([&]{ c = a + b; }, "ewise-vec", label, n, work, warmup, iterations);
+        auto t = measure([&]{ c = a + b; sink += c(n - 1); },
+                         "ewise-vec", label, n, work, warmup, iterations);
         rep.add(t);
     }
     // Matrices: C = A + B (row-parallel sweep). Distinct nrows so analyze_scaling
@@ -253,9 +257,11 @@ inline void bench_ewise(reporter& rep, const std::string& label,
         const double work = static_cast<double>(s.r) * static_cast<double>(s.c);
         const std::string op = std::string("ewise-mat-") + s.kind + " "
                              + std::to_string(s.r) + "x" + std::to_string(s.c);
-        auto t = measure([&]{ C = A + B; }, op, label, s.r, work, warmup, iterations);
+        auto t = measure([&]{ C = A + B; sink += C(s.r - 1, s.c - 1); },
+                         op, label, s.r, work, warmup, iterations);
         rep.add(t);
     }
+    (void)sink;
 }
 
 inline void bench_trmm(reporter& rep, const std::string& label,


### PR DESCRIPTION
## Summary
Phase 3 of the #297 benchmarking plan. Adds an `ewise` suite measuring the dense **element-wise expression-template sweeps** parallelized in #312: `y = a + b` (vector) and `C = A + B` (matrix). Each output element is an independent per-index write routed through `detail::parallel_ewise`; the `gflops` column carries element throughput (`elements/ns`), whose ratio across thread counts is the speedup.

Matrix shapes cover square, **tall** (many rows → splits), and a **single-row wide** case that documents the #313 row-parallel gap.

## Local numbers (4 threads, unpinned)
| case | 1→4 speedup |
|------|-------------|
| vector 1e7 | 2.02× |
| matrix 1024² / 4096² (square) | 3.38× / 2.08× |
| matrix 2M×8 (tall) | 2.06× |
| **matrix 1×16M (wide)** | **1.04×** |

Element-wise sweeps are memory-bandwidth bound, so scaling ceilings at the bandwidth (~2–3× here), not the core count. The single-row wide matrix is flat at 1.04× — the row-parallel sweep runs serial when `num_rows < threads`, exactly the **#313** limitation (which the follow-up will fix by flattening the sweep to a linear element index).

## Scope / notes
- **Benchmark-only** — no library or test change. Not built in the default CI (`MTL5_BUILD_BENCHMARKS=OFF`); verified locally (`bench_all --suite ewise` builds + runs at T=1/T=4).
- `--suite ewise` wired into `bench_all` (+ help text). Adds `mtl/vec/operators.hpp` + `mtl/mat/operators.hpp` includes to the harness.

Relates to #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `ewise` benchmark suite for measuring element-wise vector and matrix addition across different sizes and shapes.
  * Added command-line support for running the suite with `--suite ewise`.
  * Benchmark results now include operation labels and element-based work metrics.
  * The suite supports configurable warmup and iteration settings to help produce consistent performance measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->