### PR TITLE
bench: #297 scaling driver + analyzer group-by-operation (phase 4)

### DIFF
--- a/benchmarks/analyze_scaling.py
+++ b/benchmarks/analyze_scaling.py
@@ -1,15 +1,22 @@
 #!/usr/bin/env python3
-"""Analyze multi-core GEMM scaling (#108) from run_scaling.sh CSVs.
+"""Analyze on-node scaling from run_scaling*.sh CSVs.
 
-The CSVs label their `backend` column "<name>-t<T>" (e.g. native-fast-t8), so a
-single file carries every thread count for one backend. For each backend and
-size this reports GFLOP/s, speedup vs T=1, and parallel efficiency
-(speedup / T), and -- with --plot -- draws speedup-vs-threads curves (with an
-ideal-linear reference) at the largest size.
+The CSVs label their `backend` column "<name>-t<T>" (e.g. native-t8), so a single
+file carries every thread count for one backend. Each row is one case identified
+by (operation, size); this reports the case's throughput (the CSV `gflops`
+column -- GFLOP/s for GEMM/factor, elements/ns or nnz/ns for sweeps/solves),
+speedup vs the smallest thread count, and parallel efficiency, and -- with
+--plot -- draws speedup-vs-threads curves (with an ideal-linear reference).
+
+Series are keyed by (operation, size) so multiple operations, matrix shapes, or
+sparse solvers that share a `size` no longer collide (#297 phase 4). A generic
+`operation == "gemm"` with several sizes still splits into one series per size,
+so the legacy GEMM CSVs read unchanged.
 
 Examples:
-    ./analyze_scaling.py data/gemm_scaling_*.csv
-    ./analyze_scaling.py data/gemm_scaling_*.csv --plot data/gemm_scaling.png
+    ./analyze_scaling.py data/scaling_*.csv
+    ./analyze_scaling.py data/scaling_sparse.csv --plot data/sparse.png
+    ./analyze_scaling.py data/scaling_ewise.csv --op ewise-vec   # filter series
 
 Standard library only (matplotlib only for --plot). Benchmark tooling.
 """
@@ -26,7 +33,7 @@ LABEL_RE = re.compile(r"^(?P<name>.+)-t(?P<t>\d+)$")
 
 
 def load(paths):
-    """Return {backend: {size: {threads: gflops}}}."""
+    """Return {backend: {(operation, size): {threads: gflops}}}."""
     data = defaultdict(lambda: defaultdict(dict))
     for path in paths:
         try:
@@ -35,7 +42,8 @@ def load(paths):
                     m = LABEL_RE.match(row["backend"])
                     if not m or row.get("gflops", "") == "":
                         continue
-                    data[m["name"]][int(row["size"])][int(m["t"])] = float(row["gflops"])
+                    key = (row.get("operation", "?"), int(row["size"]))
+                    data[m["name"]][key][int(m["t"])] = float(row["gflops"])
         except OSError as exc:
             sys.exit(f"error: cannot read {path}: {exc}")
         except (KeyError, ValueError) as exc:
@@ -43,72 +51,97 @@ def load(paths):
     return data
 
 
+def series_label(op, size):
+    # If the operation already encodes its shape (contains a digit), the size is
+    # redundant; otherwise append N=<size> to disambiguate (e.g. plain "gemm").
+    return op if any(ch.isdigit() for ch in op) else f"{op} N={size}"
+
+
+def bitexact_warn(paths):
+    """Warn (do not fail) if any row carries an explicit bitexact=0 column."""
+    bad = 0
+    for path in paths:
+        try:
+            with open(path, newline="") as fh:
+                r = csv.DictReader(fh)
+                if r.fieldnames and "bitexact" in r.fieldnames:
+                    for row in r:
+                        if row.get("bitexact", "") == "0":
+                            bad += 1
+        except OSError:
+            pass
+    if bad:
+        print(f"WARNING: {bad} row(s) reported bitexact=0 -- those speedups are invalid.\n")
+
+
 def print_tables(data):
     for name in sorted(data):
         print(f"\n== {name} ==")
-        for size in sorted(data[name]):
-            by_t = data[name][size]
+        for (op, size) in sorted(data[name]):
+            by_t = data[name][(op, size)]
             base_t = min(by_t)                   # baseline = smallest thread count present
             base = by_t.get(base_t)
-            print(f"  N={size}")
-            print(f"    {'threads':>7} {'GFLOP/s':>10} {'speedup':>8} {'efficiency':>11}")
+            print(f"  {series_label(op, size)}")
+            print(f"    {'threads':>7} {'throughput':>11} {'speedup':>8} {'efficiency':>11}")
             for t in sorted(by_t):
                 g = by_t[t]
                 sp = g / base if base else float("nan")
                 eff = sp / (t / base_t) if base else float("nan")
-                print(f"    {t:>7} {g:>10.2f} {sp:>7.2f}x {100.0 * eff:>10.1f}%")
+                print(f"    {t:>7} {g:>11.3f} {sp:>7.2f}x {100.0 * eff:>10.1f}%")
 
 
-def make_plot(data, out):
+def make_plot(data, out, op_filter=None):
     import matplotlib
     matplotlib.use("Agg")
     import matplotlib.pyplot as plt
 
-    # Largest common size for the headline curve.
-    sizes = sorted({s for name in data for s in data[name]})
-    if not sizes:
-        sys.exit("no data to plot")
-    size = sizes[-1]
-
     fig, (ax_sp, ax_g) = plt.subplots(1, 2, figsize=(11, 4.5))
+    all_ts = set()
+    plotted = 0
     for name in sorted(data):
-        by_t = data[name].get(size)
-        if not by_t:
-            continue
-        ts = sorted(by_t)
-        base_g = by_t[ts[0]]                 # speedup relative to this backend's smallest T
-        ax_sp.plot(ts, [by_t[t] / base_g for t in ts], marker="o", label=name)
-        ax_g.plot(ts, [by_t[t] for t in ts], marker="o", label=name)
-    # Ideal line normalized to the same baseline as the speedup curves (the
-    # smallest thread count present), so it is correct even if THREADS omits 1.
-    all_ts = sorted({t for name in data for t in data[name].get(size, {})})
-    if all_ts:
-        base_t = all_ts[0]
-        ax_sp.plot(all_ts, [t / base_t for t in all_ts], "k--", alpha=0.5, label="ideal (linear)")
+        for (op, size) in sorted(data[name]):
+            if op_filter and op_filter not in op:
+                continue
+            by_t = data[name][(op, size)]
+            ts = sorted(by_t)
+            if len(ts) < 2:
+                continue
+            all_ts.update(ts)
+            base_g = by_t[ts[0]]
+            lbl = f"{name}: {series_label(op, size)}"
+            ax_sp.plot(ts, [by_t[t] / base_g for t in ts], marker="o", label=lbl)
+            ax_g.plot(ts, [by_t[t] for t in ts], marker="o", label=lbl)
+            plotted += 1
+    if not plotted:
+        sys.exit("no series to plot (check --op filter / input)")
+    ts = sorted(all_ts)
+    base_t = ts[0]
+    ax_sp.plot(ts, [t / base_t for t in ts], "k--", alpha=0.5, label="ideal (linear)")
 
-    ax_sp.set(title=f"GEMM speedup vs threads (N={size})", xlabel="threads",
-              ylabel="speedup vs 1 thread")
-    ax_g.set(title=f"GEMM GFLOP/s vs threads (N={size})", xlabel="threads", ylabel="GFLOP/s")
+    ax_sp.set(title="Speedup vs threads", xlabel="threads", ylabel="speedup vs smallest T")
+    ax_g.set(title="Throughput vs threads", xlabel="threads", ylabel="throughput (CSV gflops col)")
     for ax in (ax_sp, ax_g):
         ax.grid(True, alpha=0.3)
-        ax.legend()
-    fig.suptitle("MTL5 multi-core GEMM scaling")
+        ax.legend(fontsize=7)
+    fig.suptitle("MTL5 on-node scaling (#297)")
     fig.tight_layout()
     fig.savefig(out, dpi=110)
     print(f"wrote {out}")
 
 
 def main():
-    ap = argparse.ArgumentParser(description="Multi-core GEMM scaling analysis.")
-    ap.add_argument("csv", nargs="+", help="gemm_scaling_*.csv file(s)")
-    ap.add_argument("--plot", metavar="PNG", help="write a speedup/GFLOP-s scaling plot")
+    ap = argparse.ArgumentParser(description="On-node scaling analysis (#297).")
+    ap.add_argument("csv", nargs="+", help="scaling_*.csv file(s)")
+    ap.add_argument("--plot", metavar="PNG", help="write a speedup/throughput scaling plot")
+    ap.add_argument("--op", metavar="SUBSTR", help="only plot series whose operation contains SUBSTR")
     args = ap.parse_args()
+    bitexact_warn(args.csv)
     data = load(args.csv)
     if not data:
-        sys.exit("no scaling data found (expected backend labels like 'native-fast-t4')")
+        sys.exit("no scaling data found (expected backend labels like 'native-t4')")
     print_tables(data)
     if args.plot:
-        make_plot(data, args.plot)
+        make_plot(data, args.plot, args.op)
 
 
 if __name__ == "__main__":

--- a/benchmarks/run_scaling_297.sh
+++ b/benchmarks/run_scaling_297.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# On-node threading scaling for the #297 rollout: native 1->N scaling of every
+# threaded kernel family, pinned to distinct PHYSICAL cores so the numbers
+# reflect cores, not SMT siblings (the pitfall documented in
+# docs/design/multicore-scaling-investigation.md).
+#
+# Suites (one CSV per family, backend column labelled "native-t<T>"):
+#   gemm_rect  -- rectangular GEMM: the BLIS multi-loop (2D) grid            (#311)
+#   lu/qr/chol -- dense factorizations                                       (#298,#300)
+#   ewise      -- element-wise vector/matrix expression sweeps              (#312)
+#   sparse     -- level-scheduled sparse triangular solves                  (#301-#309)
+#
+# Environment:
+#   BENCH_PCPUS  comma list of physical-core logical ids (one sibling per core),
+#                longest first-T prefix is pinned. Default for an i7-12700K:
+#                0,2,4,6,8,10,12,14. SET THIS TO MATCH YOUR TOPOLOGY
+#                (see: lscpu -e=CPU,CORE,MAXMHZ).
+#   THREADS      thread counts to sweep (default "1 2 4 8").
+#   LAPACK_SIZES dense factor sizes (default 1024,2048,4096).
+#   SPARSE_SIZES sparse 2-D grid sides (default 200,320).
+#   BUILD        build dir (default build-scaling-297).
+#   JOBS         build parallelism (default 4).
+#
+# Example:  BENCH_PCPUS=0,2,4,6,8,10,12,14 THREADS="1 2 4 8" benchmarks/run_scaling_297.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT"
+
+PCPUS="${BENCH_PCPUS:-0,2,4,6,8,10,12,14}"
+THREADS="${THREADS:-1 2 4 8}"
+LAPACK_SIZES="${LAPACK_SIZES:-1024,2048,4096}"
+SPARSE_SIZES="${SPARSE_SIZES:-200,320}"
+BUILD="${BUILD:-build-scaling-297}"
+DATA="benchmarks/data"
+mkdir -p "$DATA"
+
+IFS=',' read -r -a PCPU_ARR <<< "$PCPUS"
+
+# pcpus_for <T>: comma list of the first T physical-core ids.
+pcpus_for() {
+    local t="$1" out=""
+    for ((i = 0; i < t && i < ${#PCPU_ARR[@]}; ++i)); do
+        out="${out:+$out,}${PCPU_ARR[$i]}"
+    done
+    printf '%s' "$out"
+}
+
+echo "=== configure + build native-fast benchmarks ($BUILD) ==="
+cmake -B "$BUILD" -DMTL5_BUILD_BENCHMARKS=ON -DCMAKE_BUILD_TYPE=Release \
+    -DMTL5_NATIVE_FAST_GEMM=ON -DMTL5_WITH_HIGHWAY=ON -DMTL5_NATIVE_ARCH=ON >/dev/null
+cmake --build "$BUILD" --target bench_all bench_sparse -j"${JOBS:-4}" >/dev/null
+
+# run_native <csv-name> <binary> <bench-args...>: sweep THREADS, one process per
+# T pinned to the first-T physical cores; concatenate into one per-suite CSV.
+run_native() {
+    local name="$1"; shift
+    local bin="$1"; shift
+    local out="$DATA/scaling_${name}.csv"; rm -f "$out"; local first=1
+    for T in $THREADS; do
+        if (( T > ${#PCPU_ARR[@]} )); then
+            echo "error: T=$T exceeds the ${#PCPU_ARR[@]} core(s) in BENCH_PCPUS ($PCPUS)" >&2
+            exit 1
+        fi
+        local pin; pin="$(pcpus_for "$T")"
+        local tmp; tmp="$(mktemp)"
+        echo "  $name  T=$T  pinned to CPUs $pin"
+        env MTL5_NUM_THREADS="$T" taskset -c "$pin" "$bin" "$@" \
+            --label "native-t${T}" --csv "$tmp" >/dev/null
+        if [[ $first -eq 1 ]]; then cat "$tmp" > "$out"; first=0; else tail -n +2 "$tmp" >> "$out"; fi
+        rm -f "$tmp"
+    done
+    echo "  -> $out"
+}
+
+BA="$BUILD/benchmarks/bench_all"
+BS="$BUILD/benchmarks/bench_sparse"
+
+echo "=== gemm-rect (multi-loop 2D grid) ==="
+run_native gemm_rect "$BA" --suite gemm-rect
+echo "=== dense factorizations (lu / qr / cholesky) ==="
+run_native lu   "$BA" --suite lu       --lapack-sizes "$LAPACK_SIZES"
+run_native qr   "$BA" --suite qr       --lapack-sizes "$LAPACK_SIZES"
+run_native chol "$BA" --suite cholesky --lapack-sizes "$LAPACK_SIZES"
+echo "=== element-wise sweeps ==="
+run_native ewise "$BA" --suite ewise
+echo "=== sparse triangular solves (level-scheduled) ==="
+run_native sparse "$BS" --sizes "$SPARSE_SIZES"
+
+echo
+echo "Done. Analyze with:"
+echo "  ./benchmarks/analyze_scaling.py $DATA/scaling_*.csv --plot $DATA/scaling_297.png"
+echo "  (add --op <substr> to focus one family, e.g. --op ewise or --op snlu)"


### PR DESCRIPTION
## Summary
Phase 4 of the #297 benchmarking plan — the driver + analysis that tie the three measurement suites together.

**`analyze_scaling.py`** — key series by **`(operation, size)`** instead of `size` alone, so multiple operations, GEMM shapes, and sparse solvers that share a `size` no longer collide (the gap noted in Phases 1–3). Backward-compatible: a generic `operation="gemm"` with several sizes still splits into one series per size, so the legacy `run_scaling.sh` GEMM CSVs read unchanged. Also adds an `--op` substring filter for the plot, a `bitexact=0` warning, and mixed-suite-friendly throughput/plot labels.

**`run_scaling_297.sh`** — drive all four #297 kernel families as native 1→N sweeps **pinned to distinct physical cores** (reusing `run_scaling.sh`'s pinning; SMT siblings excluded — the pitfall from the multicore-scaling study):
- `gemm-rect` (multi-loop 2D grid), dense `lu`/`qr`/`cholesky`, `ewise` via `bench_all`
- `sparse-solve` via `bench_sparse`

One CSV per family with `native-t<T>` labels → straight into `analyze_scaling.py`.

## Verified locally
- Analyzer now separates all **five sparse solvers at n=10000** into distinct series (collision fixed).
- Driver's pin→sweep→analyze path produces correct per-`(operation,size)` speedup/efficiency. With physical-core pinning at T=2: `ewise-mat-square 1024` → **1.99× (99.7% efficiency)**, `ewise-mat-wide 1×16M` → **1.00×** (the #313 gap) — cleaner than the earlier unpinned runs, confirming the pinning methodology matters.

## Scope / notes
- **Benchmark tooling only** — no library/test/CMake-target change; not built in the default CI.
- Sets up **Phase 5** (results write-up): run `run_scaling_297.sh` on a known multi-core box with `BENCH_PCPUS` set to its topology, then `analyze_scaling.py` for the headline tables/plot.

Relates to #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)