### PR TITLE
fix(bench): clamp the 3-D Laplacian grid size in bench_sparse

### DIFF
--- a/benchmarks/bench_sparse.cpp
+++ b/benchmarks/bench_sparse.cpp
@@ -220,9 +220,28 @@ static void run_suite(mtl::bench::reporter& rep, const std::string& label,
         bench_case(rep, "snlu "   + t2, label, L2, snlu,   lu_flops);
 
         // 3-D Laplacian (wider levels than 2-D): more parallelism per level.
-        // g3 chosen so n3 ~ n2 (comparable problem size) but bounded.
-        const std::size_t g3 = std::max<std::size_t>(8, static_cast<std::size_t>(std::cbrt(
-                                   static_cast<double>(g) * static_cast<double>(g))));
+        // g3 tracks n3 ~ n2 (comparable DOF count) but is clamped at both ends.
+        //
+        // The upper clamp matters: equal DOF is NOT equal cost. A 3-D Laplacian
+        // has far worse fill and flop growth under Cholesky than a 2-D one of
+        // the same n, and the factorization here is untimed SETUP that every
+        // run pays before measuring the (millisecond) solves. Measured whole-
+        // suite wall clock at T=1 on an i7-12700K:
+        //
+        //     side 100 -> lap3d21 (n=9,261)    11 s
+        //     side 160 -> lap3d29 (n=24,389)   3 m 38 s
+        //     side 200 -> lap3d34 (n=39,304)   killed after 3 h 28 m
+        //
+        // Without a cap, raising the 2-D size implicitly selects an intractable
+        // 3-D problem. kMaxLap3dSide is set so the documented default sizes
+        // (100,160 -> g3 21,29) are unaffected, while larger 2-D grids hold the
+        // 3-D case at a bounded cost. The case label carries g3 ("lap3d32"), so
+        // a clamped run is self-describing in the console output and the CSV.
+        constexpr std::size_t kMaxLap3dSide = 32;   // n3 <= 32,768
+        const std::size_t g3 = std::clamp<std::size_t>(
+            static_cast<std::size_t>(std::cbrt(
+                static_cast<double>(g) * static_cast<double>(g))),
+            8, kMaxLap3dSide);
         auto L3 = laplacian_3d(g3);
         const std::string t3 = "lap3d" + std::to_string(g3);
         bench_case(rep, "chol "   + t3, label, L3, chol,   chol_flops);


### PR DESCRIPTION
Closes part of #321 (item 2, the root-cause fix).

## Problem

`bench_sparse` sizes its 3-D Laplacian case so the DOF count matches the 2-D case:

```cpp
const std::size_t g3 = std::max<std::size_t>(8, std::cbrt(double(g) * double(g)));
```

`max(8, ...)` bounds `g3` only from **below**. Nothing caps it, despite the adjacent comment claiming `g3` is "bounded".

Equal DOF is not equal cost. A 3-D Laplacian has far worse fill and flop growth under Cholesky than a 2-D one of the same `n`, and this factorization is **untimed setup** paid before the (millisecond) solves are measured. So raising the 2-D grid size implicitly selects an intractable 3-D problem.

## Fix

Clamp `g3` to 32 (`n3 <= 32,768`), with the measured cost curve recorded in the comment so the bound is not mistaken for an arbitrary constant.

32 is chosen so the **documented default sizes are unaffected**: `100,160` map to `g3` 21 and 29, both below the cap. Only grids larger than the default are clamped. The case label embeds `g3` (`lap3d32`), so a clamped run stays self-describing in the console table and the CSV — no one can mistake a clamped 3-D case for an unclamped one.

## Verification

Built and run locally on an i7-12700K, `T=1`, pinned to one P-core.

**Default sizes unchanged** — side 100 still produces `lap3d21` at `n=9,261`, same as before.

**Side 200, which previously never finished:**

| | Before | After |
|---|---|---|
| 3-D case | `lap3d34`, n=39,304 | `lap3d32`, n=32,768 |
| Wall clock | killed after **3 h 28 m** | **8 m 46 s** |

At least a 24x improvement, and it confirms the diagnosis: the unbounded 3-D case was the dominant cost, not the 2-D grid. Residuals stay sound throughout (`8.9e-13` down to `1.5e-16`), so the clamp changes cost, not correctness.

## What this does not fix

`run_scaling_297.sh` still defaults to `SPARSE_SIZES=200,320`. Even clamped, side 200 costs ~8.7 min per thread count (~35 min across `THREADS="1 2 4 8"`), and side 320 has a 2-D case of `n=102,400` whose own factorization is untested at that scale. **Item 1 of #321 — lowering the driver default to `100,160` — is still needed**, and is deliberately left out of this PR to keep the root-cause fix reviewable on its own.

## Note on CI

No workflow sets `MTL5_BUILD_BENCHMARKS=ON`, so `bench_sparse.cpp` is not compiled on any runner and CI cannot validate this change. It was built and exercised locally as described above. That gap is also how the `factorL()`/`factorU()` breakage fixed in #319 went unnoticed; a build-only CI job for the benchmark targets would be a cheap follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the 3-D Laplacian benchmark sizing to stay within practical limits while preserving representative scaling.
  * Updated benchmark labels to accurately reflect the applied size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->