### PR TITLE
fix(docs): correct the #82 gate finding — marginal gate, not an N=465 dip

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -227,8 +227,10 @@ absolute perf gates flaky. Run it on dedicated hardware.
 [Benchmark systems](../docs/benchmarks/systems.md). Keeping numbers in one place
 means a re-run updates them once; this file documents how to *produce* them.
 
-As of the latest i7-12700K session the GEMM gate **fails** at 1 of 10 sizes
-(76.3% at N = 465, against 80.2–86.5% elsewhere) — a reproducible localized dip.
+As of the latest i7-12700K session the GEMM gate **fails**, but marginally:
+native-fast averages ~82% of OpenBLAS for N ≥ 256 against an 80% threshold, and
+per-size run-to-run spread reaches several points, so which sizes trip it varies
+between runs (#327). Do not read a single size in a single run as signal.
 
 ## Multi-core GEMM scaling (#108)
 

--- a/docs/benchmarks/i7-12700k.md
+++ b/docs/benchmarks/i7-12700k.md
@@ -10,9 +10,11 @@ for one desktop hybrid CPU, not a portable performance claim.
 
 ## Headline findings
 
-- **native-fast GEMM reaches 76–86% of OpenBLAS** single-threaded for N ≥ 256,
-  at 70–78% of the machine's FMA peak — with **one reproducible dip to 76% at
-  N = 465** that fails the #82 gate's 80% threshold.
+- **native-fast GEMM averages ~82% of OpenBLAS** single-threaded for N ≥ 256, at
+  70–78% of the machine's FMA peak. That is inside the epic's 10–20% target, but
+  **the #82 gate's 80% threshold has no margin**: per-size run-to-run spread
+  reaches several points, so individual runs fail at whichever sizes land low
+  (#327).
 - **The generic C++ path is ~12× slower than native-fast** on GEMM (5 vs 60
   GFLOP/s). The SIMD/blocked path is what makes MTL5 competitive at all.
 - **Multi-core GEMM scaling improved** — native-fast now reaches **6.51× on 8
@@ -60,7 +62,7 @@ dominates small problems even with `MKL_NUM_THREADS=1`.
 of the range, which makes it a better reference than OpenBLAS for small-matrix
 work.
 
-### Epic #82 acceptance gate — currently FAILING
+### Epic #82 acceptance gate — FAILING, with no margin
 
 The gate asks whether MTL5's own kernels land within 10–20% of OpenBLAS for GEMM
 at N ≥ 256. Against this session's data:
@@ -71,23 +73,44 @@ benchmarks/analyze_gate.py data/blas_sweep_native-fast.csv \
 GATE FAIL: gemm below 80% of openblas at 1/10 sizes (worst 76.3%)
 ```
 
-Nine of ten sizes pass at 80.2–86.5%. One does not:
+**The failure is real, but which sizes fail is not stable.** Repeating the
+identical protocol on an idle machine — same binaries, same sweep, same pinning
+— fails at a *different* set of sizes:
 
-| N | native-fast | openblas | ratio | |
-|---:|---:|---:|---:|---|
-| 385 | 56.83 | 70.84 | 80.2% | ok |
-| **465** | **54.53** | **71.45** | **76.3%** | **LOW** |
-| 545 | 56.89 | 70.92 | 80.2% | ok |
+| N | committed run | verification re-run |
+|---:|---:|---:|
+| 305 | 80.6% | **78.7%** LOW |
+| 385 | 80.2% | **79.0%** LOW |
+| 465 | **76.3%** LOW | 82.5% |
+| 545 | 80.2% | 86.0% |
+| 625 | 86.5% | 85.9% |
+| 705 | 82.6% | 82.8% |
+| 785 | 84.6% | 83.5% |
+| 865 | 83.9% | 82.5% |
+| 945 | 83.9% | 82.0% |
+| 1025 | 82.1% | **79.2%** LOW |
 
-**The dip is reproducible, not measurement noise.** Three isolated repeat runs at
-N = 465 put the ratio at 70.6%, 75.4% and 72.5% — consistently below the
-neighbouring sizes, which both sit at 80.2%. Something in the blocked GEMM's
-tiling interacts badly with this specific size.
+No size falls below the threshold in both runs, and the per-size spread reaches
+6 points (N = 465: 76.3% vs 82.5%). A fine sweep `433:505:8` across the region
+the first run flagged is flat — 55.8, 55.7, 58.6, 59.1, **58.7 at N = 465**,
+58.8, 58.7, 59.4, 59.3, 59.5 GFLOP/s — with no structure at that size.
 
-This is a genuine regression against the previously documented result
-("80–84% for all N ≥ 256"), and it is narrow: a localized ~4-point dip at one
-size rather than a broad decline. It wants an investigation into the blocking
-parameters around N ≈ 465, not a re-tuning of the whole kernel.
+So the honest reading is **a marginal gate, not a size-specific defect**.
+native-fast averages ~82% of OpenBLAS across N ≥ 256, comfortably inside the
+epic's 10–20% target, but an 80% threshold applied per-size to a single run has
+no margin against this much variance, so noise decides pass/fail.
+
+The variance has two known sources, both listed under [caveats](#caveats): the
+CPU governor is `powersave`, so per-size turbo behaviour is not pinned, and each
+size is a median over a small iteration count. **#327** tracks both reducing the
+measurement variance and deciding what the gate should assert — a median across
+sizes, or repeated failures, rather than any single size in a single run.
+
+> An earlier revision of this page reported the N = 465 result as a reproducible
+> kernel dip. That was wrong: the "repeats" backing it were taken on a loaded
+> machine (native-fast measured 38–40 GFLOP/s there against 56.9 idle) and were
+> compared against sweep-protocol ratios instead of like-for-like isolated runs
+> at neighbouring sizes. The control, run since, shows ordinary variation.
 
 ### L1 and L2
 
@@ -232,16 +255,22 @@ performance comparisons, not accuracy trade-offs.
 
 ## Caveats
 
-- **CPU governor was `powersave`** (`intel_pstate`). It still boosts, but clocks
-  are not pinned, which adds run-to-run variance. Numbers within a few percent
-  should not be treated as separable.
+- **Run-to-run variance is larger than it looks.** The CPU governor is
+  `powersave` (`intel_pstate`) so clocks are not pinned, and each size is a
+  median over a small iteration count. Repeating the GEMM sweep moved individual
+  sizes by up to 6 percentage points relative to OpenBLAS. **Treat differences
+  under ~5 points between two sizes, or between two runs, as noise** — a single
+  size in a single run is not evidence of anything.
+- **A loaded machine changes the numbers by ~30%.** Measurements taken while
+  other work was running put native-fast GEMM at 38–40 GFLOP/s where the idle
+  machine gives 56.9 at the same size. Every table here was measured on an idle
+  machine; anything measured otherwise is not comparable.
+- **Absolute GFLOP/s also depend on the measurement protocol.** A short
+  single-size process reports lower numbers than the same size inside a warm
+  sweep. Every table on this page comes from sweeps; do not compare these
+  figures against numbers taken another way.
 - **FMA peak is taken as ~78 GFLOP/s** for one P-core in fp64 (AVX2, 2 FMA/cycle
   × 4 doubles × 2 flops × ~4.9 GHz). Percentages of peak inherit that estimate.
-- **Absolute GFLOP/s depend on the measurement protocol.** A short single-size
-  process reports materially lower numbers than the same size inside a warm
-  sweep — the N = 465 repeats above measured 38–40 GFLOP/s where the sweep
-  measured 54.5. Every table on this page comes from sweeps; do not compare
-  these figures against numbers taken another way.
 - **The `#297` sparse family ran at grid sides 100,160**, not the driver's
   default `200,320`, which does not complete on this machine (see #321).
 


### PR DESCRIPTION
Corrects a wrong claim published in #325. Refs #327.

## What was wrong

`docs/benchmarks/i7-12700k.md` stated the N=465 GEMM result was "**reproducible, not measurement noise**" and attributed it to the blocked GEMM's tiling interacting badly with that specific size.

The evidence backing that was invalid in two ways:

1. The three "isolated repeat runs" were taken **on a loaded machine**. native-fast measured 38–40 GFLOP/s there; the same size on an idle machine measures 56.9.
2. Their ratios were compared against **sweep-protocol** ratios rather than like-for-like isolated runs at neighbouring sizes. The control that would have caught this — same protocol, neighbouring sizes, idle machine — was never run. Run since, it gives 82.1% at N=385 and 86.6% at N=545 against 79.5% at N=465, i.e. ordinary variation.

## What the data actually shows

Repeating the identical protocol (same binaries, same sweep, same pinning) on an idle machine fails the gate at a **different set of sizes**:

| N | committed run | verification re-run |
|---:|---:|---:|
| 305 | 80.6% | **78.7%** LOW |
| 385 | 80.2% | **79.0%** LOW |
| 465 | **76.3%** LOW | 82.5% |
| 545 | 80.2% | 86.0% |
| 1025 | 82.1% | **79.2%** LOW |

No size falls below threshold in both runs; per-size spread reaches 6 points. A fine sweep `433:505:8` is flat across the flagged region (58.7 GFLOP/s at N=465, neighbours 58.6–59.5).

**The gate failure is real and reproduces. Only the attribution was wrong.** native-fast averages ~82% of OpenBLAS for N ≥ 256 — inside the epic's 10–20% target — but an 80% threshold applied per-size to a single run has no margin against this variance.

## Changes

- Gate section rewritten around the two-run comparison, with the conclusion stated as a marginal gate rather than a size-specific defect.
- An explicit note recording that the earlier claim was wrong and why, so the correction is visible rather than silently rewritten.
- Caveats strengthened: a **"treat differences under ~5 points as noise"** rule, and the loaded-machine effect (~30% on absolute numbers) as its own bullet.
- Headline bullet reworded from "one reproducible dip" to the marginal-gate framing.
- `benchmarks/README.md` echoed the same claim; fixed there too.

## Verification

`npm run build` — 43 pages, unchanged. No remaining occurrences of the superseded claim.

## Follow-up

#327 tracks the substantive work: reducing measurement variance (`performance` governor, more iterations, report spread) and deciding what the gate should assert, since a per-size single-run threshold at this noise level is a coin flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GEMM benchmark results for i7-12700K systems.
  * Clarified that native-fast averages approximately 82% of OpenBLAS for larger matrix sizes, with run-to-run variation potentially causing individual threshold failures.
  * Added verification comparisons and caveats covering system load, CPU governor settings, iteration counts, and measurement differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->