### PR TITLE
ci: build the benchmark targets on every push and PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,82 @@ jobs:
           MTL5_NUM_THREADS: 4
           TSAN_OPTIONS: halt_on_error=1
 
+  # -- Benchmark sources: build only, never timed -----------------------
+  # MTL5_BUILD_BENCHMARKS defaults OFF and no other job enables it, so
+  # benchmarks/*.cpp is compiled by no runner. That is how bench_klu.cpp and
+  # bench_superlu.cpp came to reference private members of lu_numeric and stayed
+  # broken until someone built them locally (#319).
+  #
+  # This lane only COMPILES them. Timed runs need pinned cores and a quiet
+  # machine, which shared runners cannot provide -- absolute perf gates here
+  # would be flaky, so the numbers are produced on dedicated hardware and
+  # published under docs/benchmarks/ instead.
+  #
+  # Two configurations, because most of the vendor-comparison code in the
+  # scoreboards sits behind #ifdef MTL5_HAS_KLU / MTL5_HAS_SUPERLU and is
+  # invisible to a plain build:
+  #   native  -- no external libraries (the native-only paths)
+  #   vendors -- BLAS/LAPACK + KLU + SuperLU (the guarded comparison paths)
+  benchmarks:
+    name: Linux x64 benchmarks build (${{ matrix.config }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - config: native
+            cmake_flags: ""
+          - config: vendors
+            cmake_flags: >-
+              -DMTL5_WITH_BLAS=ON -DMTL5_WITH_LAPACK=ON
+              -DMTL5_WITH_SUITESPARSE_KLU=ON -DMTL5_WITH_SUPERLU=ON
+
+    # Same trusted-run gate as the build job: forked PRs skip sccache so they
+    # cannot poison the shared GHA cache.
+    env:
+      SCCACHE_LAUNCHER: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'sccache' || '' }}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up sccache
+        if: >-
+          github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name == github.repository
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+
+      - name: Install vendor libraries
+        if: matrix.config == 'vendors'
+        run: >
+          sudo apt-get update &&
+          sudo apt-get install -y
+          libopenblas-dev liblapack-dev libsuitesparse-dev libsuperlu-dev
+
+      - name: Configure
+        run: >
+          cmake -B build-bench
+          -DCMAKE_CXX_STANDARD=20
+          -DCMAKE_C_COMPILER_LAUNCHER=${{ env.SCCACHE_LAUNCHER }}
+          -DCMAKE_CXX_COMPILER_LAUNCHER=${{ env.SCCACHE_LAUNCHER }}
+          -DCMAKE_BUILD_TYPE=Release
+          -DMTL5_BUILD_BENCHMARKS=ON
+          -DMTL5_BUILD_TESTS=OFF
+          -DMTL5_BUILD_EXAMPLES=OFF
+          ${{ matrix.cmake_flags }}
+
+      - name: Build every benchmark target
+        run: >
+          cmake --build build-bench --parallel 2
+          --target bench_all bench_klu bench_superlu bench_sparse
+
+      # Link/startup check only -- bench_all parses arguments and exits. The
+      # other three have no --help and would start a real timed suite, so they
+      # are built but not run.
+      - name: Smoke check
+        run: ./build-bench/benchmarks/bench_all --help
+
   # ── Tier 2: Regression tests on Linux (~10 min) ─────────────────────
   # Runs only on non-draft PRs, after Tier 1 passes.
   # Exercises dense, sparse, and iterative solvers at 100–50K DOF.


### PR DESCRIPTION
Closes the CI gap that let #319's breakage survive.

## Problem

`MTL5_BUILD_BENCHMARKS` defaults `OFF` and no workflow enabled it, so **`benchmarks/*.cpp` was compiled by no runner**. Consequences already observed:

- `bench_klu.cpp` and `bench_superlu.cpp` referenced private members of `lu_numeric` (`blk.L` / `blk.U`) and stayed broken until someone happened to build them locally — fixed in #319, long after `lu_numeric` was encapsulated.
- The `bench_sparse` clamp in #322 could only be validated by hand, because CI could not compile the file it changed.

## What this adds

A build-only lane, `Linux x64 benchmarks build`, covering all four targets (`bench_all`, `bench_klu`, `bench_superlu`, `bench_sparse`) in two configurations:

| Config | Flags | Covers |
|---|---|---|
| `native` | *(none)* | the native-only paths |
| `vendors` | BLAS/LAPACK + KLU + SuperLU | the comparison paths behind `#ifdef MTL5_HAS_KLU` / `MTL5_HAS_SUPERLU` |

The second configuration is not redundant: most of the vendor-comparison code in the scoreboards is `#ifdef`-guarded and a plain build never sees it. Verified — `bench_klu` prints `external KLU ENABLED` only in the `vendors` build.

## What it deliberately does not do

**Nothing is timed.** Timed runs need pinned cores and a quiet machine, which shared runners cannot provide — absolute perf gates there would be flaky, which is exactly why `analyze_gate.py --gate` is not wired into CI today. Benchmark numbers come from dedicated hardware and are published under `docs/benchmarks/`. The only execution here is `bench_all --help`, as a link and startup check.

The `native-fast` variant (`MTL5_NATIVE_FAST_GEMM` + Highway) is also left out: Highway 1.4 is not in Ubuntu 24.04, so `find_package` falls through to `FetchContent`, which clones and builds Highway on every run. Worth noting separately that **`MTL5_NATIVE_FAST_GEMM` is off in every CI job**, so `detail/gemm_blocked.hpp` and the threaded GEMM/GEMV paths in `operation/mult.hpp` are not compiled anywhere in CI either — a library-side gap, broader than this PR, and worth its own decision.

## Verification

- Both configurations build locally; the vendors configure step finds BLAS, LAPACK, SuperLU and KLU.
- `bench_all --help` smoke check passes.
- **The lane catches the bug it exists for**: reintroducing `blk.L` / `blk.U` in `bench_klu.cpp` fails the build with 2 errors. File restored afterwards.
- Workflow YAML parses; pinned action SHAs match the rest of the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)