### PR TITLE
fix(bench): gate #82 on the median ratio with a per-size floor

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -212,25 +212,52 @@ BENCH_CPU=4 BENCH_SUITES=blas benchmarks/run_sweeps.sh 65:1025:80
 benchmarks/analyze_gate.py benchmarks/data/blas_sweep_native-fast.csv \
     benchmarks/data/blas_sweep_openblas.csv --peak-gflops 78
 
-# Pass/fail gate: GEMM native-fast >= 80% of OpenBLAS for N >= 256
+# Pass/fail gate: median GEMM ratio >= 80% of OpenBLAS for N >= 256,
+# and no individual size below the 70% floor
 benchmarks/analyze_gate.py benchmarks/data/blas_sweep_native-fast.csv \
-    benchmarks/data/blas_sweep_openblas.csv --gate --op gemm --threshold 0.80 --min-size 256
+    benchmarks/data/blas_sweep_openblas.csv --gate --op gemm \
+    --threshold 0.80 --floor 0.70 --min-size 256
 ```
 
-The gate (`--gate`) exits non-zero if native-fast drops below the threshold, so
-it can run in an opt-in workflow. It is **not** wired into the per-push CI:
-shared CI runners have unstable clocks and no P-core pinning, which makes
-absolute perf gates flaky. Run it on dedicated hardware.
+### What the gate asserts, and why
+
+`--gate` exits non-zero if **either**:
+
+- the **median** of the per-size ratios falls below `--threshold` (default 0.80), or
+- **any single size** falls below `--floor` (default 0.70).
+
+The median is the primary assertion because the epic's target — "within 10–20%
+of OpenBLAS" — is an aggregate claim, and because it is the only statistic here
+that reproduces. Two runs of the identical protocol on the same idle machine
+gave:
+
+| statistic | run A | run B | swing |
+|---|---:|---:|---:|
+| median of ratios | 82.3% | 82.5% | **0.2 pt** |
+| mean | 82.1% | 82.2% | 0.1 pt |
+| min (the pre-#327 rule) | 76.3% | 78.7% | 2.4 pt |
+| worst single size | — | — | **6.2 pt** |
+
+The old rule failed if *any* size was below threshold — gating on the minimum,
+the noisiest statistic available — and the two runs failed at disjoint sets of
+sizes. The median is ~30× more stable.
+
+The floor keeps the rule honest: a genuine cliff at one size must still fail, so
+no size may drop below `--floor`, set well under the threshold so ordinary
+±6-point noise cannot trip it.
+
+> **Raising the iteration count does not help.** Within-run stddev is already
+> only 0.3–2.2% of the median at 10 iterations — the variance is *between* runs
+> (turbo/thermal state, allocation, page layout), not within them.
+
+It is **not** wired into the per-push CI: shared runners have unstable clocks
+and no P-core pinning, which makes absolute perf gates flaky. Run it on
+dedicated hardware.
 
 **Measured results live on the per-system result pages, not here** — see
 [Intel i7-12700K](../docs/benchmarks/i7-12700k.md), indexed from
 [Benchmark systems](../docs/benchmarks/systems.md). Keeping numbers in one place
 means a re-run updates them once; this file documents how to *produce* them.
-
-As of the latest i7-12700K session the GEMM gate **fails**, but marginally:
-native-fast averages ~82% of OpenBLAS for N ≥ 256 against an 80% threshold, and
-per-size run-to-run spread reaches several points, so which sizes trip it varies
-between runs (#327). Do not read a single size in a single run as signal.
 
 ## Multi-core GEMM scaling (#108)
 

--- a/benchmarks/analyze_gate.py
+++ b/benchmarks/analyze_gate.py
@@ -7,10 +7,14 @@ OpenBLAS** and, optionally, as a **percentage of FMA peak** (pass --peak-gflops
 for your machine: cores_used * freq_GHz * fma_units * lanes * 2).
 
 It also doubles as the optional performance guard (`--gate`): exit non-zero if
-native-fast GEMM falls below a threshold fraction of OpenBLAS for sizes at or
-above a floor. This is deliberately NOT wired into the per-push CI -- shared CI
-runners make absolute perf gates flaky -- but it is handy locally and in an
-opt-in workflow.
+the MEDIAN of native-fast/OpenBLAS across the gated sizes falls below
+`--threshold`, or if any individual size falls below the harder `--floor`.
+Gating on the median rather than on every size is deliberate -- per-size ratios
+move by several points between runs while the median is reproducible to ~0.2
+points, so the old every-size rule let noise decide the verdict (#327).
+
+This is deliberately NOT wired into the per-push CI -- shared CI runners make
+absolute perf gates flaky -- but it is handy locally and in an opt-in workflow.
 
 Examples:
     # Comparison table (% of OpenBLAS), all ops
@@ -19,9 +23,10 @@ Examples:
     # Add % of FMA peak (e.g. 1 P-core, 4.0 GHz, 2 FMA units, 4 fp64 lanes)
     ./analyze_gate.py data/blas_sweep_*.csv --peak-gflops 64
 
-    # Gate: fail if GEMM native-fast < 80% of OpenBLAS for N >= 256
+    # Gate: fail if the MEDIAN GEMM ratio < 80% of OpenBLAS for N >= 256,
+    # or if any single size drops below the 70% floor
     ./analyze_gate.py data/blas_sweep_native-fast.csv data/blas_sweep_openblas.csv \\
-        --gate --op gemm --threshold 0.80 --min-size 256
+        --gate --op gemm --threshold 0.80 --floor 0.70 --min-size 256
 
     # Compare against BLIS instead of OpenBLAS (table or gate)
     ./analyze_gate.py data/blas_sweep_*.csv --reference blis
@@ -33,6 +38,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import statistics
 import sys
 from collections import defaultdict
 
@@ -93,7 +99,34 @@ def print_table(data, peak, reference):
             print(line)
 
 
-def run_gate(data, op, threshold, min_size, reference):
+def run_gate(data, op, threshold, min_size, reference, floor):
+    """Gate on the MEDIAN of the per-size ratios, with a per-size floor.
+
+    Rationale (#327). The original rule failed if any single size fell below
+    the threshold -- i.e. it gated on the minimum, the noisiest statistic
+    available. Two runs of the identical protocol on the same idle machine
+    produced these per-size ratios for gemm at N >= 256:
+
+        statistic                run A    run B    swing
+        median of ratios         82.3%    82.5%     0.2 pt
+        mean                     82.1%    82.2%     0.1 pt
+        min  (the old rule)      76.3%    78.7%     2.4 pt
+        worst single size          --       --      6.2 pt
+
+    They failed at disjoint sets of sizes, so the verdict was decided by noise.
+    The median is reproducible to ~0.2 points, roughly 30x more stable, and it
+    is also what the epic actually claims -- "within 10-20% of OpenBLAS" is an
+    aggregate statement, not a per-size one.
+
+    Raising the iteration count does not help: within-run stddev is already
+    only 0.3-2.2% of the median at 10 iterations. The variance is BETWEEN runs
+    (turbo/thermal state, allocation, page layout), not within them.
+
+    The floor keeps the rule honest. A genuine cliff at one size -- a blocking
+    pathology, a bad edge case -- must still fail, so no individual size may
+    drop below `floor`, set well under the threshold so ordinary +-6 point
+    noise cannot trip it.
+    """
     backends = data.get(op, {})
     nf = pick(backends, "native-fast", "native_fast")
     ref = pick(backends, reference, "openblas", "blas")
@@ -101,27 +134,54 @@ def run_gate(data, op, threshold, min_size, reference):
     if nf is None or ref is None:
         sys.exit(f"gate: need both native-fast and {reference} data for '{op}' "
                  f"(have: {sorted(backends)})")
-    failures = []
-    checked = 0
+
+    ratios = []
+    below_floor = []
     for n in sorted(backends[nf]):
         if n < min_size or n not in backends[ref] or backends[ref][n] <= 0:
             continue
-        checked += 1
         frac = backends[nf][n] / backends[ref][n]
-        status = "ok" if frac >= threshold else "LOW"
+        ratios.append((n, frac))
+        # Per-size marks are diagnostic: "low" is below the aggregate
+        # threshold (informational), "FLOOR" is below the hard floor (fatal).
+        if frac < floor:
+            status = "FLOOR"
+            below_floor.append((n, frac))
+        elif frac < threshold:
+            status = "low"
+        else:
+            status = "ok"
         print(f"  N={n:>5}  native-fast={backends[nf][n]:8.2f}  "
               f"{ref_name}={backends[ref][n]:8.2f}  {100*frac:5.1f}%  [{status}]")
-        if frac < threshold:
-            failures.append((n, frac))
-    if checked == 0:
+
+    if not ratios:
         sys.exit(f"gate: no comparable sizes >= {min_size} for '{op}'")
-    if failures:
-        worst = min(f for _, f in failures)
-        print(f"\nGATE FAIL: {op} below {threshold*100:.0f}% of {ref_name} at "
-              f"{len(failures)}/{checked} sizes (worst {worst*100:.1f}%).")
+
+    fracs = sorted(f for _, f in ratios)
+    med = statistics.median(fracs)
+    mean = statistics.fmean(fracs)
+    lo, hi = fracs[0], fracs[-1]
+    print(f"\n  median {100*med:.1f}%   mean {100*mean:.1f}%   "
+          f"min {100*lo:.1f}%   max {100*hi:.1f}%   ({len(fracs)} sizes)")
+
+    fails = []
+    if med < threshold:
+        fails.append(f"median {100*med:.1f}% < {100*threshold:.0f}%")
+    if below_floor:
+        worst_n, worst_f = min(below_floor, key=lambda t: t[1])
+        fails.append(f"{len(below_floor)} size(s) below the {100*floor:.0f}% "
+                     f"floor (worst N={worst_n} at {100*worst_f:.1f}%)")
+    if fails:
+        print(f"\nGATE FAIL: {op} vs {ref_name} — " + "; ".join(fails) + ".")
         return 1
-    print(f"\nGATE PASS: {op} >= {threshold*100:.0f}% of {ref_name} at all "
-          f"{checked} sizes (N >= {min_size}).")
+
+    note = ""
+    if lo < threshold:
+        note = (f" Individual sizes range down to {100*lo:.1f}%; per-size "
+                f"variation of a few points between runs is expected (#327).")
+    print(f"\nGATE PASS: {op} median {100*med:.1f}% >= {100*threshold:.0f}% of "
+          f"{ref_name}; all {len(fracs)} sizes >= the {100*floor:.0f}% floor "
+          f"(N >= {min_size}).{note}")
     return 0
 
 
@@ -136,18 +196,28 @@ def main():
                     help="reference backend to compare against (default: openblas; "
                          "e.g. blis, mkl)")
     ap.add_argument("--threshold", type=float, default=0.80,
-                    help="min native-fast/reference fraction (default: 0.80)")
+                    help="min MEDIAN native-fast/reference fraction across the "
+                         "gated sizes (default: 0.80)")
+    ap.add_argument("--floor", type=float, default=0.70,
+                    help="no individual size may fall below this fraction; "
+                         "catches a genuine single-size cliff while tolerating "
+                         "ordinary run-to-run spread (default: 0.70)")
     ap.add_argument("--min-size", type=int, default=256,
                     help="only gate sizes >= this (default: 256)")
     args = ap.parse_args()
     if args.peak_gflops is not None and args.peak_gflops <= 0:
         ap.error("--peak-gflops must be > 0")
+    if args.floor > args.threshold:
+        ap.error("--floor must be <= --threshold (the floor is the per-size "
+                 "backstop under the aggregate threshold)")
 
     data = load(args.csv)
     if args.gate:
-        print(f"Gate: {args.op} native-fast >= {args.threshold*100:.0f}% of "
-              f"{args.reference} for N >= {args.min_size}")
-        sys.exit(run_gate(data, args.op, args.threshold, args.min_size, args.reference))
+        print(f"Gate: {args.op} native-fast median >= {args.threshold*100:.0f}% "
+              f"of {args.reference} (per-size floor {args.floor*100:.0f}%) "
+              f"for N >= {args.min_size}")
+        sys.exit(run_gate(data, args.op, args.threshold, args.min_size,
+                          args.reference, args.floor))
     print_table(data, args.peak_gflops, args.reference)
 
 

--- a/benchmarks/data/README.md
+++ b/benchmarks/data/README.md
@@ -87,8 +87,9 @@ Reproduce the headline analyses directly from these files:
 
 ```bash
 # Epic #82 gate: is native-fast within 20% of OpenBLAS for GEMM at N >= 256?
+# Asserts the MEDIAN ratio >= 80%, plus a 70% per-size floor (#327).
 ../analyze_gate.py blas_sweep_native-fast.csv blas_sweep_openblas.csv \
-    --gate --op gemm --threshold 0.80 --min-size 256
+    --gate --op gemm --threshold 0.80 --floor 0.70 --min-size 256
 
 # Percent of a reference backend and of FMA peak (~78 GFLOP/s, 1 P-core fp64)
 ../analyze_gate.py blas_sweep_*.csv --peak-gflops 78

--- a/docs/benchmarks/i7-12700k.md
+++ b/docs/benchmarks/i7-12700k.md
@@ -10,11 +10,11 @@ for one desktop hybrid CPU, not a portable performance claim.
 
 ## Headline findings
 
-- **native-fast GEMM averages ~82% of OpenBLAS** single-threaded for N ≥ 256, at
-  70–78% of the machine's FMA peak. That is inside the epic's 10–20% target, but
-  **the #82 gate's 80% threshold has no margin**: per-size run-to-run spread
-  reaches several points, so individual runs fail at whichever sizes land low
-  (#327).
+- **native-fast GEMM is at ~82% of OpenBLAS** single-threaded for N ≥ 256 (median
+  82.3%), at 70–78% of the machine's FMA peak — inside the epic's 10–20% target,
+  so the **#82 gate passes**. Individual sizes range 76–87%; that spread is
+  run-to-run noise, not structure, which is why the gate asserts the median
+  rather than every size (#327).
 - **The generic C++ path is ~12× slower than native-fast** on GEMM (5 vs 60
   GFLOP/s). The SIMD/blocked path is what makes MTL5 competitive at all.
 - **Multi-core GEMM scaling improved** — native-fast now reaches **6.51× on 8
@@ -62,7 +62,7 @@ dominates small problems even with `MKL_NUM_THREADS=1`.
 of the range, which makes it a better reference than OpenBLAS for small-matrix
 work.
 
-### Epic #82 acceptance gate — FAILING, with no margin
+### Epic #82 acceptance gate — PASSING at 82.3%
 
 The gate asks whether MTL5's own kernels land within 10–20% of OpenBLAS for GEMM
 at N ≥ 256. Against this session's data:
@@ -70,12 +70,17 @@ at N ≥ 256. Against this session's data:
 ```text
 benchmarks/analyze_gate.py data/blas_sweep_native-fast.csv \
     data/blas_sweep_openblas.csv --gate --op gemm --threshold 0.80 --min-size 256
-GATE FAIL: gemm below 80% of openblas at 1/10 sizes (worst 76.3%)
+
+  median 82.3%   mean 82.1%   min 76.3%   max 86.5%   (10 sizes)
+
+GATE PASS: gemm median 82.3% >= 80% of openblas; all 10 sizes >= the 70% floor
 ```
 
-**The failure is real, but which sizes fail is not stable.** Repeating the
-identical protocol on an idle machine — same binaries, same sweep, same pinning
-— fails at a *different* set of sizes:
+**How the gate is assessed changed in #327, and the numbers below are why.** The
+original rule failed if *any* single size fell under 80% — gating on the minimum,
+the noisiest statistic available. Repeating the identical protocol on an idle
+machine — same binaries, same sweep, same pinning — trips a *different* set of
+sizes:
 
 | N | committed run | verification re-run |
 |---:|---:|---:|
@@ -95,16 +100,28 @@ No size falls below the threshold in both runs, and the per-size spread reaches
 the first run flagged is flat — 55.8, 55.7, 58.6, 59.1, **58.7 at N = 465**,
 58.8, 58.7, 59.4, 59.3, 59.5 GFLOP/s — with no structure at that size.
 
-So the honest reading is **a marginal gate, not a size-specific defect**.
-native-fast averages ~82% of OpenBLAS across N ≥ 256, comfortably inside the
-epic's 10–20% target, but an 80% threshold applied per-size to a single run has
-no margin against this much variance, so noise decides pass/fail.
+Aggregating fixes this. Only one statistic here reproduces:
 
-The variance has two known sources, both listed under [caveats](#caveats): the
-CPU governor is `powersave`, so per-size turbo behaviour is not pinned, and each
-size is a median over a small iteration count. **#327** tracks both reducing the
-measurement variance and deciding what the gate should assert — a median across
-sizes, or repeated failures, rather than any single size in a single run.
+| statistic | run A | run B | swing |
+|---|---:|---:|---:|
+| **median of ratios** | 82.3% | 82.5% | **0.2 pt** |
+| mean | 82.1% | 82.2% | 0.1 pt |
+| min (the pre-#327 rule) | 76.3% | 78.7% | 2.4 pt |
+
+So the gate now asserts the **median** ≥ 80%, with a per-size **floor** at 70%
+so a genuine cliff still fails while ±6-point noise does not. Both runs pass,
+which is the point: the verdict is a property of the kernel, not of which run
+you happened to take.
+
+native-fast is at ~82% of OpenBLAS across N ≥ 256 — inside the epic's 10–20%
+target. Individual sizes still range from 76% to 87%, and that range is expected
+rather than diagnostic.
+
+One correction to the earlier framing: raising the iteration count would *not*
+have helped. Within-run stddev is only 0.3–2.2% of the median at 10 iterations —
+the variance is *between* runs (turbo/thermal state, allocation, page layout),
+not within them. The remaining lever is the `powersave` governor, listed under
+[caveats](#caveats).
 
 > An earlier revision of this page reported the N = 465 result as a reproducible
 > kernel dip. That was wrong: the "repeats" backing it were taken on a loaded


### PR DESCRIPTION
Resolves #327.

## Summary

`run_gate` failed if **any** single size fell below the threshold — it gated on the minimum, the noisiest statistic available. Two runs of the identical protocol, same binaries and pinning, on the same idle machine, failed at **disjoint sets of sizes**, so the verdict was decided by noise rather than by the kernel.

| statistic | run A | run B | swing |
|---|---:|---:|---:|
| **median of ratios** | 82.3% | 82.5% | **0.2 pt** |
| mean | 82.1% | 82.2% | 0.1 pt |
| min (the old rule) | 76.3% | 78.7% | 2.4 pt |
| worst single size | — | — | **6.2 pt** |

The gate now asserts the **median** ≥ `--threshold` (0.80), with a new `--floor` (0.70) that no individual size may drop below. The median is ~30× more stable and matches what the epic actually claims — "within 10–20% of OpenBLAS" is an aggregate statement, not a per-size one. The floor keeps the rule honest: a genuine cliff still fails, while ±6-point noise does not.

## Changes

- `benchmarks/analyze_gate.py` — median-based gate, `--floor`, summary line (median/mean/min/max), per-size marks demoted to `ok`/`low`/`FLOOR` where only `FLOOR` is fatal. Validation rejects `--floor > --threshold`. The rationale and the numbers above are recorded in the docstring so the choice is not re-litigated from scratch.
- `benchmarks/README.md` — new "What the gate asserts, and why" section with the stability table.
- `benchmarks/data/README.md` — reproduction command updated.
- `docs/benchmarks/i7-12700k.md` — reported the gate as **FAILING**; now reports PASS at 82.3% with the aggregation rationale.

## Verification

| Check | Result |
|---|---|
| Run A (committed CSVs) | **PASS** — median 82.3%, exit 0 |
| Run B (independent re-run) | **PASS** — median 82.5%, exit 0 |
| Synthetic 50% cliff at N=705 | **FAIL** on floor, exit 1 |
| `--threshold 0.90` | **FAIL** on median |
| `--floor 0.9 --threshold 0.8` | rejected by argparse |
| `--reference blis` | PASS, median 84.1% |
| Table mode (non-gate path) | unchanged |
| `python3 -m py_compile` | clean |

The cliff case is the one that justifies the floor: the median stayed at 81.4% and would have passed on its own, but the floor caught it.

No gcc/clang build in the test matrix because **no C++ changed** — this PR touches one Python script and three Markdown files. `npm run build` for the docs site still produces 43 pages.

## One correction to the issue

#327 proposed "more iterations" as a variance fix. The data says otherwise: within-run stddev is already only **0.3–2.2%** of the median at 10 iterations. The variance is *between* runs (turbo/thermal state, allocation, page layout), not within them, so more iterations would cost time and change nothing. Recorded in the docstring and the README so it isn't retried. The remaining real lever is the `powersave` governor.

## Test plan

- [ ] CI passes
- [ ] Promote to ready when satisfied: `gh pr ready <N>`

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark acceptance criteria to require both an aggregate median performance threshold and a per-size minimum floor.
  * Clarified gate exit conditions, stability metrics, rerun variance, and dedicated-hardware guidance.
  * Updated benchmark results to show the GEMM gate passing with an 82.3% median ratio and 70% per-size floor.

* **Bug Fixes**
  * Improved benchmark gate evaluation with median and mean reporting, per-size floor checks, clearer diagnostics, and validation for incompatible thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->