### PR TITLE
ci: run CI when a draft PR is promoted to ready

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,16 @@ on:
     tags: [ 'v[0-9]*' ]
   pull_request:
     branches: [ main ]
+    # `ready_for_review` matters: the Tier 2 regression job gates on
+    # `pull_request.draft == false`, so a PR opened as a draft only ever has
+    # runs in which that job skipped. Without this trigger, promoting the draft
+    # re-evaluates nothing and Tier 2 never runs unless another commit is
+    # pushed -- and `gh pr checks` still reports green, because a skipped job
+    # is not a failure (#333).
+    #
+    # The other three are the defaults, and must be listed explicitly: naming
+    # `types` REPLACES the default set rather than extending it.
+    types: [ opened, synchronize, reopened, ready_for_review ]
 
 jobs:
   # -- ASCII guard: source files must contain only ASCII bytes ---------


### PR DESCRIPTION
Resolves #333.

## Problem

`pull_request` declared no `types`, so GitHub applied the default `[opened, synchronize, reopened]`. **`ready_for_review` is not in that set**, so promoting a draft triggered no run at all.

The Tier 2 `regression` job gates on `pull_request.draft == false`. For a PR opened as a draft, every run that exists was evaluated while it *was* a draft, so `regression` skipped in all of them — and promotion re-evaluated nothing. Tier 2 therefore never ran unless someone pushed another commit.

It failed silently: `gh pr checks` reports green, because a skipped job is not a failure. A reviewer sees green and merges believing the documented two-tier policy held.

Observed directly on #332 — same commit, same content:

```
regression   skipping   0       <- after `gh pr ready`
regression   pass       5m45s   <- after close/reopen (which fires `reopened`)
```

## Fix

```yaml
  pull_request:
    branches: [ main ]
    types: [ opened, synchronize, reopened, ready_for_review ]
```

The three defaults are listed explicitly because naming `types` **replaces** the default set rather than extending it — omitting them would silently stop CI on ordinary pushes to a PR, which would be far worse than the bug being fixed.

## Validating the fix on itself

`pull_request` workflows run from the PR's head branch, so this change is in effect for this PR. That makes it self-testing, which is why **this PR is deliberately opened as a draft**:

1. Draft runs → `regression` skips (the pre-fix behaviour, still correct: Tier 2 is meant to skip on drafts).
2. `gh pr ready` → with this change, a fresh run fires with `draft == false`.
3. `regression` executes rather than skipping — without any push in between.

Step 3 is exactly what does not happen on `main` today. I will post the before/after check output on this PR once promoted.

## Test plan

- [ ] Draft CI passes, `regression` skips (expected on a draft)
- [ ] `gh pr ready` triggers a new run without a push
- [ ] `regression` runs and passes in that new run
- [ ] Merge

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Continuous integration now runs when pull requests are opened, updated, reopened, or marked ready for review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->