### PR TITLE
fix(bench): default SPARSE_SIZES to 100,160 in run_scaling_297.sh

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -342,9 +342,32 @@ benchmarks/analyze_scaling.py benchmarks/data/scaling_ewise.csv --op ewise-vec
 ```
 
 Environment: `BENCH_PCPUS`, `THREADS`, `LAPACK_SIZES` (default
-`1024,2048,4096`), `SPARSE_SIZES` (2-D grid sides, default `200,320`), `BUILD`
+`1024,2048,4096`), `SPARSE_SIZES` (2-D grid sides, default `100,160`), `BUILD`
 (default `build-scaling-297`), `JOBS`. `analyze_scaling.py` keys its series on
 `(operation, size)`, so families that share a size no longer collide.
+
+#### Sparse sizes grow expensive fast
+
+The sparse family's cost is dominated by the **untimed factorization** each case
+performs before its (millisecond) solves are measured, and it scales far worse
+than the grid side suggests. Whole-suite wall clock at `T=1` on an i7-12700K:
+
+| grid side | 2-D case | wall clock |
+|---|---|---|
+| 100 | n=10,000 | 11 s |
+| 160 | n=25,600 | 3 m 38 s |
+| 200 | n=40,000 | 8 m 46 s |
+| 320 | n=102,400 | not measured |
+
+That is **per thread count** — the factorization is serial, so every value in
+`THREADS` pays it again. The default is therefore ~15 minutes for
+`THREADS="1 2 4 8"`, in proportion with the rest of the driver.
+
+The default was `200,320` until #321; a `T=1` run was killed after **3 h 28 min**
+without finishing its first size. #322 clamped the 3-D grid, which is what
+brought side 200 down to the 8 m 46 s above, but `200,320` remains impractical
+for a four-thread-count sweep. Raise `SPARSE_SIZES` deliberately, with the table
+above in mind.
 
 Results are written up in `docs/design/issue-297-threading-results.md`; the plan
 is `docs/design/issue-297-threading-benchmark-plan.md`.

--- a/benchmarks/data/README.md
+++ b/benchmarks/data/README.md
@@ -114,14 +114,14 @@ The scaling and scoreboard files come from the other drivers:
 
 ```bash
 BENCH_PCPUS=0,2,4,6,8,10,12,14 ../run_scaling.sh            # gemm_scaling_*.csv (#108)
-BENCH_PCPUS=0,2,4,6,8,10,12,14 SPARSE_SIZES=100,160 \
-    ../run_scaling_297.sh                                   # scaling_*.csv (#297)
+BENCH_PCPUS=0,2,4,6,8,10,12,14 ../run_scaling_297.sh         # scaling_*.csv (#297)
 ../../build-klu/benchmarks/bench_klu         --csv klu_scoreboard.csv     klu/*/*.mtx
 ../../build-superlu/benchmarks/bench_superlu --csv superlu_scoreboard.csv superlu/*/*.mtx
 ```
 
-`SPARSE_SIZES` is set explicitly because the driver default (`200,320`) does not
-complete on this machine — see #321.
+`scaling_sparse.csv` was measured at grid sides `100,160`, which is now the
+driver default (#321 — the previous `200,320` did not complete on this machine).
+No override is needed to reproduce it.
 
 ## Plots
 

--- a/benchmarks/run_scaling_297.sh
+++ b/benchmarks/run_scaling_297.sh
@@ -17,7 +17,8 @@
 #                (see: lscpu -e=CPU,CORE,MAXMHZ).
 #   THREADS      thread counts to sweep (default "1 2 4 8").
 #   LAPACK_SIZES dense factor sizes (default 1024,2048,4096).
-#   SPARSE_SIZES sparse 2-D grid sides (default 200,320).
+#   SPARSE_SIZES sparse 2-D grid sides (default 100,160 -- see the cost note
+#                below before raising it).
 #   BUILD        build dir (default build-scaling-297).
 #   JOBS         build parallelism (default 4).
 #
@@ -31,7 +32,25 @@ cd "$ROOT"
 PCPUS="${BENCH_PCPUS:-0,2,4,6,8,10,12,14}"
 THREADS="${THREADS:-1 2 4 8}"
 LAPACK_SIZES="${LAPACK_SIZES:-1024,2048,4096}"
-SPARSE_SIZES="${SPARSE_SIZES:-200,320}"
+# Sparse grid sides. The cost is dominated by the UNTIMED factorization each
+# case performs before the (millisecond) solves are measured, and it grows
+# steeply. Measured whole-suite wall clock at T=1 on an i7-12700K, with the
+# 3-D grid clamped (#322):
+#
+#     side 100    11 s
+#     side 160     3 m 38 s
+#     side 200     8 m 46 s
+#     side 320    not measured; its 2-D case alone is n=102,400
+#
+# That is per thread count, and the factorization is serial, so every value in
+# THREADS pays it again: this default is ~230 s x 4 = ~15 min, in proportion
+# with the rest of this driver.
+#
+# The previous default of 200,320 did not complete: a T=1 run was killed after
+# 3 h 28 min without finishing its first size (#321). #322 clamped the 3-D grid,
+# which is what brought side 200 down to the 8 m 46 s above, but 200,320 is
+# still far too slow for a four-thread-count sweep. Raise this deliberately.
+SPARSE_SIZES="${SPARSE_SIZES:-100,160}"
 BUILD="${BUILD:-build-scaling-297}"
 DATA="benchmarks/data"
 mkdir -p "$DATA"

--- a/docs/benchmarks/i7-12700k.md
+++ b/docs/benchmarks/i7-12700k.md
@@ -288,8 +288,11 @@ performance comparisons, not accuracy trade-offs.
   figures against numbers taken another way.
 - **FMA peak is taken as ~78 GFLOP/s** for one P-core in fp64 (AVX2, 2 FMA/cycle
   × 4 doubles × 2 flops × ~4.9 GHz). Percentages of peak inherit that estimate.
-- **The `#297` sparse family ran at grid sides 100,160**, not the driver's
-  default `200,320`, which does not complete on this machine (see #321).
+- **The `#297` sparse family ran at grid sides 100,160.** That was an override
+  at the time; it is now the driver default, because the previous `200,320` did
+  not complete on this machine (#321). Sparse cost is dominated by the untimed
+  factorization and grows steeply with the grid side — 11 s at side 100 versus
+  8 m 46 s at side 200, *per thread count*.
 
 ## Reproducing
 


### PR DESCRIPTION
Resolves #321 (the remaining item — #322 fixed the root cause).

## Problem

`run_scaling_297.sh` defaulted to `SPARSE_SIZES=200,320`, which does not complete. A `T=1` run was killed after **3 h 28 min** without finishing its first size, while the four dense families in the same pass finished in under 10 minutes combined.

Cost is dominated by the **untimed factorization** each case performs before its millisecond solves are measured, and it grows far faster than the grid side suggests. Whole-suite wall clock at `T=1` on an i7-12700K, with the 3-D grid clamped per #322:

| grid side | 2-D case | wall clock |
|---|---|---|
| 100 | n=10,000 | 11 s |
| 160 | n=25,600 | 3 m 38 s |
| 200 | n=40,000 | 8 m 46 s |
| 320 | n=102,400 | not measured |

That is **per thread count** — the factorization is serial, so every value in `THREADS` pays it again.

## Fix

Default to `100,160`, which is also `bench_sparse`'s own default.

Measured end-to-end on this branch: **3 m 50 s** for one thread count, so ~15 min for `THREADS="1 2 4 8"` — in proportion with the rest of the driver, where it previously dominated everything else by two orders of magnitude.

The cost table is recorded next to the default in the script *and* in `benchmarks/README.md`, so the value gets raised deliberately rather than by habit. That is the part worth reviewing: the previous default was almost certainly never run end-to-end at `T=1` on this hardware, and nothing in the file warned about the cost curve.

## Note on #322

#322 clamped the 3-D Laplacian grid, which is what brought side 200 down to the 8 m 46 s above — from "never finished". That was the root-cause fix; this is the remaining half. `200,320` is still far too slow for a four-thread-count sweep, so the default had to move as well.

I did not measure side 320 even post-clamp: its 2-D case alone is n=102,400, and the measurement would cost ~30 min for a number that only confirms a default nobody should use. It is documented as unmeasured rather than estimated.

## Changes

- `benchmarks/run_scaling_297.sh` — default changed; cost table and rationale recorded at the assignment.
- `benchmarks/README.md` — new "Sparse sizes grow expensive fast" subsection.
- `benchmarks/data/README.md` — the reproduction command no longer needs an override.
- `docs/benchmarks/i7-12700k.md` — the caveat described `100,160` as an override; it is now the default.

## Verification

- Default resolves to `100,160`; `SPARSE_SIZES=64` override still honoured.
- Sparse family runs to completion at the new default in 3 m 50 s (17 CSV rows), matching the documented estimate.
- `bash -n` clean; `npm run build` still produces 43 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)