### PR TITLE
fix(operation): stop permuting already-computed L columns in ldlt_bk

### DIFF
--- a/include/mtl/operation/ldlt_bk.hpp
+++ b/include/mtl/operation/ldlt_bk.hpp
@@ -37,10 +37,29 @@ struct bk_pivot_info {
     std::vector<int> ipiv;
 };
 
-/// Swap rows and columns r1 and r2 in the lower triangle of a symmetric matrix.
-/// Only the lower triangle (and diagonal) is accessed and modified.
+/// Swap rows and columns r1 and r2 in the lower triangle of a symmetric matrix,
+/// touching only columns >= first_col. Only the lower triangle (and diagonal)
+/// is accessed and modified.
+///
+/// `first_col` matters for Bunch-Kaufman. The factorization is a PRODUCT of
+/// per-step permutations and elementary transforms,
+///
+///     A = (P_0 L_0)(P_1 L_1)... D ...(P_1 L_1)^T (P_0 L_0)^T
+///
+/// not a single global permutation, and `ldlt_bk_solve` replays those
+/// permutations one step at a time (as LAPACK's dsytrs does). So the L columns
+/// already written by earlier steps must be left ALONE: they are recorded in the
+/// row ordering that was current when they were computed, and the solve reaches
+/// them before the later interchanges are replayed.
+///
+/// Permuting them here instead produces a factor in the "single global P"
+/// convention while the solve still reads the per-step one. The two disagree
+/// the moment any interchange happens, which silently returned wrong solutions
+/// with info == 0 (#335). Passing first_col = k keeps the swap inside the
+/// trailing submatrix, which is also what makes the stored factor match
+/// LAPACK's dsytrf byte for byte.
 template <Matrix M>
-void symmetric_swap(M& A, std::size_t r1, std::size_t r2) {
+void symmetric_swap(M& A, std::size_t r1, std::size_t r2, std::size_t first_col = 0) {
     if (r1 == r2) return;
     if (r1 > r2) std::swap(r1, r2);
     std::size_t n = A.num_rows();
@@ -50,8 +69,8 @@ void symmetric_swap(M& A, std::size_t r1, std::size_t r2) {
     A(r1, r1) = A(r2, r2);
     A(r2, r2) = tmp;
 
-    // Swap entries in rows r1 and r2 for columns < r1
-    for (std::size_t j = 0; j < r1; ++j) {
+    // Swap entries in rows r1 and r2 for columns in [first_col, r1)
+    for (std::size_t j = first_col; j < r1; ++j) {
         tmp = A(r1, j);
         A(r1, j) = A(r2, j);
         A(r2, j) = tmp;
@@ -146,13 +165,17 @@ int ldlt_bk_factor(M& A, bk_pivot_info& pivots) {
                 // Test 3: A(r,r) is a good pivot - swap r<->k, use 1x1
                 use_1x1 = true;
                 swap_r = r;
-                symmetric_swap(A, k, r);
+                // first_col = k: leave the L columns written by steps < k
+                // untouched; the solve replays this interchange at step k.
+                symmetric_swap(A, k, r, k);
             } else {
                 // Use 2x2 pivot from rows/cols {k, r}
                 // Swap r <-> k+1 to put the 2x2 block at positions {k, k+1}
                 use_2x2 = true;
                 if (r != k + 1)
-                    symmetric_swap(A, k + 1, r);
+                    // first_col = k: column k belongs to the 2x2 block being
+                    // formed and must be swapped; columns < k must not.
+                    symmetric_swap(A, k + 1, r, k);
             }
         }
 

--- a/tests/unit/operation/test_ldlt_bk.cpp
+++ b/tests/unit/operation/test_ldlt_bk.cpp
@@ -2,6 +2,7 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 #include <cmath>
+#include <cstdint>
 #include <stdexcept>
 #include <mtl/mat/dense2D.hpp>
 #include <mtl/vec/dense_vector.hpp>
@@ -256,4 +257,93 @@ TEST_CASE("Bunch-Kaufman on empty matrix", "[operation][ldlt_bk]") {
     bk_pivot_info pivots;
     int info = ldlt_bk_factor(A, pivots);
     REQUIRE(info == 0);
+}
+
+// ---------------------------------------------------------------------------
+// Regression: #335 -- wrong solutions whenever a pivot interchange occurs.
+//
+// The factorization permuted the L columns already written by earlier steps,
+// putting the stored factor in the "single global P" convention while
+// ldlt_bk_solve replays the interchanges one step at a time. The two agree only
+// when no interchange happens, so the pre-existing n = 2 and n = 3 cases above
+// all passed while anything larger silently returned a wrong answer with
+// info == 0 -- backward errors around 1e-1 rather than 1e-16.
+//
+// The reported 4x4 is exercised verbatim, plus a randomized sweep over sizes
+// large enough to force interchanges and 2x2 blocks.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Bunch-Kaufman with pivot interchange (#335)", "[operation][ldlt_bk][regression]") {
+    const std::size_t n = 4;
+    const double a[4][4] = {
+        { 1.22060812, -1.33949552,  0.42837340, -0.12346316},
+        {-1.33949552,  1.41437718, -0.12405069,  2.00815707},
+        { 0.42837340, -0.12405069,  0.22988654,  0.60489374},
+        {-0.12346316,  2.00815707,  0.60489374,  1.62715984}};
+
+    mat::dense2D<double> A(n, n), Aorig(n, n);
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j) { A(i,j) = a[i][j]; Aorig(i,j) = a[i][j]; }
+
+    vec::dense_vector<double> b(n), x(n);
+    b[0] = 1.59456055; b[1] = 0.23043417; b[2] = -0.06491033; b[3] = -0.96898025;
+
+    bk_pivot_info pivots;
+    REQUIRE(ldlt_bk_factor(A, pivots) == 0);
+    ldlt_bk_solve(A, pivots, x, b);
+
+    // This matrix pivots: ipiv is {1,4,4,4}, i.e. two 1x1 interchanges and no
+    // 2x2 block. The test is only meaningful if an interchange actually occurs.
+    bool interchanged = false;
+    for (std::size_t k = 0; k < n; ++k)
+        if (pivots.ipiv[k] > 0 && static_cast<std::size_t>(pivots.ipiv[k] - 1) != k)
+            interchanged = true;
+    REQUIRE(interchanged);
+
+    REQUIRE(backward_error(Aorig, x, b) < 1e-12);
+}
+
+TEST_CASE("Bunch-Kaufman random symmetric indefinite sweep (#335)",
+          "[operation][ldlt_bk][regression]") {
+    // Deterministic LCG so the sweep is reproducible without <random> policy.
+    std::uint64_t seed = 20260802u;
+    auto next = [&seed]() {
+        seed = seed * 6364136223846793005ull + 1442695040888963407ull;
+        return static_cast<double>((seed >> 11) % 2000001) / 1000000.0 - 1.0;  // [-1,1]
+    };
+
+    std::size_t saw_2x2 = 0, saw_swap = 0, checked = 0;
+
+    for (std::size_t n = 4; n <= 12; ++n) {
+        for (int trial = 0; trial < 20; ++trial) {
+            mat::dense2D<double> A(n, n), Aorig(n, n);
+            for (std::size_t i = 0; i < n; ++i)
+                for (std::size_t j = 0; j <= i; ++j) {
+                    double v = next();
+                    A(i,j) = v; A(j,i) = v; Aorig(i,j) = v; Aorig(j,i) = v;
+                }
+
+            vec::dense_vector<double> b(n), x(n);
+            for (std::size_t i = 0; i < n; ++i) b[i] = next();
+
+            bk_pivot_info pivots;
+            if (ldlt_bk_factor(A, pivots) != 0) continue;   // singular draw
+            ldlt_bk_solve(A, pivots, x, b);
+            ++checked;
+
+            for (std::size_t k = 0; k < n; ++k) {
+                if (pivots.ipiv[k] < 0) { ++saw_2x2; break; }
+                if (static_cast<std::size_t>(pivots.ipiv[k] - 1) != k) { ++saw_swap; break; }
+            }
+
+            INFO("n = " << n << ", trial = " << trial);
+            REQUIRE(backward_error(Aorig, x, b) < 1e-10);
+        }
+    }
+
+    REQUIRE(checked > 0);
+    // Guard the guard: if the sweep stopped producing interchanges or 2x2
+    // blocks it would pass while covering only the regime that never broke.
+    REQUIRE(saw_2x2 > 0);
+    REQUIRE(saw_swap > 0);
 }


### PR DESCRIPTION
Resolves #335.

## Root cause

`symmetric_swap` permuted the **entire** rows `r1` and `r2` — including the L columns written by *earlier* steps (`ldlt_bk.hpp`, the `j < r1` loop).

That puts the stored factor in the "single global P" convention (`P*A*P^T = L*D*L^T` for one composite `P`), while `ldlt_bk_solve` replays the interchanges **one step at a time**, as LAPACK's `dsytrs` does. Bunch-Kaufman is a *product* of per-step permutations and elementary transforms:

```
A = (P_0 L_0)(P_1 L_1) ... D ... (P_1 L_1)^T (P_0 L_0)^T
```

so those earlier L columns are recorded in the row ordering that was current when they were computed, and the solve reaches them *before* the later interchanges are replayed. Permuting them makes factor and solve disagree the moment anything is interchanged — which is exactly the reported symptom.

The fix restricts the swap to columns `>= k`. For a 2×2 pivot, column `k` still swaps (it belongs to the block being formed); columns `< k` no longer do.

## The pivot search was never wrong

Worth stating because it narrows the blast radius: `ipiv` matched LAPACK's `dsytrf` **exactly, both before and after** this change. Only the *application* of the interchange was wrong. With the fix, the stored factor matches `dsytrf` entry for entry too.

Diagnosis followed the report's own lead — it observed the numerics were sound whenever no permutation was applied. Reconstructing `L*D*L^T` against `P*A*P^T` confirmed the factorization was self-consistent under the global-P reading (2.2e-16), which located the disagreement between the two conventions rather than in the arithmetic.

## Verification against LAPACK

5700 random symmetric matrices, n = 2..20 — 4874 containing a 2×2 block, 3943 containing a 1×1 interchange:

| | before | after |
|---|---|---|
| backward-error failures | **4560 / 5700** | **0 / 5700** |
| worst backward error | 7.127e-01 | **2.474e-16** |
| factor ≠ `dsytrf` | 4560 | 0 |
| `ipiv` ≠ `dsytrf` | 0 | 0 |

On the reported 4×4, the factored matrix now matches `dsytrf` byte for byte and the backward error goes from `6.300e-01` to `4.200e-17`.

## Tests

The file covered only n = 2 and n = 3 — entirely inside the no-interchange regime that always worked, which is why this survived. Added:

- the reported 4×4, which **asserts an interchange actually occurs**, so the case cannot silently stop covering the bug if pivot selection ever shifts;
- a randomized n = 4..12 sweep that likewise **asserts it saw both a 2×2 block and a 1×1 interchange** before trusting its own pass.

Both new cases fail without the fix (verified by reverting the header and keeping the tests: 2 failed / 10 passed).

## Test results

| Target | GCC 13 build | GCC 13 test | Clang 18 build | Clang 18 test |
|---|---|---|---|---|
| `op_test_ldlt_bk` | OK | PASS (206 assertions) | OK | PASS (206 assertions) |
| full suite | OK | PASS (154/154) | OK | PASS (154/154) |

## Note

Reported from `mtl5-python`, where the Bunch-Kaufman binding was withheld pending this fix. `ldlt_bk` is the recommended path for symmetric indefinite systems and the fallback when plain `ldlt` rejects a matrix, so a silent wrong answer under `info == 0` was the worst-case failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)