### PR TITLE
perf(operation): pack the shared B panel with the whole team, not the leader

### DIFF
--- a/include/mtl/detail/gemm_blocked.hpp
+++ b/include/mtl/detail/gemm_blocked.hpp
@@ -268,11 +268,27 @@ void gemm_blocked(std::size_t m, std::size_t n, std::size_t k,
             const std::size_t npanels = (nci + NR - 1) / NR;
             for (std::size_t pc = 0; pc < k; pc += KC) {
                 const std::size_t kci = std::min(KC, k - pc);
-                if (ic_id == 0 && !failed.load(std::memory_order_relaxed)) {
-                    try {                                         // team leader packs shared B once
-                        pack_B<TAB, NR>(B + static_cast<std::ptrdiff_t>(pc) * b_rs
-                                          + static_cast<std::ptrdiff_t>(jc) * b_cs,
-                                        b_rs, b_cs, kci, nci, Bteam);
+                // The whole team packs the shared B block cooperatively, each
+                // member taking a disjoint range of NR-column panels. Packing
+                // used to be done by the leader alone while every other member
+                // sat on the barrier -- a serial region proportional to
+                // kc*nc per pc step, which is what capped parallel efficiency
+                // (#110): at N=2048 with one team of 8, thread 0 packed ~67 MB
+                // while 7 cores idled.
+                //
+                // Panels are independent and land at computable disjoint
+                // offsets, and packing is pure data movement, so the packed
+                // bytes -- and therefore the GEMM result -- are identical to
+                // the serial pack for any split.
+                if (!failed.load(std::memory_order_relaxed)) {
+                    try {
+                        const std::size_t per = (npanels + ic_nt - 1) / ic_nt;
+                        const std::size_t q0  = std::min<std::size_t>(npanels, ic_id * per);
+                        const std::size_t q1  = std::min<std::size_t>(npanels, q0 + per);
+                        if (q0 < q1)
+                            pack_B_panels<TAB, NR>(B + static_cast<std::ptrdiff_t>(pc) * b_rs
+                                                     + static_cast<std::ptrdiff_t>(jc) * b_cs,
+                                                   b_rs, b_cs, kci, nci, Bteam, q0, q1);
                     } catch (...) { record_failure(std::current_exception()); }
                 }
                 bar.wait();                                       // publish B to the team

--- a/include/mtl/detail/gemm_pack.hpp
+++ b/include/mtl/detail/gemm_pack.hpp
@@ -78,14 +78,27 @@ void pack_A(const T* A, std::ptrdiff_t rs, std::ptrdiff_t cs,
 ///     Bp[q*NR*k + p*NR + j] = (q*NR+j < n) ? B(p, q*NR+j) : 0
 /// for p in [0,k), j in [0,NR). This is exactly what gemm_microkernel reads as
 /// Bp[p*NR + j]. `Bp` must hold packed_B_size(k,n,NR) elements.
+/// Pack only panels [q0, q1) of the same layout, writing each to the offset it
+/// would occupy in a whole-panel pack: panel q owns Bp[q*NR*k, (q+1)*NR*k).
+///
+/// Panels are independent and their destinations are disjoint and computable, so
+/// a team of threads can pack one B block cooperatively by taking disjoint panel
+/// ranges. Packing is pure data movement -- no arithmetic -- so the packed bytes
+/// are identical however the range is split, and any GEMM consuming the result
+/// stays bit-identical. That is what lets the threaded pack in gemm_blocked.hpp
+/// preserve the bit-exactness guarantee (#110).
 template <typename T, std::size_t NR>
     requires mtl::Scalar<T>
-void pack_B(const T* B, std::ptrdiff_t rs, std::ptrdiff_t cs,
-            std::size_t k, std::size_t n, T* Bp) {
+void pack_B_panels(const T* B, std::ptrdiff_t rs, std::ptrdiff_t cs,
+                   std::size_t k, std::size_t n, T* Bp,
+                   std::size_t q0, std::size_t q1) {
     static_assert(NR > 0, "NR must be positive");
-    std::size_t dst = 0;
-    for (std::size_t j0 = 0; j0 < n; j0 += NR) {
+    const std::size_t npanels = (n + NR - 1) / NR;
+    if (q1 > npanels) q1 = npanels;
+    for (std::size_t q = q0; q < q1; ++q) {
+        const std::size_t j0 = q * NR;
         const std::size_t nr = (n - j0 < NR) ? (n - j0) : NR;  // cols in this panel
+        std::size_t dst = q * NR * k;                          // this panel's slot
         for (std::size_t p = 0; p < k; ++p) {
             const T* row = B + static_cast<std::ptrdiff_t>(p) * rs
                              + static_cast<std::ptrdiff_t>(j0) * cs;
@@ -95,6 +108,13 @@ void pack_B(const T* B, std::ptrdiff_t rs, std::ptrdiff_t cs,
                 Bp[dst++] = T(0);  // zero-pad trailing cols up to NR
         }
     }
+}
+
+template <typename T, std::size_t NR>
+    requires mtl::Scalar<T>
+void pack_B(const T* B, std::ptrdiff_t rs, std::ptrdiff_t cs,
+            std::size_t k, std::size_t n, T* Bp) {
+    pack_B_panels<T, NR>(B, rs, cs, k, n, Bp, 0, (n + NR - 1) / NR);
 }
 
 } // namespace mtl::detail


### PR DESCRIPTION
Relates to #110 — closes the parallel-efficiency gap, leaves the `mc`/granularity coupling open.

## Summary

Parallel efficiency at 8 P-cores was **79%**, against ~89–92% for OpenBLAS, BLIS and MKL. The cause turned out to be a **serial region**, not the decomposition: inside each jc-team only `ic_id == 0` packed the shared B block while every other member blocked on the barrier.

At N=2048 there is one team of 8 (`nc=4096` makes `njb=1`), `kc=256` gives 8 `pc` steps, and each pack moves `kc*nc*8` = **8.39 MB** — so thread 0 copied ~67 MB while 7 cores idled.

Solving Amdahl backwards from the measured 6.36× gives a serial fraction of **~3.7%**, i.e. ~11 ms of the 297 ms single-thread time — the same order as that packing cost. That is what pointed at it.

## Fix

Every team member packs a disjoint range of NR-column panels. Panels are independent and land at computable disjoint offsets (`panel q` owns `Bp[q*NR*k, (q+1)*NR*k)`), so the split needs no coordination beyond the barrier that already published the buffer. New `pack_B_panels`; the existing `pack_B` delegates to it.

## Measured (N=2048, pinned P-cores, native-fast)

| T | before | after | Δ |
|---:|---:|---:|---:|
| 1 | 57.83 | 57.30 | −0.9% (noise; serial path untouched) |
| 2 | 112.56 | 114.02 | +1.3% |
| 4 | 209.28 | 224.17 | +7.1% |
| 8 | **367.51** | **418.06** | **+13.8%** |

**Speedup 6.36× → 7.30×, efficiency 79% → 91%** — meeting this issue's ≥85% target.

For context, the same machine measured today: OpenBLAS 7.14× / 89%, MKL 7.24× / 91%, BLIS 7.39× / 92%. Relative throughput at 8 threads rises from 70.3% to **79.1% of OpenBLAS**, which is essentially the single-thread ratio — so **threading is no longer what separates them**; the remainder is the single-core kernel gap tracked in #82.

## Bit-exactness

**Preserved by construction.** Packing is pure data movement, not arithmetic, so the packed bytes are identical however the panel range is split, and no accumulation order changes.

Verified anyway — threaded output byte-identical to serial at T=2, 4, 8:

| shape | | shape | |
|---|---|---|---|
| 512³ | identical | 64×4096×1024 (wide) | identical |
| 2048³ | identical | 4096×64×512 (tall) | identical |
| 1000×777×333 (odd) | identical | | |

## Test Results

| Target | gcc build | gcc test | clang build | clang test |
|---|---|---|---|---|
| full suite (serial) | OK | PASS 156/156 | OK | PASS 156/156 |
| full suite (`MTL5_NUM_THREADS=4`) | OK | PASS 156/156 | OK | PASS 156/156 |
| TSan `_mt` lane | — | — | OK | PASS 6/6, clean |

## Scope

This does **not** address the `mc`/granularity coupling that #110 also describes, or its dependency #347 (`nc` sized to 100% of a shared L3). Both remain open — but with efficiency now at 91%, they are a smaller prize than when the issue was re-scoped, so `Relates to` rather than `Resolves`.

The committed scaling data and the i7-12700K result page still carry the old numbers; updating them wants a full `run_scaling.sh` sweep across all backends, which is a separate pass.

## Test plan

- [ ] CI passes
- [ ] Promote to ready when satisfied: `gh pr ready <N>`

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved matrix multiplication performance on multi-threaded workloads by distributing preparation work more evenly across available threads.
  * Preserved existing synchronization and error-handling behavior for reliable execution.
  * Maintained compatibility with existing matrix multiplication interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->