### PR TITLE
feat(operation): add Hermitian Cholesky (LL^H) and restrict LL^T to real types

### DIFF
--- a/include/mtl/detail/structure_tol.hpp
+++ b/include/mtl/detail/structure_tol.hpp
@@ -1,0 +1,49 @@
+#pragma once
+// MTL5 -- Tolerances for structural predicates on matrices (symmetric?
+// Hermitian? real diagonal?).
+//
+// These exist because an EXACT structural test is the wrong test. A matrix
+// assembled in floating point -- from an FEM pass, or from a blocked B^H*B
+// whose (i,j) and (j,i) sums accumulate in different orders -- carries its
+// structure only to rounding. An exact test passes on every matrix a test
+// author types as a literal and fails on the ones a user computes: during the
+// #352 work a ONE-ULP perturbation of a Hermitian matrix defeated an exact
+// guard and produced an answer wrong in the first significant digit under
+// info == 0, which is the failure the guard existed to prevent.
+//
+// Shared by ldlt.hpp and cholesky.hpp so the two use the same threshold.
+
+#include <cmath>
+#include <cstddef>
+#include <limits>
+
+#include <mtl/concepts/magnitude.hpp>
+#include <mtl/functor/scalar/real.hpp>
+#include <mtl/functor/scalar/imag.hpp>
+
+namespace mtl::detail {
+
+/// LAPACK's CABS1: |Re z| + |Im z|. Within a factor of sqrt(2) of |z| and free
+/// of the sqrt/hypot that abs() would cost -- which is what a structural noise
+/// threshold wants, since the threshold itself is only order-of-magnitude.
+/// The prepass is O(n^2) against an O(n^3/3) factorization, so avoiding a hypot
+/// per entry matters at small n.
+template <typename T>
+constexpr magnitude_t<T> cabs1(const T& z) {
+    using std::abs;
+    return abs(functor::scalar::real<T>::apply(z))
+         + abs(functor::scalar::imag<T>::apply(z));
+}
+
+/// Threshold separating "this matrix has this structure" from "rounding noise",
+/// scaled by the size of the problem and the magnitude of the data.
+///
+/// For a type without a std::numeric_limits specialization epsilon() is 0, so
+/// this degrades to an exact test rather than to something arbitrary -- which
+/// matters for the custom number types this library targets.
+template <typename Mag>
+constexpr Mag structure_tol(std::size_t n, Mag scale) {
+    return static_cast<Mag>(n) * std::numeric_limits<Mag>::epsilon() * scale;
+}
+
+}  // namespace mtl::detail

--- a/include/mtl/operation/cholesky.hpp
+++ b/include/mtl/operation/cholesky.hpp
@@ -1,15 +1,38 @@
 #pragma once
-// MTL5 -- Cholesky factorization for symmetric positive definite matrices
-// A = L*L^T. In-place: lower triangle of A is overwritten with L.
+// MTL5 -- Cholesky factorization for positive definite matrices
+//
+// LL^T vs LL^H (#353). This file provides BOTH, and they are not
+// interchangeable for complex elements:
+//
+//   cholesky_factor / cholesky_solve      A = L*L^T   -- REAL symmetric
+//                                         positive definite only
+//   cholesky_h_factor / cholesky_h_solve  A = L*L^H   -- real symmetric OR
+//                                         HERMITIAN positive definite
+//
+// For real elements conjugation is the identity, so the two agree. For complex
+// elements only the LL^H form exists: "positive definite" is a statement about
+// an ordering, and a complex SYMMETRIC matrix has no real diagonal to order.
+// That is why cholesky_factor is restricted to real element types rather than
+// given a complex-symmetric variant the way ldlt_factor has one -- see the
+// static_assert below.
+//
+// In-place: lower triangle of A is overwritten with L.
 // Optional LAPACK dispatch when MTL5_HAS_LAPACK is defined and types qualify.
 #include <algorithm>
 #include <cassert>
 #include <cmath>
 #include <cstddef>
+#include <type_traits>
 #include <mtl/concepts/matrix.hpp>
 #include <mtl/concepts/vector.hpp>
+#include <mtl/concepts/magnitude.hpp>
+#include <mtl/concepts/scalar.hpp>
 #include <mtl/vec/dense_vector.hpp>
 #include <mtl/math/identity.hpp>
+#include <mtl/functor/scalar/conj.hpp>
+#include <mtl/functor/scalar/real.hpp>
+#include <mtl/functor/scalar/imag.hpp>
+#include <mtl/detail/structure_tol.hpp>
 #include <mtl/interface/dispatch_traits.hpp>
 #include <mtl/detail/thread_pool.hpp>
 #ifdef MTL5_HAS_LAPACK
@@ -18,9 +41,16 @@
 
 namespace mtl {
 
-/// Cholesky factorization: A = L * L^T.
+/// Returned by cholesky_h_factor when the input is complex and has a non-real
+/// diagonal, which a Hermitian matrix cannot have. Negative so it cannot
+/// collide with the k+1 not-positive-definite codes.
+inline constexpr int CHOLESKY_NOT_HERMITIAN = -2;
+
+/// Cholesky factorization: A = L * L^T, for a REAL symmetric positive definite A.
 /// The lower triangle of A is overwritten with L. Upper triangle is untouched.
 /// Returns 0 on success, k+1 if A(k,k) <= 0 (not SPD).
+///
+/// Complex element types are rejected at compile time; use cholesky_h_factor.
 template <Matrix M>
 int cholesky_factor(M& A) {
     using value_type = typename M::value_type;
@@ -28,6 +58,24 @@ int cholesky_factor(M& A) {
     using std::sqrt;
     const size_type n = A.num_rows();
     assert(A.num_cols() == n);
+
+    // This routine computes A = L*L^T and tests the diagonal for positive
+    // definiteness. Neither half survives a complex element type:
+    //
+    //   - the test `diag <= 0` is an ORDERING, and complex is not ordered. It
+    //     used to fail here with an opaque "no match for operator<=" (#353).
+    //   - even with the comparison repaired, the unconjugated inner product
+    //     `sum += A(j,k) * A(j,k)` computes L*L^T, which is not the
+    //     factorization a Hermitian matrix has.
+    //
+    // Repairing only the comparison would therefore convert a compile error
+    // into a silently wrong answer -- exactly what happened to ldlt in #352.
+    // Reject instead, and point at the routine that is correct for that input.
+    static_assert(!is_complex_v<value_type>,
+        "cholesky_factor computes A = L*L^T and orders the diagonal to test positive "
+        "definiteness, neither of which is meaningful for a complex element type. For a "
+        "HERMITIAN positive definite matrix use cholesky_h_factor / cholesky_h_solve, "
+        "which compute A = L*L^H (#353).");
 
 #ifdef MTL5_HAS_LAPACK
     if constexpr (interface::BlasDenseMatrix<M> && !interface::is_row_major_v<M>) {
@@ -96,6 +144,125 @@ void cholesky_solve(const M& L, VecX& x, const VecB& b) {
         auto sum = math::zero<value_type>();
         for (size_type j = i + 1; j < n; ++j)
             sum += L(j, i) * x(j);  // L^T(i,j) = L(j,i)
+        x(i) = (x(i) - sum) / L(i, i);
+    }
+}
+
+
+/// Cholesky factorization: A = L * L^H, for a HERMITIAN positive definite A.
+///
+/// The lower triangle of A is overwritten with L, whose diagonal is REAL for a
+/// Hermitian A and is stored in the element type with a zero imaginary part.
+/// Only the lower triangle is read, so the caller's upper triangle is
+/// irrelevant and need not be populated consistently.
+///
+/// Returns 0 on success, k+1 if the k-th pivot is not positive (not HPD), or
+/// CHOLESKY_NOT_HERMITIAN if the diagonal is not real -- a Hermitian matrix
+/// cannot have one, so that input does not belong here.
+///
+/// For real element types conjugation is the identity and this is exactly
+/// cholesky_factor -- see the note at the top of this file (#353).
+template <Matrix M>
+int cholesky_h_factor(M& A) {
+    using value_type = typename M::value_type;
+    using size_type  = typename M::size_type;
+    using mag_t      = magnitude_t<value_type>;
+    using conj_t     = functor::scalar::conj<value_type>;
+    using real_t     = functor::scalar::real<value_type>;
+    using std::sqrt;
+    const size_type n = A.num_rows();
+    assert(A.num_cols() == n);
+
+    // A Hermitian matrix has a REAL diagonal. If a complex-symmetric matrix
+    // arrives here by mistake, taking the real part below would silently
+    // discard its imaginary diagonal and factor a DIFFERENT matrix while
+    // returning 0 -- the mirror of the ldlt bug in #352. The check is O(n),
+    // reads only the diagonal (preserving the lower-triangle-only contract),
+    // and is scale-relative because a Hermitian matrix assembled in floating
+    // point carries a rounding-sized imaginary residue.
+    if constexpr (is_complex_v<value_type>) {
+        mag_t dscale(0), dimag(0);
+        for (size_type j = 0; j < n; ++j) {
+            const mag_t a = detail::cabs1(A(j, j));
+            if (a > dscale) dscale = a;
+            using std::abs;
+            const mag_t im = abs(functor::scalar::imag<value_type>::apply(A(j, j)));
+            if (im > dimag) dimag = im;
+        }
+        if (dimag > detail::structure_tol(static_cast<std::size_t>(n), dscale))
+            return CHOLESKY_NOT_HERMITIAN;
+    }
+
+    // For j = 0..n-1:
+    //   L(j,j) = sqrt( Re( A(j,j) ) - sum_{k<j} |L(j,k)|^2 )      -- real
+    //   L(i,j) = ( A(i,j) - sum_{k<j} L(i,k) * conj(L(j,k)) ) / L(j,j)
+    //
+    // The pivot is real by construction: |L(j,k)|^2 is real and A(j,j) is real
+    // for a Hermitian A. Accumulating it in the MAGNITUDE type rather than the
+    // element type is what makes the positivity test well-formed -- it is the
+    // ordering that does not exist for the element type itself.
+    for (size_type j = 0; j < n; ++j) {
+        mag_t s(0);
+        for (size_type k = 0; k < j; ++k)
+            // |L(j,k)|^2: the product is real by construction, so take its real
+            // part rather than abs() (no sqrt) or cabs1() (which would add the
+            // rounding-sized imaginary residue instead of discarding it).
+            s += real_t::apply(value_type(A(j, k) * conj_t::apply(A(j, k))));
+        const mag_t diag = real_t::apply(A(j, j)) - s;
+        if (!(diag > mag_t(0)))
+            return static_cast<int>(j + 1);
+        const mag_t ljj = sqrt(diag);
+        A(j, j) = value_type(ljj);
+
+        // Rows i > j are independent: each writes only A(i,j) and reads already
+        // finalized columns k < j plus the shared column j -- so chunking is
+        // bit-identical to the serial path, as in cholesky_factor above.
+        const size_type rows = n - j - 1;
+        if (rows > 0) {
+            const std::size_t inner = static_cast<std::size_t>(j == 0 ? 1 : j);
+            const std::size_t grain =
+                std::max<std::size_t>(std::size_t{1}, std::size_t{65536} / inner);
+            detail::thread_pool::instance().parallel_for(
+                static_cast<std::size_t>(rows), grain,
+                [&](std::size_t b, std::size_t e) {
+                    for (std::size_t t = b; t < e; ++t) {
+                        const size_type i = j + 1 + static_cast<size_type>(t);
+                        auto sum = math::zero<value_type>();
+                        for (size_type k = 0; k < j; ++k)
+                            sum += A(i, k) * conj_t::apply(A(j, k));
+                        A(i, j) = (A(i, j) - sum) / value_type(ljj);
+                    }
+                });
+        }
+    }
+    return 0;
+}
+
+/// Solve A*x = b using precomputed Cholesky factors of a HERMITIAN A, i.e. the
+/// L of A = L*L^H stored in the lower triangle by cholesky_h_factor.
+/// Solves L*y = b (forward), then L^H*x = y (backward).
+template <Matrix M, Vector VecX, Vector VecB>
+void cholesky_h_solve(const M& L, VecX& x, const VecB& b) {
+    using value_type = typename VecX::value_type;
+    using size_type  = typename M::size_type;
+    using conj_t     = functor::scalar::conj<value_type>;
+    const size_type n = L.num_rows();
+    assert(L.num_cols() == n && x.size() == n && b.size() == n);
+
+    // Forward substitution: L*y = b
+    for (size_type i = 0; i < n; ++i) {
+        auto sum = math::zero<value_type>();
+        for (size_type j = 0; j < i; ++j)
+            sum += L(i, j) * x(j);
+        x(i) = (b(i) - sum) / L(i, i);
+    }
+
+    // Back substitution: L^H*x = y, where L^H(i,j) = conj(L(j,i)).
+    for (size_type ii = 0; ii < n; ++ii) {
+        size_type i = n - 1 - ii;
+        auto sum = math::zero<value_type>();
+        for (size_type j = i + 1; j < n; ++j)
+            sum += conj_t::apply(L(j, i)) * x(j);
         x(i) = (x(i) - sum) / L(i, i);
     }
 }

--- a/include/mtl/operation/ldlt.hpp
+++ b/include/mtl/operation/ldlt.hpp
@@ -45,6 +45,7 @@
 #include <mtl/functor/scalar/conj.hpp>
 #include <mtl/functor/scalar/real.hpp>
 #include <mtl/functor/scalar/imag.hpp>
+#include <mtl/detail/structure_tol.hpp>
 
 namespace mtl {
 
@@ -60,29 +61,6 @@ inline constexpr int LDLT_NOT_SYMMETRIC = -1;
 /// ldlt_factor for that input.
 inline constexpr int LDLT_NOT_HERMITIAN = -2;
 
-namespace detail {
-
-/// LAPACK's CABS1: |Re z| + |Im z|. Within a factor of sqrt(2) of |z| and free
-/// of the sqrt/hypot that abs() would cost, which is what a structural
-/// noise threshold wants -- see ldlt_structure_tol.
-template <typename T>
-constexpr magnitude_t<T> ldlt_cabs1(const T& z) {
-    using std::abs;
-    return abs(functor::scalar::real<T>::apply(z))
-         + abs(functor::scalar::imag<T>::apply(z));
-}
-
-/// Threshold separating "this matrix has this structure" from "rounding noise",
-/// scaled by the size of the problem and the magnitude of the data.
-///
-/// For a type without a std::numeric_limits specialization epsilon() is 0, so
-/// this degrades to an exact test rather than to something arbitrary.
-template <typename Mag>
-constexpr Mag ldlt_structure_tol(std::size_t n, Mag scale) {
-    return static_cast<Mag>(n) * std::numeric_limits<Mag>::epsilon() * scale;
-}
-
-}  // namespace detail
 
 /// LDL^T factorization: A = L * D * L^T.
 /// The strictly lower triangle of A is overwritten with L (unit diagonal implicit).
@@ -120,15 +98,15 @@ int ldlt_factor(M& A) {
             for (std::size_t j = i; j < n; ++j) {   // each pair once; j == i covers
                                                     // the diagonal, which must be
                                                     // real for a Hermitian A
-                const mag_t a = detail::ldlt_cabs1(A(i, j));
+                const mag_t a = detail::cabs1(A(i, j));
                 if (a > scale) scale = a;
-                const mag_t s = detail::ldlt_cabs1(value_type(A(i, j) - A(j, i)));
+                const mag_t s = detail::cabs1(value_type(A(i, j) - A(j, i)));
                 if (s > sym_err) sym_err = s;
-                const mag_t h = detail::ldlt_cabs1(
+                const mag_t h = detail::cabs1(
                     value_type(A(i, j) - conj_t::apply(A(j, i))));
                 if (h > herm_err) herm_err = h;
             }
-        const mag_t tol = detail::ldlt_structure_tol(n, scale);
+        const mag_t tol = detail::structure_tol(n, scale);
         if (herm_err <= tol && sym_err > tol) return LDLT_NOT_SYMMETRIC;
     }
 
@@ -233,13 +211,13 @@ int ldlt_h_factor(M& A) {
     if constexpr (is_complex_v<value_type>) {
         mag_t dscale(0), dimag(0);
         for (std::size_t j = 0; j < n; ++j) {
-            const mag_t a = detail::ldlt_cabs1(A(j, j));
+            const mag_t a = detail::cabs1(A(j, j));
             if (a > dscale) dscale = a;
             using std::abs;
             const mag_t im = abs(functor::scalar::imag<value_type>::apply(A(j, j)));
             if (im > dimag) dimag = im;
         }
-        if (dimag > detail::ldlt_structure_tol(n, dscale)) return LDLT_NOT_HERMITIAN;
+        if (dimag > detail::structure_tol(n, dscale)) return LDLT_NOT_HERMITIAN;
     }
 
     // For j = 0..n-1:

--- a/tests/unit/compile_fail/cholesky_factor_complex.cpp
+++ b/tests/unit/compile_fail/cholesky_factor_complex.cpp
@@ -1,0 +1,18 @@
+// This translation unit MUST NOT COMPILE.
+//
+// cholesky_factor computes A = L*L^T and orders the diagonal to test positive
+// definiteness. Neither survives a complex element type, and repairing only the
+// comparison would turn a compile error into a silently wrong factorization --
+// the failure mode of #352. It is restricted to real element types, with a
+// diagnostic naming cholesky_h_factor as the routine for Hermitian input (#353).
+//
+// EXPECT-ERROR: cholesky_factor computes A = L
+#include <complex>
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/operation/cholesky.hpp>
+
+int main() {
+    mtl::mat::dense2D<std::complex<double>> A(4, 4);
+    mtl::cholesky_factor(A);
+    return 0;
+}

--- a/tests/unit/operation/test_cholesky.cpp
+++ b/tests/unit/operation/test_cholesky.cpp
@@ -1,7 +1,10 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
+#include <complex>
+#include <cstdint>
 #include <mtl/mat/dense2D.hpp>
+#include <mtl/operation/mult.hpp>
 #include <mtl/vec/dense_vector.hpp>
 #include <mtl/operation/cholesky.hpp>
 #include <mtl/operation/operators.hpp>
@@ -173,4 +176,182 @@ TEST_CASE("Cholesky on Lehmer matrix", "[operation][cholesky][generator]") {
     for (std::size_t i = 0; i < n; ++i)
         for (std::size_t j = 0; j < n; ++j)
             REQUIRE_THAT(LLt(i, j), Catch::Matchers::WithinAbs(Aorig(i, j), 1e-8));
+}
+
+// ---------------------------------------------------------------------------
+// #353: cholesky did not compile for complex element types.
+//
+// The first failure was an opaque "no match for operator<=" on the definiteness
+// test, but the gap was larger than the comparison: the inner product was
+// unconjugated too, so repairing only the comparison would have produced
+// something that compiles and computes the WRONG factorization -- which is
+// precisely what happened to ldlt in #352.
+//
+// Resolution: cholesky_factor is now restricted to real element types with a
+// diagnostic that names the alternative, and cholesky_h_factor /
+// cholesky_h_solve provide A = L*L^H for Hermitian positive definite input.
+// The rejection of complex is pinned by
+// tests/unit/compile_fail/cholesky_factor_complex.cpp.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Cholesky LL^H factors a Hermitian positive definite matrix (#353)",
+          "[operation][cholesky][regression]") {
+    using cd = std::complex<double>;
+    const std::size_t n = 2;
+    mat::dense2D<cd> A(n, n);
+    A(0,0) = cd(4, 0); A(0,1) = cd(1,-1);
+    A(1,0) = cd(1, 1); A(1,1) = cd(3, 0);      // HPD, eigenvalues 5 and 2
+
+    mat::dense2D<cd> L(A);
+    REQUIRE(cholesky_h_factor(L) == 0);
+
+    // The factor's diagonal is real for a Hermitian A.
+    for (std::size_t i = 0; i < n; ++i)
+        REQUIRE(std::abs(L(i,i).imag()) < 1e-14);
+
+    // L*L^H reconstructs A over the lower triangle (the only part read).
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j <= i; ++j) {
+            cd s(0, 0);
+            for (std::size_t k = 0; k <= j; ++k) s += L(i,k) * std::conj(L(j,k));
+            INFO("i=" << i << " j=" << j);
+            REQUIRE(std::abs(s - A(i,j)) < 1e-12);
+        }
+
+    // And it solves.
+    vec::dense_vector<cd> xt(n), b(n), x(n);
+    xt[0] = cd(1, 0); xt[1] = cd(0, 1);
+    mult(A, xt, b);
+    cholesky_h_solve(L, x, b);
+    for (std::size_t i = 0; i < n; ++i)
+        REQUIRE(std::abs(x(i) - xt(i)) < 1e-12);
+}
+
+TEST_CASE("Cholesky LL^H over random Hermitian positive definite matrices (#353)",
+          "[operation][cholesky][regression]") {
+    using cd = std::complex<double>;
+    std::uint64_t seed = 20260803u;
+    auto next = [&seed]() {
+        seed = seed * 6364136223846793005ull + 1442695040888963407ull;
+        return static_cast<double>((seed >> 11) % 2000001) / 1000000.0 - 1.0;
+    };
+
+    for (std::size_t n : {3u, 5u, 8u}) {
+        // A = B^H*B + n*I is Hermitian positive definite by construction.
+        mat::dense2D<cd> B(n, n), A(n, n);
+        for (std::size_t i = 0; i < n; ++i)
+            for (std::size_t j = 0; j < n; ++j) B(i,j) = cd(next(), next());
+        for (std::size_t i = 0; i < n; ++i)
+            for (std::size_t j = 0; j < n; ++j) {
+                cd s(0, 0);
+                for (std::size_t k = 0; k < n; ++k) s += std::conj(B(k,i)) * B(k,j);
+                A(i,j) = s + (i == j ? cd(static_cast<double>(n), 0) : cd(0, 0));
+            }
+
+        vec::dense_vector<cd> xt(n), b(n), x(n);
+        for (std::size_t i = 0; i < n; ++i) xt[i] = cd(next(), next());
+        mult(A, xt, b);
+
+        mat::dense2D<cd> L(A);
+        INFO("n = " << n);
+        REQUIRE(cholesky_h_factor(L) == 0);
+        cholesky_h_solve(L, x, b);
+        for (std::size_t i = 0; i < n; ++i)
+            REQUIRE(std::abs(x(i) - xt(i)) < 1e-9);
+    }
+}
+
+TEST_CASE("Cholesky LL^H refuses input with a non-real diagonal (#353)",
+          "[operation][cholesky][regression]") {
+    // A Hermitian matrix cannot have a non-real diagonal, so complex-symmetric
+    // input is a caller mistake. Taking the real part would silently factor a
+    // DIFFERENT matrix and return 0 -- the mirror of the ldlt bug in #352.
+    using cd = std::complex<double>;
+    mat::dense2D<cd> S(2, 2);
+    S(0,0) = cd(4, 1); S(0,1) = cd(1, 2);
+    S(1,0) = cd(1, 2); S(1,1) = cd(5,-1);
+    REQUIRE(cholesky_h_factor(S) == CHOLESKY_NOT_HERMITIAN);
+}
+
+TEST_CASE("Cholesky LL^H detects a non-positive-definite Hermitian matrix (#353)",
+          "[operation][cholesky][regression]") {
+    using cd = std::complex<double>;
+    mat::dense2D<cd> N(2, 2);
+    N(0,0) = cd(1, 0); N(0,1) = cd(2, 0);
+    N(1,0) = cd(2, 0); N(1,1) = cd(1, 0);      // Hermitian, indefinite
+    REQUIRE(cholesky_h_factor(N) == 2);        // fails at pivot k=1 -> k+1
+}
+
+TEST_CASE("Cholesky LL^H handles the degenerate sizes (#353)",
+          "[operation][cholesky][regression]") {
+    SECTION("empty") {
+        mat::dense2D<double> A(0, 0);
+        vec::dense_vector<double> x(0), b(0);
+        REQUIRE(cholesky_h_factor(A) == 0);
+        REQUIRE_NOTHROW(cholesky_h_solve(A, x, b));
+    }
+    SECTION("1x1 real") {
+        mat::dense2D<double> A(1, 1);
+        A(0,0) = 4.0;
+        vec::dense_vector<double> x(1), b(1);
+        b[0] = 8.0;
+        REQUIRE(cholesky_h_factor(A) == 0);
+        REQUIRE_THAT(A(0,0), Catch::Matchers::WithinAbs(2.0, 1e-14));
+        cholesky_h_solve(A, x, b);
+        REQUIRE_THAT(x(0), Catch::Matchers::WithinAbs(2.0, 1e-14));
+    }
+    SECTION("1x1 Hermitian complex") {
+        using cd = std::complex<double>;
+        mat::dense2D<cd> A(1, 1);
+        A(0,0) = cd(4, 0);                     // a 1x1 Hermitian matrix is real
+        vec::dense_vector<cd> x(1), b(1);
+        b[0] = cd(8, 4);
+        REQUIRE(cholesky_h_factor(A) == 0);
+        cholesky_h_solve(A, x, b);
+        REQUIRE(std::abs(x(0) - cd(2, 1)) < 1e-14);
+    }
+    SECTION("1x1 with a non-real diagonal is refused") {
+        using cd = std::complex<double>;
+        mat::dense2D<cd> A(1, 1);
+        A(0,0) = cd(4, 1);
+        REQUIRE(cholesky_h_factor(A) == CHOLESKY_NOT_HERMITIAN);
+    }
+    SECTION("1x1 non-positive is refused") {
+        mat::dense2D<double> A(1, 1);
+        A(0,0) = -1.0;
+        REQUIRE(cholesky_h_factor(A) == 1);
+    }
+}
+
+TEST_CASE("Cholesky LL^H equals LL^T for real symmetric input (#353)",
+          "[operation][cholesky][regression]") {
+    const std::size_t n = 6;
+    mat::dense2D<double> A(n, n);
+    for (std::size_t i = 0; i < n; ++i) {
+        A(i,i) = 4.0 + static_cast<double>(i);
+        for (std::size_t j = i + 1; j < n; ++j) {
+            const double v = 0.5 + 0.25 * static_cast<double>(i + j);
+            A(i,j) = v; A(j,i) = v;
+        }
+    }
+    vec::dense_vector<double> b(n), x1(n), x2(n);
+    for (std::size_t i = 0; i < n; ++i) b[i] = 1.0 + static_cast<double>(i);
+
+    mat::dense2D<double> L1(A), L2(A);
+    REQUIRE(cholesky_factor(L1) == 0);
+    REQUIRE(cholesky_h_factor(L2) == 0);
+    cholesky_solve(L1, x1, b);
+    cholesky_h_solve(L2, x2, b);
+
+    // Deliberately EXACT, not epsilon-based -- the same invariant test_ldlt.cpp
+    // asserts for ldlt_h. The claim is not "these agree numerically" but "for a
+    // real type the LL^H path IS the LL^T path", conj<T>::apply being the
+    // identity. A one-ULP difference means the arithmetic in one path diverged
+    // from the other, which is exactly what this catches. Do not relax it to a
+    // tolerance; that would silently retire the invariant.
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j <= i; ++j)
+            REQUIRE(L1(i,j) == L2(i,j));
+    for (std::size_t i = 0; i < n; ++i)
+        REQUIRE(x1(i) == x2(i));
 }


### PR DESCRIPTION
## Summary

**Part 1 of #353**, which covers both `cholesky` and `qr`. This is the cholesky half. The householder/qr half is deliberately separate — see [Why this is split](#why-this-is-split) — so this PR uses `Relates to`, not `Resolves`.

`cholesky_factor` failed to compile for `std::complex` with an opaque `no match for 'operator<='` on the definiteness test.

**Repairing only that comparison would have been the wrong fix.** The inner product is unconjugated:

```cpp
sum += A(j, k) * A(j, k);        // L*L^T, not L*L^H
```

so with the comparison fixed the routine would compile and compute the wrong factorization — turning a loud compile error into a silent wrong answer. That is exactly what happened to `ldlt` in #352, and #353's own opening paragraph warns about it. So this PR does not repair the comparison.

## What it does instead

**`cholesky_factor` is restricted to real element types**, with a `static_assert` that names the alternative:

```
error: static assertion failed: cholesky_factor computes A = L*L^T and orders the
diagonal to test positive definiteness, neither of which is meaningful for a complex
element type. For a HERMITIAN positive definite matrix use cholesky_h_factor /
cholesky_h_solve, which compute A = L*L^H (#353).
```

Unlike `ldlt`, there is **no complex-symmetric variant to offer**. `ldlt_factor` legitimately serves complex-symmetric input because it only needs a zero-pivot test. "Positive definite" is a statement about an *ordering*, and a complex symmetric matrix has no real diagonal to order — so restriction is the honest answer here, not a missing feature.

**`cholesky_h_factor` / `cholesky_h_solve` compute `A = L·Lᴴ`** for Hermitian positive definite input. The pivot accumulates in the **magnitude** type rather than the element type:

```cpp
mag_t s(0);
for (k < j) s += real(A(j,k) * conj(A(j,k)));   // |L(j,k)|^2
const mag_t diag = real(A(j,j)) - s;
if (!(diag > mag_t(0))) return j + 1;           // also rejects NaN
```

That is what makes the positivity test well-formed: the ordering is precisely what the element type lacks, so the test belongs in the type that has one.

**It rejects a non-real diagonal** with `CHOLESKY_NOT_HERMITIAN`. A Hermitian matrix cannot have one, so complex-symmetric input arriving here is a caller mistake, and taking `real()` would silently factor a *different* matrix while returning 0 — the mirror of #352. The check is O(n), reads only the diagonal (preserving the lower-triangle-only contract), and is **scale-relative** for the reason established in #356: a Hermitian matrix assembled in floating point carries a rounding-sized imaginary residue, and an exact test passes only on matrices typed as literals.

## Shared threshold

`detail::cabs1` and `detail::structure_tol` move out of `ldlt.hpp` into a new `detail/structure_tol.hpp`, so cholesky uses the same threshold rather than duplicating it. `ldlt`'s behaviour is unchanged — 156 assertions in 18 cases, identical to before the move.

## Verification

Measured, not assumed:

| check | result |
|---|---|
| `L·Lᴴ` reconstructs `A` (2×2 HPD, eigenvalues 5 and 2) | exact to all printed digits |
| random HPD `n = 3, 5, 8`, built as `Bᴴ·B + n·I` | solves to 1e-9 |
| complex-symmetric input | `CHOLESKY_NOT_HERMITIAN` |
| Hermitian indefinite | `k+1` at the failing pivot |
| **real input: `_h` vs original** | **bit-exact — 0 differing factor entries, 0 differing solution entries** |

The bit-exact real-path check is the invariant `test_ldlt.cpp` established in #356 and this file now asserts too: for a real type, `conj` is the identity, so the `_h` path *is* the original path. It is deliberately `==`, with a comment saying so.

Also covered: empty, 1×1 real, 1×1 Hermitian, 1×1 non-real-diagonal, 1×1 non-positive.

## The compile-failure test, and a result worth recording

The rejection is pinned by `tests/unit/compile_fail/cholesky_factor_complex.cpp`, using the harness added in #358.

Its negative control produced the best evidence yet for why that harness matches the *expected diagnostic* instead of using CMake's `WILL_FAIL`. With the `static_assert` removed, the file **still fails to compile** — via the old `operator<=` error — so:

```
compile_fail_cholesky_factor_complex ... ***Failed
    Required regular expression not found. Regex=[cholesky_factor computes A = L
```

**`WILL_FAIL` would have passed green**, because the build did return non-zero. Matching the diagnostic catches a regression *to the worse error message*, which is the thing this PR is actually delivering. Removing the guard fails only this test; the other two compile-failure tests stay green.

<a name="why-this-is-split"></a>
## Why this is split, and what remains

The qr half is not a type fix. The reflector form changes from `I − β·v·vᵀ` to `I − τ·v·vᴴ`, which moves the contract for every consumer:

| site | change |
|---|---|
| `householder.hpp` | `scale`/`axi` → `magnitude_t<T>`; `sigma` → `Σ\|x(i)\|²`; sign choice → **phase** choice; `beta` → complex `tau` (LAPACK `zlarfg`); `apply_*` need `conj(v(i))` in the inner products |
| `qr.hpp` | Q extraction and solve apply `H_j`; for complex, `H` vs `Hᴴ` and `conj(tau)` placement matter |
| `lq.hpp`, `hessenberg.hpp`, `eigenvalue_symmetric.hpp` | consumers of the changed reflector contract |

That is 5 headers plus tests, wants `zlarfg`/`zlarf`/`zungqr` as the reference, and needs validation against `QᴴQ = I` and `QR = A` alongside a bit-exact real-path invariant. Folding it in here would have made a reviewable change unreviewable.

## Test results

| target | gcc build | gcc test | clang build | clang test |
|---|---|---|---|---|
| `op_test_cholesky` | OK | PASS (219 assertions / 13 cases) | OK | PASS |
| `op_test_ldlt` | OK | PASS (156 / 18, unchanged) | OK | PASS |
| full unit suite | OK | **159/159** | OK | **159/159** |

## Test plan
- [ ] Fast CI passes (gcc + clang)
- [ ] Promote to ready when satisfied

Relates to #353

Generated with [Claude Code](https://claude.com/claude-code)