### PR TITLE
docs(operation): guidance page for choosing a symmetric/Hermitian factorization

### DIFF
--- a/docs-site/sync-content.mjs
+++ b/docs-site/sync-content.mjs
@@ -51,6 +51,7 @@ const FILE_MAP = {
   // ── Linear Algebra Algorithms ───────────────────────────────────
   'algorithms/overview.md':                     'algorithms/overview.md',
   'algorithms/eigenvalues.md':                  'algorithms/eigenvalues.md',
+  'algorithms/choosing-a-factorization.md':     'algorithms/choosing-a-factorization.md',
   'algorithms/on-node-threading.md':            'algorithms/on-node-threading.md',
   'algorithms/mixed-precision-kernels.md':      'algorithms/mixed-precision-kernels.md',
   'algorithms/measuring-solver-accuracy.md':    'algorithms/measuring-solver-accuracy.md',

--- a/docs/algorithms/choosing-a-factorization.md
+++ b/docs/algorithms/choosing-a-factorization.md
@@ -1,0 +1,112 @@
+# Choosing a symmetric or Hermitian factorization
+
+MTL5 offers four entry points for factoring a symmetric or Hermitian matrix:
+`cholesky_factor`, `cholesky_h_factor`, `ldlt_factor`, `ldlt_h_factor`. This page
+says which one to call, and why the choice is smaller than it looks.
+
+## The rule
+
+**Call the `_h` form unconditionally.**
+
+```cpp
+mtl::cholesky_h_factor(A);   mtl::cholesky_h_solve(A, x, b);   // positive definite
+mtl::ldlt_h_factor(A);       mtl::ldlt_h_solve(A, x, b);       // possibly indefinite
+```
+
+The `_h` routines are **not complex-only**. For a real element type conjugation is
+the identity, so `cholesky_h_factor` *is* `cholesky_factor` — not "equivalent to",
+not "agrees within tolerance", but the same arithmetic producing the same bits:
+
+```
+real SPD    cholesky_factor=0  cholesky_h_factor=0   bitdiff=0
+real sym    ldlt_factor=0      ldlt_h_factor=0       bitdiff=0
+```
+
+That invariant is asserted in `tests/unit/operation/test_cholesky.cpp` and
+`test_ldlt.cpp` with `==`, deliberately, rather than an epsilon comparison. It is
+not an accident of the current implementation — it is a property the tests exist
+to keep true.
+
+So generic code templated on the scalar type needs **no `is_complex_v` branch**.
+Writing one is the common mistake: it doubles the API surface a caller has to
+cover and buys nothing.
+
+## The full picture
+
+What each routine does with each kind of input, measured rather than asserted:
+
+| input | `cholesky_factor` | `cholesky_h_factor` | `ldlt_factor` | `ldlt_h_factor` |
+|---|---|---|---|---|
+| real symmetric positive definite | `0` | `0` — bit-identical | `0` | `0` — bit-identical |
+| real symmetric, indefinite | `k+1` (not PD) | `k+1` (not PD) | `0` | `0` — bit-identical |
+| **Hermitian** (`A == Aᴴ`) | compile error | `0` | **`LDLT_NOT_SYMMETRIC`** | `0` |
+| **complex symmetric** (`A == Aᵀ`) | compile error | **`CHOLESKY_NOT_HERMITIAN`** | `0` | **`LDLT_NOT_HERMITIAN`** |
+
+Two things follow from the table.
+
+**Every wrong choice is caught.** Feeding a routine the structure it does not
+handle produces a negative return code or a compile error, never a plausible
+wrong answer. That was not always so: until [#352](https://github.com/stillwater-sc/mtl5/issues/352),
+`ldlt_factor` ran a Hermitian matrix to completion and returned a wrong solution
+under `info == 0`. The guards exist because that failure mode is invisible.
+
+**The guards are scale-relative, not exact.** A matrix assembled in floating
+point — from an FEM pass, or a blocked `Bᴴ·B` whose `(i,j)` and `(j,i)` sums
+accumulate in different orders — is Hermitian only to rounding. An exact test
+passes on matrices written as literals and fails on matrices that are computed;
+during #352 a **one-ULP** perturbation defeated an exact guard and produced an
+answer wrong in the first significant digit. The threshold is `n · eps · scale`
+(`detail/structure_tol.hpp`), degrading to an exact test for element types
+without a `std::numeric_limits` specialization.
+
+## When you want the plain forms
+
+**`ldlt_factor` — a complex symmetric matrix.** `A == Aᵀ` with a non-real
+diagonal is a real case (moment matrices, some frequency-domain formulations) and
+`L·D·Lᵀ` is its correct factorization. This is the one situation where the `_h`
+form is the wrong answer, and it is why `ldlt_factor` still accepts complex.
+
+**`cholesky_factor` — nothing, beyond real code that already calls it.** It is
+restricted to real element types, and that is not a gap waiting to be filled:
+"positive definite" is a statement about an **ordering**, and a complex symmetric
+matrix has no real diagonal to order. There is no complex-symmetric Cholesky to
+offer. For complex input, `L·Lᴴ` is the only meaningful factorization, which is
+exactly what `cholesky_h_factor` computes.
+
+The asymmetry between the two is therefore principled, not historical: `ldlt` has
+two genuinely different complex factorizations, and `cholesky` has one.
+
+## Which factorization, not which spelling
+
+Orthogonal to the `_h` question:
+
+- **`cholesky_h`** needs positive definiteness and takes a square root per pivot.
+  Returns `k+1` if pivot `k` is not positive, which doubles as a definiteness test.
+- **`ldlt_h`** is square-root-free and handles **indefinite** matrices, since `D`
+  may carry negative entries. Same `O(n³/3)` cost, and no precision loss from
+  `sqrt` on an ill-conditioned pivot.
+
+If you do not know that the matrix is positive definite, use `ldlt_h`. If you are
+using the factorization *as* a definiteness test, use `cholesky_h` and read the
+return code.
+
+## Not yet available
+
+**Complex eigenvalues.** `hessenberg_factor` and `eigen_symmetric` reject complex
+element types: they apply `H·A·H`, which is a similarity transform only because a
+*real* Householder reflector is Hermitian. The unitary reduction `A → H·A·Hᴴ`
+with a real subdiagonal and phase accumulation is tracked in
+[#362](https://github.com/stillwater-sc/mtl5/issues/362).
+
+Complex `qr`, `lq` and the Householder reflectors themselves are supported
+([#361](https://github.com/stillwater-sc/mtl5/pull/361)), including a real `R`
+diagonal matching LAPACK's guarantee.
+
+## Summary
+
+| you have | call |
+|---|---|
+| anything symmetric or Hermitian, positive definite | `cholesky_h_factor` |
+| anything symmetric or Hermitian, possibly indefinite | `ldlt_h_factor` |
+| complex **symmetric** (`A == Aᵀ`), indefinite | `ldlt_factor` |
+| complex symmetric, positive definite | does not exist — see above |

--- a/docs/algorithms/choosing-a-factorization.md
+++ b/docs/algorithms/choosing-a-factorization.md
@@ -76,6 +76,31 @@ exactly what `cholesky_h_factor` computes.
 The asymmetry between the two is therefore principled, not historical: `ldlt` has
 two genuinely different complex factorizations, and `cholesky` has one.
 
+### Design note: why `cholesky_factor` rejects rather than dispatches
+
+Since `L·Lᴴ` is the *only* meaningful Cholesky for a complex matrix, there is no
+ambiguity for a restriction to protect against — so `cholesky_factor` could
+simply dispatch to the Hermitian algorithm for complex input and "just work" for
+generic callers. That was considered and **deliberately rejected**
+([#366](https://github.com/stillwater-sc/mtl5/issues/366)). The reasons, recorded
+here so the question does not get re-opened by each new consumer:
+
+- **The caller should name the factorization they are getting.** `A = L·Lᵀ` and
+  `A = L·Lᴴ` are different objects; having one spelling silently mean either
+  depending on the element type makes generic code harder to reason about, not
+  easier.
+- **Consistency with `ldlt`.** There, dispatch is not available even in
+  principle — both complex forms are meaningful — so `_h` must be explicit. One
+  naming convention across both families beats a special case in one.
+- **It follows the rule that produced these routines.**
+  [#352](https://github.com/stillwater-sc/mtl5/issues/352) and
+  [#353](https://github.com/stillwater-sc/mtl5/issues/353) were both cases of a
+  routine quietly doing something adjacent to what was asked. Restricting and
+  naming the alternative is the habit that fixed them.
+
+The cost is one line at each call site, and the `static_assert` names the
+replacement, so the compiler tells you what to write.
+
 ## Which factorization, not which spelling
 
 Orthogonal to the `_h` question:

--- a/docs/algorithms/overview.md
+++ b/docs/algorithms/overview.md
@@ -28,6 +28,9 @@ effort tracking its performance, but the characterization stands on its own.
   the entry point to MTL5's reason for existing: storing narrow while accumulating
   wide, the Element → Accumulate → Result model, and the SIMD *widening* GEMM as a
   worked example of how a mixed-precision kernel is made fast.
+- **[Choosing a Symmetric or Hermitian Factorization](choosing-a-factorization.md)** —
+  which of `cholesky_factor` / `cholesky_h_factor` / `ldlt_factor` / `ldlt_h_factor`
+  to call, and why the `_h` forms are the generic answer for real *and* complex.
 - **[Measuring Solver Accuracy](measuring-solver-accuracy.md)** — the residual,
   norms, absolute vs relative error, and backward vs forward error linked by the
   condition number. The foundation for how every solver's correctness is judged.

--- a/docs/design/capability-assessment-and-expansion.md
+++ b/docs/design/capability-assessment-and-expansion.md
@@ -68,6 +68,13 @@ must add.
 - **Eigen:** no generalized problem `A x = λ B x`; no public Schur decomposition;
   symmetric path is QR-iteration only (no divide-and-conquer / MRRR); the Krylov
   eigensolvers have **no implicit restart** (no IRAM/IRLM/Krylov–Schur).
+- **Complex element types:** the dense factorizations are covered — `cholesky_h`,
+  `ldlt_h`, `qr` and `lq` all handle Hermitian/complex input, and the guards make
+  a mismatched call fail loudly rather than return a plausible wrong answer (see
+  [Choosing a Symmetric or Hermitian Factorization](../algorithms/choosing-a-factorization.md)).
+  The **eigenproblem is not**: `hessenberg_factor` and `eigen_symmetric` reject
+  complex, because they apply `H·A·H`, a similarity transform only for a *real*
+  reflector. The unitary reduction `A → H·A·Hᴴ` is tracked in #362.
 - **Matrix functions:** no `expm`/`logm`/`sqrtm`, polar decomposition, or
   pseudo-inverse; no condition-number estimator API.
 - **Preconditioners:** no algebraic multigrid (AMG), no sparse approximate inverse


### PR DESCRIPTION
## Summary

Parts 1 and 3 of #366. **Part 2 is deliberately not implemented** — see [The decision I did not make](#the-decision-i-did-not-make).

An mtl5-python integration read a `cholesky_factor` `static_assert` on complex input as *"complex Cholesky was never implemented"*, and was about to add an `is_complex_v` branch to choose between the plain and `_h` forms. Both conclusions are wrong, and the fact that makes them wrong lived only in header comments — the one place a bindings author does not read.

**The fact:** the `_h` routines are not complex-only, they are the **generic** ones. For a real element type conjugation is the identity, so `cholesky_h_factor` *is* `cholesky_factor` — same arithmetic, same bits, asserted with `==` in the test suite rather than a tolerance. Callers want the `_h` form unconditionally, with no branch.

## The table is measured, not asserted

Every row was produced by running it, including one I had written from memory and then checked:

```
real SPD     cholesky_factor=0  cholesky_h_factor=0   bitdiff=0
real sym     ldlt_factor=0      ldlt_h_factor=0       bitdiff=0
real indef   cholesky_*=2 (k+1, not PD)   ldlt_*=0, bitdiff=0
Hermitian    cholesky_h=0  ldlt_h=0  ldlt_factor=-1 (LDLT_NOT_SYMMETRIC)
complex sym  ldlt_factor=0  ldlt_h=-2 (LDLT_NOT_HERMITIAN)
                            cholesky_h=-2 (CHOLESKY_NOT_HERMITIAN)
```

Two properties fall out and are stated on the page:

- **Every wrong choice is caught** — negative code or compile error, never a plausible wrong answer. That was not always true; #352 is exactly the case where it wasn't.
- **The guards are scale-relative, not exact**, because an exact structure test passes on matrices written as literals and fails on matrices that are computed. The one-ULP finding from #356.

## The asymmetry, explained rather than apologised for

The page says why `ldlt_factor` still accepts complex while `cholesky_factor` does not, because it looks arbitrary until stated:

`ldlt` has **two** genuinely different complex factorizations — `L·D·Lᵀ` for complex symmetric, `L·D·Lᴴ` for Hermitian — so both entry points earn their place. `cholesky` has **one**: "positive definite" is a statement about an *ordering*, and a complex symmetric matrix has no real diagonal to order, so there is no complex-symmetric Cholesky to offer. Principled, not historical.

<a name="the-decision-i-did-not-make"></a>
## The decision I did not make

#366 part 2 asks whether `cholesky_factor` should **dispatch** to `L·Lᴴ` for complex instead of rejecting it. I have not implemented either way, because it is an API decision with a real trade-off and it is yours to make:

| | for dispatch | for the current rejection |
|---|---|---|
| | For complex there is only one meaningful Cholesky, so unlike `ldlt` there is no ambiguity the restriction protects against | Explicitness — the caller names the factorization they want |
| | Generic code and bindings "just work" with the familiar name | Symmetry with `ldlt`'s `_h` naming |
| | `CHOLESKY_NOT_HERMITIAN` would still catch a complex-symmetric matrix passed by mistake | The #352/#353 principle: restrict rather than silently do something the caller did not ask for |

The page as written documents the current behaviour. If you choose dispatch, the page needs one row changed and the `static_assert` becomes an `if constexpr` — small either way, which is why it is worth deciding deliberately rather than by default.

## One correction to #366

The issue said to cross-link from `docs/design/capability-assessment-and-expansion.md`, "which lists complex support gaps". **It does not mention complex at all** — I checked. So rather than link into nothing, this adds an accurate complex-support entry to its functional-gaps list: the dense factorizations are covered, the eigenproblem is not (#362).

Note that doc is **not in `FILE_MAP`**, so it is repo-only and never published to the site. The relative link works in GitHub's file view. Whether it should be published is a separate question I have not touched.

## Changes

| file | what |
|---|---|
| `docs/algorithms/choosing-a-factorization.md` | new — the routing rule, measured behaviour matrix, and the `cholesky_h` vs `ldlt_h` choice |
| `docs-site/sync-content.mjs` | `FILE_MAP` entry |
| `docs/algorithms/overview.md` | index entry |
| `docs/design/capability-assessment-and-expansion.md` | accurate complex entry under functional gaps |

## Verification

- `npm run build` in `docs-site/`: **clean, 45 pages** (was 44)
- Title extracted correctly from the H1 into frontmatter
- Sidebar picks it up via the `algorithms` autogenerate
- Inbound link from `algorithms/overview` resolves to `/mtl5/algorithms/choosing-a-factorization/`

Docs only, no code touched.

Relates to #366

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for choosing Cholesky and LDLT factorizations for symmetric and Hermitian matrices.
  * Documented real and complex input support, structural validation, and recommended generic APIs.
  * Added a decision table comparing factorization options and clarified when standard LDLT is appropriate.
  * Documented current complex-number limitations for Hessenberg reduction and symmetric eigenvalue routines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->