### PR TITLE
docs: organize the Design sidebar section into Parallelization / Library / Benchmarking subsections

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -62,7 +62,33 @@ export default defineConfig({
         },
         {
           label: 'Design',
-          autogenerate: { directory: 'design' },
+          items: [
+            {
+              label: 'Parallelization',
+              items: [
+                { slug: 'design/parallelization-patterns-and-pitfalls' },
+                { slug: 'design/blas-kernel-architecture' },
+              ],
+            },
+            {
+              label: 'Library',
+              items: [
+                { slug: 'design/mixed-precision-acceleration' },
+                { slug: 'design/expression-template-architecture' },
+                { slug: 'design/operation-dispatch-architecture' },
+                { slug: 'design/mixed-precision-custom-types-simd' },
+                { slug: 'design/sparse-direct-solvers' },
+              ],
+            },
+            {
+              label: 'Benchmarking',
+              items: [
+                { slug: 'design/multicore-scaling-investigation' },
+                { slug: 'design/issue-297-threading-benchmark-plan' },
+                { slug: 'design/issue-297-threading-results' },
+              ],
+            },
+          ],
         },
         {
           label: 'Examples',


### PR DESCRIPTION
﻿## Summary

Reorganizes the flat **Design** sidebar section into three subsections, as requested:

- **Parallelization**
  - Parallelizing algorithms (`parallelization-patterns-and-pitfalls`)
  - BLAS kernel architecture
- **Library**
  - MTL5 + Universal (`mixed-precision-acceleration`)
  - Expression-template layer
  - Operation dispatch layer
  - Custom number types through the SIMD BLAS (`mixed-precision-custom-types-SIMD`)
  - Sparse direct solvers
- **Benchmarking** (the rest)
  - Multi-core scaling case study
  - On-node threading benchmark plan (#297)
  - On-node threading results (#297)

## Mechanics

Sidebar-only change: the Design entry moves from a flat `autogenerate` to explicit nested groups listing each page by slug. **No docs are moved**, so every URL and every design-doc cross-link is unchanged (nothing to break). All 10 published design pages are accounted for; the unregistered `capability-assessment-and-expansion.md` is left as-is.

## Verification

Full `astro build` — **55 pages, no errors** (confirms all 10 slug references resolve). Confirmed in the built HTML that the three subgroups render with exactly the pages above.

One note: there is now both a top-level **Benchmarking** section (the results pages: systems / i7 / ryzen) and a **Benchmarking** subsection under Design (the threading/scaling case studies) — per the request. Happy to rename the Design subsection (e.g. "Performance studies") if the duplication is confusing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Design documentation sidebar with organized navigation groups for Parallelization, Library, and Benchmarking.
  * Added direct links to specific documentation topics for easier browsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->