### PR TITLE
docs: rename Design > Benchmarking subsection to Performance studies

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -81,7 +81,7 @@ export default defineConfig({
               ],
             },
             {
-              label: 'Benchmarking',
+              label: 'Performance studies',
               items: [
                 { slug: 'design/multicore-scaling-investigation' },
                 { slug: 'design/issue-297-threading-benchmark-plan' },


### PR DESCRIPTION
Renames the Design **Benchmarking** subsection to **Performance studies**, so it no longer shares a label with the top-level Benchmarking section (results pages). Same three case-study docs (multi-core scaling + #297 threading). Sidebar-label-only change; verified with a full `astro build` (55 pages, no errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)