### PR TITLE
perf(simd): size the GEMM register tile against the register file, not the latency floor

### DIFF
--- a/include/mtl/simd/blocking.hpp
+++ b/include/mtl/simd/blocking.hpp
@@ -46,17 +46,26 @@ struct hw_traits {
     std::size_t l2_bytes;      // per-core L2
     std::size_t l3_bytes;      // shared L3 (per core group)
     std::size_t page_bytes;    // page size (TLB reasoning)
+    // APPENDED, not inserted (#351). hw_traits is a public aggregate and is
+    // initialized positionally in tests and downstream code; inserting a field
+    // mid-struct silently shifts every later one -- during this change that
+    // turned an l1_bytes of 32 KB into 8 bytes with no diagnostic. Appending
+    // means an initializer that predates this field value-initializes it to 0,
+    // which derive_blocking treats as "unknown" and falls back to the
+    // latency-floor tile, i.e. the pre-#351 behaviour.
+    std::size_t vec_registers; // Nreg: architectural vector registers (0 = unknown)
 };
 
 /// Generic modern-x86 (AVX2-class) default; override per architecture.
 /// Matches a Haswell-class core: 32 KB/8-way L1, 256 KB L2, 8 MB L3,
-/// FMA latency 4, 2 FMA units.
+/// FMA latency 4, 2 FMA units, 16 ymm registers.
 inline constexpr hw_traits default_hw_traits{
     /*fma_latency*/ 4, /*fma_units*/ 2,
     /*l1_bytes*/ 32u * 1024, /*l1_assoc*/ 8, /*line_bytes*/ 64,
     /*l2_bytes*/ 256u * 1024,
     /*l3_bytes*/ 8u * 1024 * 1024,
     /*page_bytes*/ 4096,
+    /*vec_registers*/ 16,
 };
 
 /// GEMM blocking parameters: mr x nr register microtile, kc/mc/nc cache blocks.
@@ -73,13 +82,65 @@ constexpr blocking_params derive_blocking(std::size_t nvec,
     const std::size_t sdata = sizeof(T);
     if (nvec == 0) nvec = 1;
 
-    // Register block (Eqs. 1-3): area >= Nvec*Lvfma*Nvfma, near-square, nr a
-    // multiple of the SIMD width (nr is the vectorized dimension).
-    const std::size_t area = nvec * hw.fma_latency * hw.fma_units;
-    std::size_t nr = round_up(isqrt_ceil(area), nvec);
-    if (nr == 0) nr = nvec;
-    std::size_t mr = ceil_div(area, nr);
-    if (mr == 0) mr = 1;
+    // Register block. Two constraints, and which one BINDS is the whole point:
+    //
+    //   floor    mr*nr >= Nvec*Lvfma*Nvfma -- enough accumulators to cover
+    //            dependent-FMA latency at the issue width. Eq. 1 of the BLIS
+    //            analytical model. It is a LOWER bound.
+    //   ceiling  the accumulators, plus the operands they are multiplied by,
+    //            must FIT the architectural vector register file. Exceed it and
+    //            the microkernel spills every k step.
+    //
+    // This used to size the tile at exactly the floor -- `area` was used as the
+    // target rather than the minimum -- and there was no register-file term at
+    // all. On an AVX2 core that gave 4x8 for double: 8 accumulator vectors out
+    // of 16 ymm, half the file idle. Measured cost (#351, i7-12700K, one pinned
+    // P-core, fp64, median of 3):
+    //
+    //     tile   acc vectors   N=1024   N=2048
+    //     4x8         8         57.90    56.90     <- floor-sized, was default
+    //     5x8        10         63.41    64.16
+    //     6x8        12         67.57    66.96     <- +17%
+    //     8x8        16         57.68    57.03     <- fills the file, spills
+    //     8x12       24         55.31    55.72
+    //
+    // Both directions cost: too few accumulators cannot hide latency, too many
+    // leave nothing for operands. The peak sits at ~3/4 of the register file,
+    // which is also where BLIS's hand-written Haswell dgemm kernel sits (6x8),
+    // and where its AVX-512 kernel sits (8x24 = 24 of 32).
+    //
+    // So: budget 3/4 of the file for accumulators, hold the B micro-panel in
+    // NRVEC vector registers, and let the floor raise mr if a narrow file would
+    // otherwise put us under it.
+    constexpr std::size_t NRVEC = 2;                 // B panel width, in vectors
+    const std::size_t area_floor = nvec * hw.fma_latency * hw.fma_units;
+
+    std::size_t nr, mr;
+    if (hw.vec_registers == 0) {
+        // Register file unknown (an initializer predating this field): fall back
+        // to the pre-#351 near-square tile sized at the latency floor.
+        nr = round_up(isqrt_ceil(area_floor), nvec);
+        if (nr == 0) nr = nvec;
+        mr = ceil_div(area_floor, nr);
+        if (mr == 0) mr = 1;
+    } else {
+        nr = nvec * NRVEC;
+        if (nr == 0) nr = nvec;
+        // Accumulator budget, leaving room for the B panel and the A broadcast.
+        std::size_t acc_budget = (hw.vec_registers * 3) / 4;
+        if (acc_budget < NRVEC + 1) acc_budget = NRVEC + 1;
+        mr = acc_budget / NRVEC;
+        if (mr == 0) mr = 1;
+        // The floor is a floor: if a narrow file put us under it, fall back to
+        // the near-square shape rather than growing mr alone into a degenerate
+        // aspect ratio.
+        if (mr * nr < area_floor) {
+            nr = round_up(isqrt_ceil(area_floor), nvec);
+            if (nr == 0) nr = nvec;
+            mr = ceil_div(area_floor, nr);
+            if (mr == 0) mr = 1;
+        }
+    }
 
     // kc: B micro-panel (kc x nr) occupies ~half of L1.
     std::size_t kc = (hw.l1_bytes / 2) / (nr * sdata);

--- a/tests/unit/simd/test_blocking.cpp
+++ b/tests/unit/simd/test_blocking.cpp
@@ -23,12 +23,45 @@ TEST_CASE("constexpr integer helpers", "[simd][blocking]") {
 
 TEST_CASE("AVX2 double derivation matches published Haswell-class values", "[simd][blocking]") {
     // Nvec=4 (AVX2 double), default Haswell-class traits.
+    //
+    // 6x8, not the 4x8 this pinned before #351. The tile is now sized against
+    // the REGISTER FILE (12 accumulator vectors of 16 ymm) rather than at the
+    // dependent-FMA latency floor, which is a lower bound the old derivation
+    // used as a target. 6x8 is also BLIS's hand-written Haswell dgemm tile, and
+    // it measured +17% single-core over 4x8 on an i7-12700K.
     constexpr blocking_params bp = derive_blocking<double>(4);
-    STATIC_REQUIRE(bp.mr == 4);
-    STATIC_REQUIRE(bp.nr == 8);     // multiple of Nvec=4; matches OpenBLAS Haswell 4x8
+    STATIC_REQUIRE(bp.mr == 6);
+    STATIC_REQUIRE(bp.nr == 8);     // NRVEC=2 vectors of Nvec=4; matches BLIS Haswell 6x8
     STATIC_REQUIRE(bp.kc == 256);   // (32KB/2)/(8*8)
-    STATIC_REQUIRE(bp.mc == 64);    // (256KB/2)/(256*8), multiple of mr
+    STATIC_REQUIRE(bp.mc == 60);    // (256KB/2)/(256*8) rounded down to a multiple of mr=6
     STATIC_REQUIRE(bp.nc == 4096);  // 8MB/(256*8), multiple of nr
+
+    // The accumulators fit the file with room for the B panel and the A
+    // broadcast -- the constraint the old derivation did not model at all.
+    constexpr std::size_t acc_vectors = bp.mr * (bp.nr / 4);
+    STATIC_REQUIRE(acc_vectors == 12);
+    STATIC_REQUIRE(acc_vectors + 2 + 1 <= default_hw_traits.vec_registers);
+
+    // ...and still clear the latency floor it used to sit exactly on.
+    STATIC_REQUIRE(bp.mr * bp.nr
+                   > 4 * default_hw_traits.fma_latency * default_hw_traits.fma_units);
+}
+
+TEST_CASE("register-file budget binds above the latency floor (#351)", "[simd][blocking]") {
+    // The floor is a LOWER bound, not a target. On a register-poor target it
+    // binds and the tile falls back; on a normal one the file budget governs.
+    hw_traits poor = default_hw_traits;
+    poor.vec_registers = 8;
+    const blocking_params bp_poor = derive_blocking<double>(4, poor);
+    CHECK(bp_poor.mr * bp_poor.nr >= 4 * poor.fma_latency * poor.fma_units);
+
+    // A 32-register file (AVX-512, NEON, SVE) buys a wider tile, at the same
+    // ~3/4 occupancy that measured best on 16.
+    hw_traits wide = default_hw_traits;
+    wide.vec_registers = 32;
+    const blocking_params bp_wide = derive_blocking<double>(8, wide);
+    CHECK(bp_wide.mr * (bp_wide.nr / 8) == 24);
+    CHECK(bp_wide.mr * (bp_wide.nr / 8) <= wide.vec_registers);
 }
 
 namespace {
@@ -66,6 +99,7 @@ TEST_CASE("derivation adapts to a different hardware profile (AVX-512 / bigger c
         /*l2_bytes*/ 1024u * 1024,           // 1 MB L2 (Skylake-X)
         /*l3_bytes*/ 16u * 1024 * 1024,
         /*page_bytes*/ 4096,
+        /*vec_registers*/ 32,          // AVX-512: 32 zmm
     };
     constexpr blocking_params bp = derive_blocking<double>(8, avx512);   // 8 doubles = AVX-512
     STATIC_REQUIRE(bp.nr % 8 == 0);


### PR DESCRIPTION
## Summary

**+16% single-core GEMM** (fp64, i7-12700K, one pinned P-core) from a parameter-derivation change. No kernel was rewritten.

The tile came from Eq. 1 of the BLIS analytical model —

```
area = Nvec * Lvfma * Nvfma          // 4 * 4 * 2 = 32 elements
```

— used as the **target**. It is a **lower bound**: the minimum accumulators needed to cover dependent-FMA latency at the issue width. The derivation had **no register-file term at all**, so nothing modelled the ceiling. On AVX2 that gives 4×8 for double: **8 accumulator vectors out of 16 ymm, half the file idle**.

## The sweep

`mr`/`nr` are reachable by varying `fma_latency`/`fma_units`, the only handle the current model exposes. Single core, pinned, fp64, median of 3:

| tile | acc vectors | N=1024 | N=2048 |
|---|---:|---:|---:|
| **4×8** | 8 | 57.90 | 56.90 | ← shipped default |
| 5×8 | 10 | 63.41 | 64.16 |
| **6×8** | **12** | **67.57** | **66.96** | ← **+17%** |
| 8×8 | 16 | 57.68 | 57.03 | ← fills the file, spills |
| 6×12 | 18 | 60.24 | 59.38 |
| 8×12 | 24 | 55.31 | 55.72 |
| 11×12 | 33 | 53.33 | 54.31 |

**Both directions cost.** Too few accumulators cannot hide FMA latency; too many leave nothing for the operands and the microkernel spills every k step. The peak is at **~¾ of the register file** — which is also where **BLIS's hand-written Haswell `dgemm` kernel sits: 6×8**, the same shape this sweep found independently.

That is a sharper diagnosis than "derived at the minimum": the model was missing a constraint, not merely tuned low.

## Measured after implementing

| | before | after | |
|---|---:|---:|---|
| T=1 N=512 | 59.36 | **69.23** | +16.6% |
| T=1 N=1024 | 59.40 | **68.17** | +14.8% |
| T=1 N=2048 | 57.21 | **66.61** | +16.4% |
| T=8 N=2048 | 404.56 | **419.71** | +3.7% |

At N=2048 that moves single-core from **73% → 86% of FMA peak**, and from 75.5% → ~91% of OpenBLAS.

**The threaded gain is much smaller, and that is worth stating plainly:** at ~420 GFLOP/s the cores outrun what memory can feed, so parallel efficiency *drops* from 89% to 78% even as total throughput rises. Net win at every thread count, no regression — but this closes a single-core gap, not a scaling one.

## A bug I introduced and caught

`vec_registers` is **appended** to `hw_traits`, not inserted.

I inserted it third at first. `hw_traits` is a public aggregate that tests — and potentially downstream code — initialize **positionally**, so every later field silently shifted: a 32 KB `l1_bytes` became **8 bytes**, and `mr` came out as **12288**. The existing test caught it; user code would have been silently mis-configured with no diagnostic.

Appending means an initializer written before this field value-initializes it to `0`, which `derive_blocking` treats as *unknown* and falls back to the pre-#351 near-square latency-floor tile. **Old code keeps compiling and keeps its old behaviour** instead of getting garbage. The reasoning is a comment on the field so the ordering is not "tidied" later.

## Scope of the evidence

Measured **only on AVX2 with 16 ymm registers.** The ¾ budget extrapolates to 32-register ISAs (AVX-512, NEON, SVE) as 12×16 = 24 of 32, which is consistent with BLIS's AVX-512 kernel sitting at 24/32 — but that is *reasoning, not measurement*. ARM64 CI will confirm it still passes; it will not confirm it is optimal there.

#222 (runtime cache/ISA detection) is where a real `vec_registers` would come from rather than a compile-time default.

## Related

- **#347** — re-framed. Its premise ("#110 needs this before option 1") died with #110. `packB` is invariantly 8.00 MB across every tile in this sweep, so it did not confound these numbers; whether panel sizing contributes separately to the single-core gap is still open.
- **#381** — filed from this work: three MT sparse tests fail under `-march=native` because they compare bit-exactly across two different loop nests. Unrelated to this change; found while sweeping.

## Test results

| target | gcc build | gcc test | clang build | clang test |
|---|---|---|---|---|
| `simd_test_blocking` | OK | PASS (149 assertions / 8 cases) | OK | PASS |
| full unit suite | OK | **161/161** | OK | **161/161** |

New cases pin the register-file budget (12 of 16, with room for the B panel and A broadcast), assert the tile now clears the latency floor rather than sitting on it, and cover both the register-poor fallback and a 32-register file.

## Test plan
- [ ] Fast CI passes (gcc + clang, incl. ARM64)
- [ ] Promote to ready when satisfied

Resolves #351

Generated with [Claude Code](https://claude.com/claude-code)