### PR TITLE
test(sparse): pin FP contraction for the MT solve tests, and assert determinism

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -43,6 +43,34 @@ compile_all("true" "iface" "Tests/interface" "MTL5::mtl5;Catch2::Catch2WithMain"
 file(GLOB SPARSE_SRC "sparse/*.cpp")
 compile_all("true" "sparse" "Tests/sparse" "MTL5::mtl5;Catch2::Catch2WithMain" ${SPARSE_SRC})
 
+# The threaded solve tests assert BIT-IDENTITY against their serial counterparts
+# (#381). That claim is about ACCUMULATION ORDER -- the level-scheduled gather
+# visits each row's entries in the same increasing-column order the serial CSC
+# scatter does -- and it is true at the source level.
+#
+# FP contraction does not change that order; it fuses a multiply and an add. But
+# it is applied per-expression, so the compiler may contract one of the two loop
+# nests and not the other, and the results then differ in the last ulp. Measured
+# under -O3 -march=native: half the entries differ, by ~1 eps relative to the
+# solution norm. With contraction off, 0 entries differ on both GCC and Clang.
+#
+# So these targets pin contraction, which is what makes the order claim testable
+# rather than a claim about the optimizer. MSVC needs nothing: /fp:precise is the
+# default and does not contract across statements.
+#
+# The invariants that hold under ANY flags -- determinism across repeated
+# threaded runs, and agreement with the serial solve to a measured bound -- are
+# asserted inside the tests themselves and are not affected by this.
+if(NOT MSVC)
+    foreach(mt_target sparse_test_supernodal_ldlt_mt
+                      sparse_test_supernodal_lu_mt
+                      sparse_test_trisolve_level_schedule_mt)
+        if(TARGET ${mt_target})
+            target_compile_options(${mt_target} PRIVATE -ffp-contract=off)
+        endif()
+    endforeach()
+endif()
+
 file(GLOB ARRAY_SRC "array/*.cpp")
 compile_all("true" "array" "Tests/array" "MTL5::mtl5;Catch2::Catch2WithMain" ${ARRAY_SRC})
 

--- a/tests/unit/sparse/test_supernodal_ldlt_mt.cpp
+++ b/tests/unit/sparse/test_supernodal_ldlt_mt.cpp
@@ -114,8 +114,21 @@ void require_supernodal_solve_bit_identical(const mat::compressed2D<double>& A) 
     vec::dense_vector<double> x(n);
     fac.solve(x, b);
 
+    // ORDER: identical accumulation order to the serial dense kernels. A
+    // source-level claim, observable only with FP contraction pinned -- the
+    // target pins it (tests/unit/CMakeLists.txt, #381).
     for (std::size_t i = 0; i < n; ++i)
         REQUIRE(x(static_cast<int>(i)) == ref[i]);   // exact equality
+
+    // DETERMINISM: the threaded solve is reproducible run to run. Same function,
+    // same expression tree, so this holds under any optimization flags, and it
+    // is what guards against a racing or order-dependent reduction.
+    for (int rep = 0; rep < 3; ++rep) {
+        vec::dense_vector<double> again(n);
+        fac.solve(again, b);
+        for (std::size_t i = 0; i < n; ++i)
+            REQUIRE(again(static_cast<int>(i)) == x(static_cast<int>(i)));
+    }
 }
 
 } // namespace

--- a/tests/unit/sparse/test_supernodal_lu_mt.cpp
+++ b/tests/unit/sparse/test_supernodal_lu_mt.cpp
@@ -124,8 +124,21 @@ void require_supernodal_lu_solve_bit_identical(const mat::compressed2D<double>& 
     vec::dense_vector<double> x(n);
     fac.solve(x, b);
 
+    // ORDER: identical accumulation order to the serial dense kernels. A
+    // source-level claim, observable only with FP contraction pinned -- the
+    // target pins it (tests/unit/CMakeLists.txt, #381).
     for (std::size_t i = 0; i < n; ++i)
         REQUIRE(x(static_cast<int>(i)) == ref[i]);   // exact equality
+
+    // DETERMINISM: the threaded solve is reproducible run to run. Same function,
+    // same expression tree, so this holds under any optimization flags, and it
+    // is what guards against a racing or order-dependent reduction.
+    for (int rep = 0; rep < 3; ++rep) {
+        vec::dense_vector<double> again(n);
+        fac.solve(again, b);
+        for (std::size_t i = 0; i < n; ++i)
+            REQUIRE(again(static_cast<int>(i)) == x(static_cast<int>(i)));
+    }
 }
 
 } // namespace

--- a/tests/unit/sparse/test_trisolve_level_schedule_mt.cpp
+++ b/tests/unit/sparse/test_trisolve_level_schedule_mt.cpp
@@ -91,6 +91,20 @@ std::vector<double> random_rhs(std::size_t n, std::uint64_t seed) {
 }
 
 // Assert level_scheduled_lower_solve == dense_lower_solve, bit-for-bit.
+//
+// Two distinct invariants, and they need different justification (#381):
+//
+//   ORDER      got == ref exactly. A source-level claim: the level-scheduled
+//              gather visits each row in the same increasing-column order the
+//              serial CSC scatter does. True regardless of thread count -- but
+//              only observable with FP contraction pinned, since the compiler
+//              may fuse a multiply-add in one loop nest and not the other. The
+//              target pins it (see tests/unit/CMakeLists.txt).
+//   DETERMINISM the threaded solve returns bit-identical results across repeated
+//              runs. Same function, same expression tree, so this holds under
+//              ANY optimization flags -- and it is the invariant that actually
+//              guards against a racing or order-dependent reduction, which is
+//              what threading threatens.
 void require_bit_identical(const csc_matrix<double>& L, std::uint64_t rhs_seed) {
     const std::size_t n = L.ncols;
     auto ref = random_rhs(n, rhs_seed);
@@ -99,6 +113,14 @@ void require_bit_identical(const csc_matrix<double>& L, std::uint64_t rhs_seed) 
     auto sched = factorization::build_lower_solve_schedule(L);
     factorization::level_scheduled_lower_solve(L, sched, got);       // level-scheduled
     for (std::size_t i = 0; i < n; ++i) REQUIRE(got[i] == ref[i]);
+
+    // DETERMINISM: independent of contraction, and of how the pool happened to
+    // schedule the first run.
+    for (int rep = 0; rep < 3; ++rep) {
+        auto again = random_rhs(n, rhs_seed);
+        factorization::level_scheduled_lower_solve(L, sched, again);
+        for (std::size_t i = 0; i < n; ++i) REQUIRE(again[i] == got[i]);
+    }
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

Three threaded sparse solve tests failed under `-march=native` while passing everywhere CI builds. Fixed by making each assertion **testable in the configuration it claims to hold in**, rather than by loosening it.

## What was actually wrong

The tests assert bit-identity between the threaded solve and its serial counterpart, on the grounds stated in their own headers:

> the row-gather accumulates each `x[i]` in the same increasing-column order the CSC scatter uses

That claim is about **accumulation order**, and it is **true**. FP contraction does not change accumulation order — it fuses a multiply and an add. But it applies *per expression*, so the compiler may contract one of the two loop nests and not the other.

Measured, `-O3 -march=native`, 2000×2000 banded factor:

| | |
|---|---|
| differing entries | **1035 / 2000** |
| max \|got − ref\| | 1.110e-16 |
| max abs / max\|x\| | **2.327e-16** — ~1 eps, one ulp |
| determinism | **0 / 2000** differ across repeated threaded runs |

With `-ffp-contract=off`: **0/2000 differ**, on GCC and Clang alike.

## Why not a tolerance — I changed my mind from the issue

#381 is mine, and it suggested loosening the cross-kernel comparison. **The measurement says that trades away the wrong thing.**

The error is ~1 ulp against the solution norm — but a per-*element* relative tolerance would need to be **1.6e-12**, four orders looser than the real error, because entries near zero inflate the ratio. A bar that loose would no longer catch an accumulation-order regression, which is precisely what these tests exist to detect.

Testing a *source-level* order claim requires holding contraction fixed. So the three targets compile with `-ffp-contract=off`. MSVC needs nothing — `/fp:precise` is the default and does not contract across statements.

## What was added

**Determinism.** Each threaded solve now runs repeatedly and must be bit-identical to its own first result. Same function, same expression tree, so this holds under **any** optimization flags — and it is the invariant that actually guards against a racing or order-dependent reduction, which is what threading threatens.

It passed even with contraction left *on*, confirming it is independent of the flag.

So the tests now make **two claims with separate justifications**, instead of one claim that was only true on some targets:

| invariant | holds because | tested how |
|---|---|---|
| **order** — threaded == serial, bit for bit | same accumulation order at source level | contraction pinned on the target |
| **determinism** — threaded == itself, run to run | one function, one expression tree | unconditional, any flags |

Assertions went **470594 → 945313** in the trisolve test.

## Verification

**Negative control:** removing the contraction pin restores *exactly* the original 4 failures; restoring it passes.

Three configurations, **161/161** each:

| configuration | result |
|---|---|
| Release + Highway + `-march=native` — the config that was failing | 161/161 |
| Debug gcc — what CI builds | 161/161 |
| Debug clang — what CI builds | 161/161 |

## Still open: should a CI lane use `-march=native`?

Part 2 of #381, deliberately **not** decided here. The existing rationale against it is sound (`.github/workflows/ci.yml`):

> `MTL5_NATIVE_ARCH` is deliberately NOT set: `-march=native` would pin the build to whatever microarchitecture the runner happens to be.

The consequence is that no test lane compiles with it, while the release preset and benchmark lanes do — so the configuration a performance-minded user most likely builds is the one the test suite never runs in. This PR removes the specific breakage, not the coverage gap.

If it is worth closing, a single non-matrix job pinned to a fixed `-march=x86-64-v3` would be reproducible rather than runner-dependent. That is a cost/policy call, so I have left it to you.

## Test plan
- [ ] Fast CI passes (gcc + clang)
- [ ] Promote to ready when satisfied

Resolves #381

Generated with [Claude Code](https://claude.com/claude-code)