### PR TITLE
docs(design): add smoothers and multigrid architecture documents

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -78,6 +78,8 @@ export default defineConfig({
                 { slug: 'design/operation-dispatch-architecture' },
                 { slug: 'design/iterative-solvers-architecture' },
                 { slug: 'design/eigensolvers-architecture' },
+                { slug: 'design/smoothers-architecture' },
+                { slug: 'design/multigrid-architecture' },
                 { slug: 'design/mixed-precision-custom-types-simd' },
                 { slug: 'design/sparse-direct-solvers' },
               ],

--- a/docs-site/sync-content.mjs
+++ b/docs-site/sync-content.mjs
@@ -81,6 +81,8 @@ const FILE_MAP = {
   'design/operation-dispatch-architecture.md':  'design/operation-dispatch-architecture.md',
   'design/iterative-solvers-architecture.md':   'design/iterative-solvers-architecture.md',
   'design/eigensolvers-architecture.md':        'design/eigensolvers-architecture.md',
+  'design/smoothers-architecture.md':           'design/smoothers-architecture.md',
+  'design/multigrid-architecture.md':           'design/multigrid-architecture.md',
   'design/blas-kernel-architecture.md':         'design/blas-kernel-architecture.md',
   'design/multicore-scaling-investigation.md':  'design/multicore-scaling-investigation.md',
   'design/parallelization-patterns-and-pitfalls.md': 'design/parallelization-patterns-and-pitfalls.md',

--- a/docs/design/multigrid-architecture.md
+++ b/docs/design/multigrid-architecture.md
@@ -1,0 +1,203 @@
+# Multigrid: the V-cycle over pluggable smoothers and grids
+
+How MTL5's multigrid driver works, and *why* it is built as a recursion over four
+pluggable roles — a grid hierarchy, inter-grid transfer operators, a
+[smoother](smoothers-architecture.md), and a coarse solver. Multigrid is the method
+that turns the slow tail of a stationary iteration into an O(n) solve, and the
+design mirrors the composability of the [Krylov solvers](iterative-solvers-architecture.md):
+the driver owns only the cycle; every numerical ingredient is supplied.
+
+The subsystem is the `multigrid` driver plus the grid-transfer operators in
+[`itl/mg/`](https://github.com/stillwater-sc/mtl5/tree/main/include/mtl/itl/mg)
+(namespace `mtl::itl::mg`).
+
+---
+
+## The idea: split the error by frequency across grids
+
+A [smoother](smoothers-architecture.md) damps the *high-frequency* (oscillatory)
+components of the error in a few sweeps, but barely touches the *low-frequency*
+(smooth) components — which is why a stationary iteration stalls. Multigrid's
+insight is that **smooth error on a fine grid looks oscillatory on a coarser grid**,
+where a smoother *can* damp it cheaply. So it recursively pushes the residual down to
+coarser grids, smooths at each, and interpolates the correction back up:
+
+```text
+smooth (kill high freq)  →  restrict residual to coarser grid
+   →  [solve the coarse problem the same way, recursively]
+   →  prolongate the correction back  →  smooth again
+```
+
+Each grid handles the frequency band it damps efficiently, and the coarsest grid —
+small enough to solve exactly — mops up what remains. The result is a solver whose
+cost is O(n) for the model problems it targets, instead of the O(n^1.5) or worse of a
+lone smoother or unpreconditioned Krylov method on a PDE.
+
+---
+
+## Decision 1 — the V-cycle (and W-cycle) recursion
+
+The core is `vcycle(x, b, level)`, a direct transcription of the idea:
+
+```cpp
+void vcycle(vector_type& x, const vector_type& b, int level) {
+    if (level == coarsest) { coarse_solve_(x, b); return; }       // base case: solve exactly
+
+    for (int s = 0; s < nu_pre_;  ++s) smoothers_[level](x, b);    // pre-smooth
+    r        = b - A[level] * x;                                   // residual
+    r_coarse = restrict(R[level], r);                             // fine -> coarse
+    e_coarse = 0;
+    vcycle(e_coarse, r_coarse, level + 1);                        // recurse (solve A_c e_c = r_c)
+    x += prolongate(P[level], e_coarse);                         // coarse -> fine, correct
+    for (int s = 0; s < nu_post_; ++s) smoothers_[level](x, b);   // post-smooth
+}
+```
+
+Pre-smooth, restrict the residual, recurse on the coarse-grid *error equation*
+(starting from zero), prolongate the correction, post-smooth. The recursion bottoms
+out at the coarsest level with a direct solve. The **W-cycle** is the same body with
+the recursion invoked **twice** per level — more coarse-grid work per visit, more
+robust for harder problems. V and W are one recursion shape with a one-line
+difference, so they are the two methods and nothing else.
+
+---
+
+## Decision 2 — composition over four pluggable roles
+
+The `multigrid` object is assembled from independent ingredients, exactly the
+composition pattern the [Krylov solvers](iterative-solvers-architecture.md#decision-6--the-cartesian-product-for-free)
+use:
+
+```cpp
+multigrid(levels,        // A[0] (finest) … A[L-1] (coarsest) — the grid hierarchy
+          restrictors,   // R[0] … R[L-2] — fine→coarse transfer matrices
+          prolongators,  // P[0] … P[L-2] — coarse→fine transfer matrices
+          smoother_factory,   // makes a smoother for a given level's matrix
+          coarse_solver,      // solves the coarsest level exactly
+          nu_pre, nu_post);   // smoothing counts
+```
+
+The driver knows the *cycle*; it does not know *which* smoother or coarse solver you
+use. Any [`itl::smoother`](smoothers-architecture.md) (Jacobi, Gauss-Seidel, SOR)
+plugs in through the factory, and any callable that solves the coarse system plugs in
+as `coarse_solver`. That is what ties this subsystem to the smoother one: multigrid
+is the composition layer, the smoothers are the components. Swap the smoother, the
+cycle count, or the hierarchy depth without touching the driver.
+
+---
+
+## Decision 3 — inter-grid transfer is a sparse matvec
+
+Restriction and prolongation are not special machinery — they are
+[`compressed2D`](../architecture/containers/compressed2d-architecture.md) matrices,
+and applying them is an ordinary sparse matrix-vector product:
+
+```text
+r_coarse = R · r_fine        R : n_coarse × n_fine   (fine → coarse)
+e_fine   = P · e_coarse       P : n_fine × n_coarse   (coarse → fine)
+```
+
+For the shipped 1-D geometric case, `make_restriction_1d` builds `R` with the
+standard **full-weighting** stencil `[¼, ½, ¼]`, and `make_prolongation_1d` builds
+`P` by **linear interpolation** — related by the classic `P = 2·Rᵀ`. Both are
+assembled with the [`compressed2D` inserter](../architecture/containers/compressed2d-architecture.md) and applied
+with a hand CRS matvec. Casting grid transfer as "just" SpMV with purpose-built
+sparse operators means the entire sparse-matrix and matvec toolchain is reused; the
+multigrid driver adds no new linear-algebra primitive, only the cycle that sequences
+them.
+
+---
+
+## Decision 4 — type erasure for the per-level smoother collection
+
+One implementation choice stands out against MTL5's usual compile-time-generic
+style. The per-level smoothers are stored as a homogeneous vector of
+`std::function`:
+
+```cpp
+std::vector<std::function<void(vector_type&, const vector_type&)>> smoothers_;
+std::function<void(vector_type&, const vector_type&)>              coarse_solve_;
+```
+
+The constructor builds one smoother per level via the factory and **type-erases** it
+into a `std::function`. This is a runtime-dispatch cost the rest of the library
+avoids — and it is the right call *here*, because the hierarchy holds a
+**collection** of smoothers, one per level, that must live in a single container and
+be indexed by level at run time. A `std::vector` needs a single element type;
+`std::function` provides it while still letting each level's smoother be any callable
+the factory produced. The erasure is confined to the driver's storage; the smoothers
+themselves stay statically typed.
+
+---
+
+## Decision 5 — multigrid is both a solver and a Krylov preconditioner
+
+The driver exposes two faces:
+
+- **A standalone iteration.** `operator()(x, b)` applies one V-cycle; repeated
+  application is a convergent solver in its own right.
+- **A preconditioner.** `solve(x, b)` / `adjoint_solve(x, b)` apply one V-cycle as
+  `M⁻¹`, satisfying the [`Preconditioner` concept](iterative-solvers-architecture.md#decision-3--the-preconditioner-is-a-concept-solve--adjoint_solve).
+  This is the powerful combination — **multigrid-preconditioned CG** — where one
+  V-cycle per Krylov step gives grid-independent convergence.
+
+That second face closes a loop across the whole `itl/` subsystem: multigrid is *built
+from* smoothers (which, symmetric, are themselves Krylov preconditioners), and
+multigrid *is itself* a Krylov preconditioner. The same small parts compose at every
+level. (`adjoint_solve` equals `solve`, valid when the cycle is symmetric — symmetric
+smoothers with matching pre/post counts; and `solve` `const_cast`s to run the
+mutating cycle through the const preconditioner interface — a small, honest wart of
+that adaptation.)
+
+---
+
+## What the design deliberately does not do
+
+- **Geometric, 1-D transfer operators only.** `make_restriction_1d` /
+  `make_prolongation_1d` build the 1-D full-weighting / linear-interpolation
+  operators. There is no **algebraic multigrid** (AMG), where `R`/`P` are derived
+  from `A`'s graph, and no built-in 2-D/3-D geometric transfers — though the driver
+  itself is dimension-agnostic given the matrices, so a caller can supply their own.
+- **The coarsest solve is exact and external.** The base case delegates to the
+  supplied `coarse_solver`; the driver does not prescribe how the small coarse system
+  is solved.
+- **Reference-grade, not a tuned MG library.** Like the Krylov eigensolvers, this is
+  a legible reference implementation — the cycle and the composition are the point,
+  not a production AMG with aggressive coarsening and smoother tuning.
+
+---
+
+## Where it sits in the stack
+
+```text
+containers    (compressed2D level matrices + R/P transfer operators; dense_vector state)
+   │
+smoothers     (itl/smoother: the per-level high-frequency error damper)
+   │
+▶ MULTIGRID    (itl/mg: the V/W-cycle that sequences smooth → restrict → recurse →
+                prolongate → smooth, over a supplied hierarchy)
+   │
+(optionally) Krylov solver   (itl/krylov: preconditioned by one V-cycle)
+```
+
+Multigrid adds no arithmetic primitive of its own. It is pure orchestration: it
+sequences smoother sweeps, sparse matvecs (the transfers), and a coarse solve into a
+recursion whose whole is far more than its parts — an O(n) solver, or a
+grid-independent preconditioner, assembled from pieces documented elsewhere.
+
+---
+
+## File map
+
+| File | Role |
+|---|---|
+| [`itl/mg/multigrid.hpp`](https://github.com/stillwater-sc/mtl5/blob/main/include/mtl/itl/mg/multigrid.hpp) | the V-cycle / W-cycle driver; solver `operator()` and `Preconditioner` `solve` |
+| [`itl/mg/restriction.hpp`](https://github.com/stillwater-sc/mtl5/blob/main/include/mtl/itl/mg/restriction.hpp) | `make_restriction_1d` (full-weighting) + `restrict` (SpMV) |
+| [`itl/mg/prolongation.hpp`](https://github.com/stillwater-sc/mtl5/blob/main/include/mtl/itl/mg/prolongation.hpp) | `make_prolongation_1d` (linear interp, `P = 2·Rᵀ`) + `prolongate` |
+| [`itl/smoother/`](https://github.com/stillwater-sc/mtl5/tree/main/include/mtl/itl/smoother) | the smoothers the driver applies per level |
+
+For the smoothers it sequences, see the
+[smoothers architecture](smoothers-architecture.md); for the Krylov methods it can
+precondition, the [iterative solvers](iterative-solvers-architecture.md) doc; for the
+CRS matrices and inserter it builds transfers with, the
+[compressed2D](../architecture/containers/compressed2d-architecture.md) doc.

--- a/docs/design/smoothers-architecture.md
+++ b/docs/design/smoothers-architecture.md
@@ -1,0 +1,192 @@
+# The smoothers: stationary iterations as reusable sweeps
+
+How MTL5 implements Jacobi, Gauss-Seidel, and SOR, and *why* they are packaged as
+small, reusable *sweep* functors rather than solve-to-convergence routines. A
+smoother applies one matrix-splitting sweep of `A·x = b`, cheaply damping the
+high-frequency components of the error — its role inside
+[multigrid](multigrid-architecture.md) — while also serving, in its symmetric
+form, as a Krylov [preconditioner](iterative-solvers-architecture.md#decision-3--the-preconditioner-is-a-concept-solve--adjoint_solve).
+
+The subsystem is three methods and their sweep-direction variants in
+[`itl/smoother/`](https://github.com/stillwater-sc/mtl5/tree/main/include/mtl/itl/smoother)
+(namespace `mtl::itl::smoother`). They share one row kernel and differ only in how
+the update is ordered.
+
+---
+
+## The common form: one splitting, three orderings
+
+Every smoother computes the same per-row update — solve row `i` for `x_i`, holding
+the other unknowns fixed:
+
+```text
+x_i  ←  D_ii⁻¹ · ( b_i  −  Σ_{j≠i} A_ij · x_j )        # D = diag(A)
+```
+
+The three methods differ only in *which* `x_j` the row sum reads and how the result
+is blended in:
+
+| Method | Reads, for the row sum | Update |
+|---|---|---|
+| **Jacobi** | the **old** `x` everywhere (simultaneous) | write to a fresh `x_new`, copy back |
+| **Gauss-Seidel** | the **latest** `x` — `x_j` for `j<i` already updated this sweep | in place |
+| **SOR** | latest `x` (as GS) | `x_i ← ω·(GS update) + (1−ω)·x_i` |
+
+That one shared kernel with three orderings is the whole family; the code is
+organized to reflect it.
+
+---
+
+## Decision 1 — a smoother is a functor: construct from `A`, apply as one sweep
+
+Each smoother is a small class parameterized on the matrix type, built once from
+`A` and then applied repeatedly:
+
+```cpp
+gauss_seidel<compressed2D<double>> S(A);   // ctor precomputes inv(diag A)
+S(x, b);                                    // ONE forward sweep, mutates x
+S(x, b);                                    // apply again — a few sweeps is the usage
+```
+
+The constructor precomputes the inverse diagonal (`dia_inv_`); `operator()(x, b)`
+runs a single sweep and returns the updated `x`. Crucially, a smoother does **not**
+iterate to a tolerance — one call is one sweep. This is deliberate: a smoother is a
+*primitive*, applied a fixed small number of times (two or three) by whatever drives
+it. Its job is not to solve the system but to make the error smooth, and "how many
+sweeps / when to stop" belongs to the caller (multigrid, or a stationary-iteration
+loop), not the smoother. The name says it: *smoother*, not *solver*.
+
+---
+
+## Decision 2 — Jacobi (simultaneous) vs Gauss-Seidel (in-place) vs SOR (relaxed)
+
+The three differ in exactly the way the mathematics does:
+
+- **Jacobi** computes every `x_new(i)` from the *old* `x`, then copies `x_new` back.
+  It needs an O(n) temporary, and the sweep is order-independent (every update sees
+  the same input) — which is what makes Jacobi trivially parallel, at the cost of
+  slower convergence.
+- **Gauss-Seidel** writes in place, so when it reaches row `i` the entries `x_j`,
+  `j<i`, already hold this sweep's updated values. No temporary, faster
+  convergence, but the sweep carries a **sequential dependency** (row `i` depends on
+  the rows before it). Sweep *direction* therefore matters, and the code exposes
+  `forward()` (ascending rows) and `backward()` (descending).
+- **SOR** is Gauss-Seidel with a relaxation factor `ω`: `x_i = ω·gs_update +
+  (1−ω)·x_i`. `ω = 1` recovers GS; `ω > 1` over-relaxes to accelerate convergence;
+  `ω < 1` under-relaxes for stability. It reuses the GS row sum and adds the blend.
+
+Jacobi allocates its `x_new`; GS and SOR are in place. That memory-vs-parallelism
+distinction is intrinsic to the methods, and the implementations wear it plainly.
+
+---
+
+## Decision 3 — sweep-direction and symmetric variants are first-class types
+
+Beyond the base forward sweep, the layer ships named variants:
+
+```text
+gauss_seidel            forward() / backward()
+backward_gauss_seidel   one descending sweep
+symmetric_gauss_seidel  forward THEN backward, per application
+sor / backward_sor / symmetric_sor   the same, relaxed
+```
+
+The **symmetric** variant (a forward sweep immediately followed by a backward one)
+is provided as a first-class primitive for a specific reason, stated in the source:
+for symmetric `A`, symmetric Gauss-Seidel is itself a **symmetric, SPD-preserving**
+operation, which is exactly the property a
+[Conjugate Gradient preconditioner](iterative-solvers-architecture.md#decision-3--the-preconditioner-is-a-concept-solve--adjoint_solve)
+must have. So SGS/SSOR are not left for the caller to compose from two half-sweeps;
+they are named types, because that composed operation *is* a distinct, useful
+object — the kernel behind the `pc::ssor` preconditioner. A sweep direction is a
+correctness-relevant choice here, not a detail, so it is lifted into the type.
+
+---
+
+## Decision 4 — dense and sparse specializations (O(n²) vs O(nnz))
+
+Each smoother has two implementations, chosen by the matrix type:
+
+- The **generic** template computes the row sum with `A(i, j)` over all `j` —
+  O(n²) per sweep, correct for any matrix but touching every (mostly-zero) entry.
+- A **`compressed2D` specialization** walks the raw CRS arrays
+  (`starts`/`indices`/`data`), summing only stored nonzeros — **O(nnz)** per sweep —
+  and (for Gauss-Seidel) caches each row's diagonal position so the split into
+  diagonal and off-diagonal is a lookup, not a search.
+
+This is the same "specialize the sparse fast path over the generic floor" pattern
+the whole library uses. It matters especially here: smoothers earn their keep on
+the large sparse systems from PDE discretizations, where the O(n²) dense sweep would
+be unusable and the O(nnz) CRS sweep is the point.
+
+---
+
+## Decision 5 — the per-row `Accumulator`, instrumented for mixed-precision study
+
+Every smoother carries an optional `Accumulator` template parameter governing the
+precision in which the off-diagonal row sum `σ = Σ_{j≠i} A_ij x_j` is accumulated,
+routed through `accumulator_traits` — the same mechanism as the
+[Krylov solvers](iterative-solvers-architecture.md#decision-7--mixed-precision-threads-through-from-the-operation-layer)
+and `void` (naive `value_type` accumulation) by default.
+
+But the smoothers are a *deliberate research instrument* for mixed-precision
+iterative methods, and two design choices reflect that:
+
+- **The accumulator scope is per row** — cleared at the start of each row. Combined
+  with Gauss-Seidel's in-place sweep (row `i` reads the freshly-updated, possibly
+  already-rounded `x_j`, `j<i`), this exposes exactly the **intra-sweep error
+  propagation** that low-precision-iterative studies target. The accumulator governs
+  the rounding of one row sum; it does not change which entries are read.
+- **In SOR, the `ω` blend is kept *outside* the accumulator** — only the row sum is
+  accumulated; `dia_inv·(b−σ)` and the `ω`-blend are ordinary scalar arithmetic.
+  This lets a study vary `ω` against precision *independently* of the sum's rounding.
+
+The exact/quire accumulators themselves live downstream — "MTL5 stays
+Universal-free." The smoothers just provide the precisely-scoped seam.
+
+---
+
+## What the design deliberately does not do
+
+- **One sweep per call, no convergence loop.** A smoother is a primitive; running it
+  to a tolerance is the caller's job. That keeps it composable (multigrid calls it
+  `nu` times; a preconditioner wraps one application).
+- **No colored / red-black parallel Gauss-Seidel.** The in-place GS sweep is
+  inherently sequential, and the shipped version keeps it so — a legible reference,
+  not a parallelized reordering. (Jacobi is the parallel-friendly member, by
+  construction.)
+- **Smoothers expose `operator()`, not `solve()`.** They are not themselves
+  `Preconditioner`-concept types; the `pc::ssor` wrapper adapts the symmetric sweep
+  to the `solve`/`adjoint_solve` face when a Krylov method needs one.
+
+---
+
+## Where they are used
+
+A smoother is a building block for two higher-level constructs:
+
+- **Multigrid** applies a smoother `nu_pre`/`nu_post` times at each grid level to
+  damp high-frequency error before/after the coarse-grid correction — its primary
+  reason for existing. See the [multigrid architecture](multigrid-architecture.md).
+- **Krylov preconditioning** uses the symmetric variants (via `pc::ssor`) as an
+  SPD-preserving `M` for CG and friends.
+
+Each is a small, single-purpose sweep; the power is in how the layers above compose
+them.
+
+---
+
+## File map
+
+| File | Role |
+|---|---|
+| [`itl/smoother/jacobi.hpp`](https://github.com/stillwater-sc/mtl5/blob/main/include/mtl/itl/smoother/jacobi.hpp) | Jacobi (simultaneous update; dense + CRS specializations) |
+| [`itl/smoother/gauss_seidel.hpp`](https://github.com/stillwater-sc/mtl5/blob/main/include/mtl/itl/smoother/gauss_seidel.hpp) | Gauss-Seidel + `backward_` / `symmetric_` variants |
+| [`itl/smoother/sor.hpp`](https://github.com/stillwater-sc/mtl5/blob/main/include/mtl/itl/smoother/sor.hpp) | SOR (relaxed GS) + `backward_` / `symmetric_` variants |
+| [`itl/pc/ssor.hpp`](https://github.com/stillwater-sc/mtl5/blob/main/include/mtl/itl/pc/ssor.hpp) | adapts the symmetric sweep to the `Preconditioner` concept |
+
+For the driver that applies these sweeps across a grid hierarchy, see the
+[multigrid architecture](multigrid-architecture.md); for the CRS matrix they sweep
+over, the [compressed2D](../architecture/containers/compressed2d-architecture.md)
+doc; for the Krylov methods that precondition with them, the
+[iterative solvers](iterative-solvers-architecture.md) doc.


### PR DESCRIPTION
﻿## Summary

Adds two architecture docs — one for the `itl/` **smoothers**, one for **multigrid** — cross-linked to each other and to the rest of the `itl/` subsystem. Both filed under **Design → Library**.

### `smoothers-architecture.md`

Jacobi / Gauss-Seidel / SOR as reusable **single-sweep functors**:
- **One matrix splitting, three orderings** — simultaneous (Jacobi, needs a temp, parallel-friendly) vs in-place (Gauss-Seidel, sequential dependency, sweep direction matters) vs relaxed (SOR).
- **Construct-from-A / apply-as-one-sweep** — a primitive, not a solve-to-tolerance; the caller decides how many sweeps.
- **Sweep-direction + symmetric variants as first-class types** — SGS/SSOR are SPD-preserving, so they underlie the `pc::ssor` CG preconditioner (a named type, not a caller compose).
- **Dense O(n²) vs `compressed2D` O(nnz)** specializations.
- **The per-row `Accumulator`, instrumented for mixed-precision-iterative study** — per-row scope exposes GS intra-sweep error propagation; SOR keeps the `ω` blend *outside* the accumulator so ω-vs-precision can be studied independently.

### `multigrid-architecture.md`

The V-cycle / W-cycle driver:
- **The idea** — smoother kills high-frequency error, coarse grid kills low-frequency (smooth error looks oscillatory when coarsened); O(n) solves.
- **The recursion** — pre-smooth, restrict residual, recurse on the coarse *error equation*, prolongate the correction, post-smooth; W-cycle recurses twice.
- **Composition over four pluggable roles** — levels, transfer matrices, smoother factory, coarse solver (the smoothers doc's subjects plug in here).
- **Inter-grid transfer is a sparse matvec** — full-weighting `R`, linear-interp `P = 2·Rᵀ`, built via the `compressed2D` inserter.
- **`std::function` type erasure** for the per-level smoother collection — the one runtime-dispatch spot in the library, and why it's justified here.
- **Both a solver and a Krylov preconditioner** — closing the `itl/` loop (multigrid built from smoothers; multigrid *is* a preconditioner).
- Non-goals: geometric/1-D transfers only, no AMG, reference-grade.

Registered in `FILE_MAP`; both added to the **Design → Library** sidebar. Verified with a full `astro build` (59 pages, no errors); all cross-links resolve (including a bare-link slip I caught and fixed pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architecture documentation for smoothers, including Jacobi, Gauss-Seidel, and SOR methods.
  * Added multigrid architecture documentation covering cycles, grid transfers, smoothers, coarse solvers, and supported limitations.
  * Added both pages to the Design → Library documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->