### PR TITLE
fix(itl): compute bicg's rho from z^T r~, not z~^T z

### DIFF
--- a/include/mtl/itl/krylov/bicg.hpp
+++ b/include/mtl/itl/krylov/bicg.hpp
@@ -43,7 +43,16 @@ int bicg(const LinearOp& A, VecX& x, const VecB& b, const PC& M, Iter& iter) {
     M.solve(z, r);
     M.adjoint_solve(z_tilde, r_tilde);
 
-    value_type rho = mtl::dot<Accumulator, value_type>(z_tilde, z);
+    // rho = z^T r~ : the PRECONDITIONED residual against the UNpreconditioned
+    // shadow residual (Barrett et al., Templates, section 2.3.5; Saad,
+    // Iterative Methods, Alg. 7.1).
+    //
+    // This used to be dot(z_tilde, z), which applies the preconditioner twice:
+    //   z~ . z = (M^-T r~) . (M^-1 r) = r~^T M^-1 M^-1 r
+    // where the algorithm needs r~^T M^-1 r. With pc::identity, z == r and
+    // z~ == r~, so the two coincide -- which is exactly why identity was the
+    // only preconditioner bicg converged with (#392).
+    value_type rho = mtl::dot<Accumulator, value_type>(r_tilde, z);
     value_type rho_1{};
 
     while (!iter.finished(r)) {
@@ -87,7 +96,7 @@ int bicg(const LinearOp& A, VecX& x, const VecB& b, const PC& M, Iter& iter) {
         M.adjoint_solve(z_tilde, r_tilde);
 
         rho_1 = rho;
-        rho = mtl::dot<Accumulator, value_type>(z_tilde, z);
+        rho = mtl::dot<Accumulator, value_type>(r_tilde, z);   // z^T r~, see above (#392)
 
         // rho == 0 is ambiguous between a true Lanczos breakdown and exact
         // convergence (r == 0 drives z == z_tilde == 0, hence rho == 0).

--- a/tests/unit/itl/test_bicg.cpp
+++ b/tests/unit/itl/test_bicg.cpp
@@ -9,6 +9,12 @@
 #include <mtl/operation/norms.hpp>
 #include <mtl/operation/dot.hpp>
 #include <mtl/itl/pc/identity.hpp>
+#include <mtl/itl/pc/diagonal.hpp>
+#include <mtl/itl/pc/ssor.hpp>
+#include <mtl/itl/pc/ilu_0.hpp>
+#include <mtl/itl/pc/ic_0.hpp>
+#include <mtl/operation/mult.hpp>
+#include <mtl/itl/krylov/cg.hpp>
 #include <mtl/itl/iteration/basic_iteration.hpp>
 #include <mtl/itl/krylov/bicg.hpp>
 
@@ -65,4 +71,168 @@ TEST_CASE("BiCG on sparse tridiagonal system", "[itl][bicg][sparse]") {
     for (std::size_t i = 0; i < n; ++i) {
         REQUIRE_THAT(Ax(i), Catch::Matchers::WithinAbs(b(i), 1e-8));
     }
+}
+
+// ---------------------------------------------------------------------------
+// #392: bicg computed rho from the wrong pair of vectors and therefore
+// converged ONLY with pc::identity.
+//
+//   rho = z^T r~     preconditioned residual against the UNpreconditioned
+//                    shadow residual (Barrett et al., Templates, 2.3.5)
+//
+// It used dot(z_tilde, z), which applies the preconditioner twice:
+// z~ . z = (M^-T r~) . (M^-1 r) = r~^T M^-1 M^-1 r, where the algorithm needs
+// r~^T M^-1 r. With identity, z == r and z~ == r~, so the two coincide.
+//
+// Which is precisely why it went unnoticed: every test in this file used
+// pc::identity, the single configuration in which the defect is invisible.
+// test_qmr.cpp does the same and qmr is broken the same way (#393);
+// test_bicgstab.cpp exercises pc::diagonal and bicgstab is correct.
+//
+// So these cases all use a NON-identity preconditioner. That is the point of
+// them, not an incidental detail.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/// 2-D Laplacian, SPD. The diagonal is varied so a diagonal preconditioner is
+/// not merely a scalar multiple of the identity -- otherwise the bug would stay
+/// hidden even with pc::diagonal.
+mat::compressed2D<double> laplacian_spd(std::size_t k) {
+    const std::size_t n = k * k;
+    mat::compressed2D<double> A(n, n);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        for (std::size_t i = 0; i < k; ++i)
+            for (std::size_t j = 0; j < k; ++j) {
+                const std::size_t r = i * k + j;
+                ins[r][r] << 4.0 * (1.0 + static_cast<double>(r % 7) * 0.1);
+                if (i)         ins[r][r - k] << -1.0;
+                if (i + 1 < k) ins[r][r + k] << -1.0;
+                if (j)         ins[r][r - 1] << -1.0;
+                if (j + 1 < k) ins[r][r + 1] << -1.0;
+            }
+    }
+    return A;
+}
+
+/// Solve A x = b for a known x, and return the relative infinity-norm error.
+template <typename Mat, typename Prec>
+double solve_err(const Mat& A, Prec& pc, int max_iter, int& iters, int& info) {
+    const std::size_t n = A.num_rows();
+    vec::dense_vector<double> xt(n);
+    for (std::size_t i = 0; i < n; ++i)
+        xt[i] = 1.0 + 0.5 * std::sin(static_cast<double>(i));
+    vec::dense_vector<double> b(n);
+    mtl::mult(A, xt, b);
+    vec::dense_vector<double> x(n, 0.0);
+    itl::basic_iteration<double> iter(b, max_iter, 1e-12);
+    info = itl::bicg(A, x, b, pc, iter);
+    iters = static_cast<int>(iter.iterations());
+    double e = 0.0, nx = 0.0;
+    for (std::size_t i = 0; i < n; ++i) {
+        e  = std::max(e, std::abs(x(i) - xt(i)));
+        nx = std::max(nx, std::abs(xt(i)));
+    }
+    return e / nx;
+}
+
+}  // namespace
+
+TEST_CASE("BiCG converges with a non-identity preconditioner (#392)",
+          "[itl][bicg][regression]") {
+    const auto A = laplacian_spd(12);
+    int iters = 0, info = 0;
+
+    SECTION("diagonal") {
+        // Was: 3000 iterations, relative error 2.25e-01.
+        itl::pc::diagonal<mat::compressed2D<double>> pc(A);
+        const double err = solve_err(A, pc, 3000, iters, info);
+        INFO("iters = " << iters << ", rel err = " << err);
+        REQUIRE(info == 0);
+        REQUIRE(err < 1e-8);
+        REQUIRE(iters < 100);          // was hitting the 3000 cap
+    }
+
+    SECTION("ssor") {
+        itl::pc::ssor<mat::compressed2D<double>> pc(A);
+        const double err = solve_err(A, pc, 3000, iters, info);
+        INFO("iters = " << iters << ", rel err = " << err);
+        REQUIRE(info == 0);
+        REQUIRE(err < 1e-8);
+    }
+
+    SECTION("ilu_0") {
+        itl::pc::ilu_0<double> pc(A);
+        const double err = solve_err(A, pc, 3000, iters, info);
+        INFO("iters = " << iters << ", rel err = " << err);
+        REQUIRE(info == 0);
+        REQUIRE(err < 1e-8);
+    }
+
+    SECTION("ic_0") {
+        itl::pc::ic_0<double> pc(A);
+        const double err = solve_err(A, pc, 3000, iters, info);
+        INFO("iters = " << iters << ", rel err = " << err);
+        REQUIRE(info == 0);
+        REQUIRE(err < 1e-8);
+    }
+}
+
+TEST_CASE("BiCG with a diagonal preconditioner matches CG on an SPD system (#392)",
+          "[itl][bicg][regression]") {
+    // The sharpest statement of the fix: on an SPD matrix, preconditioned BiCG
+    // reduces to preconditioned CG, so it must take the same iteration count.
+    // Before the fix bicg took 3000 (the cap) where cg took 33.
+    const auto A = laplacian_spd(12);
+    const std::size_t n = A.num_rows();
+
+    vec::dense_vector<double> xt(n);
+    for (std::size_t i = 0; i < n; ++i)
+        xt[i] = 1.0 + 0.5 * std::sin(static_cast<double>(i));
+    vec::dense_vector<double> b(n);
+    mtl::mult(A, xt, b);
+
+    itl::pc::diagonal<mat::compressed2D<double>> pc_cg(A), pc_bicg(A);
+
+    vec::dense_vector<double> x_cg(n, 0.0), x_bicg(n, 0.0);
+    itl::basic_iteration<double> it_cg(b, 3000, 1e-12), it_bicg(b, 3000, 1e-12);
+    REQUIRE(itl::cg(A, x_cg, b, pc_cg, it_cg) == 0);
+    REQUIRE(itl::bicg(A, x_bicg, b, pc_bicg, it_bicg) == 0);
+
+    INFO("cg = " << it_cg.iterations() << ", bicg = " << it_bicg.iterations());
+    REQUIRE(it_bicg.iterations() == it_cg.iterations());
+    for (std::size_t i = 0; i < n; ++i)
+        REQUIRE_THAT(x_bicg(i), Catch::Matchers::WithinAbs(x_cg(i), 1e-9));
+}
+
+TEST_CASE("BiCG with a symmetric preconditioner on a NON-symmetric system (#392)",
+          "[itl][bicg][regression]") {
+    // The fix is necessary and sufficient when the PRECONDITIONER is symmetric,
+    // which is a statement about M and not about A. A diagonal preconditioner is
+    // symmetric whatever A is, so this must converge.
+    //
+    // ssor/ilu_0 of a NON-symmetric A are themselves non-symmetric, and those
+    // still fail -- for a different reason, the adjoint_solve stub tracked in
+    // #394. They are deliberately not exercised here.
+    const std::size_t k = 12, n = k * k;
+    mat::compressed2D<double> A(n, n);
+    {
+        mat::inserter<mat::compressed2D<double>> ins(A);
+        for (std::size_t i = 0; i < k; ++i)
+            for (std::size_t j = 0; j < k; ++j) {
+                const std::size_t r = i * k + j;
+                ins[r][r] << 4.0 * (1.0 + static_cast<double>(r % 7) * 0.1);
+                if (i)         ins[r][r - k] << -1.0;
+                if (i + 1 < k) ins[r][r + k] << -0.6;    // asymmetric
+                if (j)         ins[r][r - 1] << -1.0;
+                if (j + 1 < k) ins[r][r + 1] << -1.4;    // asymmetric
+            }
+    }
+    itl::pc::diagonal<mat::compressed2D<double>> pc(A);
+    int iters = 0, info = 0;
+    const double err = solve_err(A, pc, 3000, iters, info);
+    INFO("iters = " << iters << ", rel err = " << err);
+    REQUIRE(info == 0);
+    REQUIRE(err < 1e-8);
 }


### PR DESCRIPTION
## Summary

`bicg` converged **only** with `pc::identity`. With any other preconditioner it stalled and returned a solution wrong by O(1) — including `pc::diagonal` on an SPD matrix, where nothing about the preconditioner is in question.

Preconditioned BiCG needs the **preconditioned** residual against the **unpreconditioned** shadow residual (Barrett et al., *Templates* §2.3.5; Saad, *Iterative Methods* Alg. 7.1):

```
rho = z^T r~
```

It used `dot(z_tilde, z)`, which applies the preconditioner **twice**:

```
z~ . z = (M^-T r~) . (M^-1 r) = r~^T M^-1 M^-1 r
```

where the algorithm needs `r~^T M^-1 r`. With `identity`, `z == r` and `z~ == r~`, so the two coincide — which is exactly why `identity` was the only preconditioner that worked.

#392's diagnosis and one-line fix were correct; I reproduced, applied, and confirmed the reported numbers: `bicg + diagonal` from **3000 iterations / rel 2.25e-01** to **33 / 2.05e-12**, matching `cg + diagonal`'s 33 on the same SPD system.

## Bounding the fix

Swept the preconditioner space (3000 cap, tol 1e-12, 144×144):

| A | identity | diagonal | ssor | ilu_0 | ic_0 |
|---|---|---|---|---|---|
| symmetric | 35 ✓ | 33 ✓ | 17 ✓ | 12 ✓ | 12 ✓ |
| **non-symmetric** | 39 ✓ | 36 ✓ | **fails** | **fails** | — |

The dividing line is the **preconditioner's** symmetry, not the matrix's. `diagonal` works on a non-symmetric A because D is symmetric whatever A is; `ssor`/`ilu_0` of a non-symmetric A are themselves non-symmetric and still fail. That remaining failure is the `adjoint_solve` stub — **#394**, a separate defect, not this one.

## Why it survived, and what that implies for the tests

`test_bicg.cpp` used `pc::identity` in **both** of its cases — the single configuration in which this defect is invisible. The correlation across the solver suite is exact:

| solver | preconditioners in its tests | status |
|---|---|---|
| `bicg` | identity only | was broken |
| `qmr` | identity only | broken (**#393**) |
| `bicgstab` | identity **and diagonal** | correct |

So the new cases deliberately use non-identity preconditioners. That is their point, not an incidental detail.

**Negative control:** reverting the fix gives **2 passed / 3 failed** — and the 2 that pass are the pre-existing identity-only tests. They cannot see this bug.

The sharpest new assertion is that on an SPD system `bicg` must take the **same iteration count as `cg`**, since preconditioned BiCG reduces to preconditioned CG there. Before the fix: 3000 against 33.

## Filed from this work, deliberately not fixed here

- **#393** — `qmr` fails identically. Verified **not** fixed by this change: `qmr + diagonal` still 3000 / 2.48e-01 after `bicg + diagonal` reached 33 / 2.05e-12. It uses a split preconditioner `M = M1·M2` and applies the whole `M` for both halves. I did not isolate it further rather than guess at a patch.
- **#394** — `adjoint_solve` is a stub. I surveyed all seven preconditioners: `identity`/`diagonal` are correct, `ic_0`/`ildl` are correct **by construction** (their factorizations are symmetric), and `ssor`/`ilu_0`/`block_diagonal` are wrong for non-symmetric input.

## Changes

| file | what |
|---|---|
| `include/mtl/itl/krylov/bicg.hpp` | `dot(z_tilde, z)` → `dot(r_tilde, z)` at both sites, with the derivation in a comment |
| `tests/unit/itl/test_bicg.cpp` | four preconditioners on SPD, the cg-iteration-count equivalence, and a symmetric preconditioner on a non-symmetric system |

## Test results

| target | gcc build | gcc test | clang build | clang test |
|---|---|---|---|---|
| `itl_test_bicg` | OK | PASS (173 assertions / 5 cases) | OK | PASS |
| full unit suite | OK | **161/161** | OK | **161/161** |

## Test plan
- [ ] Fast CI passes (gcc + clang)
- [ ] Promote to ready when satisfied

Resolves #392

Generated with [Claude Code](https://claude.com/claude-code)