### PR TITLE
fix(itl): real adjoint for block_diagonal via lu_adjoint_solve; correct ssor's docs

### DIFF
--- a/include/mtl/itl/pc/block_diagonal.hpp
+++ b/include/mtl/itl/pc/block_diagonal.hpp
@@ -48,9 +48,32 @@ public:
         }
     }
 
+    /// Solve M^H x = b, block by block.
+    ///
+    /// This used to delegate to solve(), commented "approximate". It is not an
+    /// approximation: a diagonal block of a non-symmetric A is itself
+    /// non-symmetric, so the wrong operator was applied outright. bicg and qmr
+    /// are the only callers and both failed to converge (#394).
     template <typename VecX, typename VecB>
     void adjoint_solve(VecX& x, const VecB& b) const {
-        solve(x, b);  // approximate
+        // M is block DIAGONAL, so M^H is block diagonal with each block
+        // conjugate-transposed -- the blocks stay independent and no coupling
+        // appears between them.
+        for (size_type blk = 0; blk < nb_; ++blk) {
+            size_type start = blk * bs_;
+            size_type end   = std::min(start + bs_, n_);
+            size_type bsize = end - start;
+
+            vec::dense_vector<value_type> bsub(bsize);
+            vec::dense_vector<value_type> xsub(bsize);
+            for (size_type i = 0; i < bsize; ++i)
+                bsub(i) = b(start + i);
+
+            lu_adjoint_solve(blocks_[blk], pivots_[blk], xsub, bsub);
+
+            for (size_type i = 0; i < bsize; ++i)
+                x(start + i) = xsub(i);
+        }
     }
 
 private:

--- a/include/mtl/itl/pc/ssor.hpp
+++ b/include/mtl/itl/pc/ssor.hpp
@@ -1,6 +1,11 @@
 #pragma once
-// MTL5 -- SSOR (Symmetric Successive Over-Relaxation) preconditioner
-// Forward SOR sweep followed by backward SOR sweep.
+// MTL5 -- SSOR-style preconditioner: a forward SOR sweep followed by a backward
+// SOR sweep, both starting from x = b.
+//
+// NOTE this is the two-sweep smoother, not the classical factored operator
+// M = (D/w + L)(D/w)^-1(D/w + U) applied as triangular solves. It is an
+// effective preconditioner but it is NOT self-adjoint, so adjoint_solve cannot
+// simply delegate to solve -- see the note on adjoint_solve below (#394, #398).
 #include <cassert>
 #include <cstddef>
 #include <mtl/vec/dense_vector.hpp>
@@ -54,9 +59,36 @@ public:
         }
     }
 
+    /// adjoint_solve delegates to solve(), and that is NOT because the operator
+    /// is self-adjoint. Measured against <M^-1 b, c> == <b, M^-H c> on a
+    /// 144x144 Laplacian, the relative violation is 1.1e-01 for a SYMMETRIC A
+    /// and 4.1e-01 for a non-symmetric one (#394). Reversing the sweep order
+    /// does not give the adjoint either (8.2e-02).
+    ///
+    /// The reason is that solve() above is not the classical SSOR operator. It
+    /// runs two SOR SWEEPS starting from x = b, whereas
+    ///
+    ///     M = (D/w + L) (D/w)^-1 (D/w + U)
+    ///
+    /// is applied as two TRIANGULAR SOLVES. The implemented operator is a
+    /// two-sweep smoother, which is a perfectly good preconditioner -- cg
+    /// converges in 17 iterations with it against 33 with pc::diagonal, and
+    /// gmres in 13 -- but it has no simple adjoint because it is not that
+    /// factorization.
+    ///
+    /// Consequences, all measured:
+    ///   - cg, gmres and the other eight solvers do not call adjoint_solve and
+    ///     are unaffected.
+    ///   - bicg and qmr do call it. They converge with ssor on a SYMMETRIC A
+    ///     (17 iterations), and do NOT converge on a non-symmetric one.
+    ///
+    /// So: ssor is usable with bicg/qmr only for symmetric A. Reimplementing it
+    /// in the classical factored form would make it genuinely self-adjoint and
+    /// give it a real adjoint, at the cost of changing the iteration counts of
+    /// every solver that uses it; that is tracked separately (#398).
     template <typename VecX, typename VecB>
     void adjoint_solve(VecX& x, const VecB& b) const {
-        solve(x, b);  // SSOR is symmetric
+        solve(x, b);   // NOT self-adjoint -- see the note above (#394)
     }
 
 private:
@@ -124,9 +156,36 @@ public:
         }
     }
 
+    /// adjoint_solve delegates to solve(), and that is NOT because the operator
+    /// is self-adjoint. Measured against <M^-1 b, c> == <b, M^-H c> on a
+    /// 144x144 Laplacian, the relative violation is 1.1e-01 for a SYMMETRIC A
+    /// and 4.1e-01 for a non-symmetric one (#394). Reversing the sweep order
+    /// does not give the adjoint either (8.2e-02).
+    ///
+    /// The reason is that solve() above is not the classical SSOR operator. It
+    /// runs two SOR SWEEPS starting from x = b, whereas
+    ///
+    ///     M = (D/w + L) (D/w)^-1 (D/w + U)
+    ///
+    /// is applied as two TRIANGULAR SOLVES. The implemented operator is a
+    /// two-sweep smoother, which is a perfectly good preconditioner -- cg
+    /// converges in 17 iterations with it against 33 with pc::diagonal, and
+    /// gmres in 13 -- but it has no simple adjoint because it is not that
+    /// factorization.
+    ///
+    /// Consequences, all measured:
+    ///   - cg, gmres and the other eight solvers do not call adjoint_solve and
+    ///     are unaffected.
+    ///   - bicg and qmr do call it. They converge with ssor on a SYMMETRIC A
+    ///     (17 iterations), and do NOT converge on a non-symmetric one.
+    ///
+    /// So: ssor is usable with bicg/qmr only for symmetric A. Reimplementing it
+    /// in the classical factored form would make it genuinely self-adjoint and
+    /// give it a real adjoint, at the cost of changing the iteration counts of
+    /// every solver that uses it; that is tracked separately (#398).
     template <typename VecX, typename VecB>
     void adjoint_solve(VecX& x, const VecB& b) const {
-        solve(x, b);  // SSOR is symmetric
+        solve(x, b);   // NOT self-adjoint -- see the note above (#394)
     }
 
 private:

--- a/include/mtl/operation/lu.hpp
+++ b/include/mtl/operation/lu.hpp
@@ -13,6 +13,7 @@
 #include <mtl/concepts/vector.hpp>
 #include <mtl/vec/dense_vector.hpp>
 #include <mtl/math/identity.hpp>
+#include <mtl/functor/scalar/conj.hpp>
 #include <mtl/operation/lower_trisolve.hpp>
 #include <mtl/operation/upper_trisolve.hpp>
 #include <mtl/interface/dispatch_traits.hpp>
@@ -131,6 +132,63 @@ void lu_solve(const M& LU, const std::vector<typename M::size_type>& pivot,
 
     // Back substitution: U*x = y
     upper_trisolve(LU, x, /*unit_diag=*/false);
+}
+
+/// Solve A^H * x = b using the precomputed LU factorization of A.
+///
+/// lu_factor produces P*A = L*U, so A = P^-1*L*U and
+///
+///     A^H = U^H * L^H * P^-H = U^H * L^H * P
+///
+/// because P is a real permutation, hence P^-H = P. The solve is therefore the
+/// mirror image of lu_solve: the triangular factors are applied conjugated, in
+/// the opposite order, and the permutation moves to the END and is inverted.
+///
+/// The permutation in lu_solve is a forward sequence of row interchanges, so
+/// its inverse is the same interchanges applied in reverse order.
+///
+/// Needed by bicg and qmr, the only solvers that ask a preconditioner for
+/// M^-H (#394).
+template <Matrix M, Vector VecX, Vector VecB>
+void lu_adjoint_solve(const M& LU, const std::vector<typename M::size_type>& pivot,
+                      VecX& x, const VecB& b) {
+    using size_type  = typename M::size_type;
+    using value_type = typename M::value_type;
+    using conj_t     = functor::scalar::conj<value_type>;
+    const size_type n = LU.num_rows();
+    assert(LU.num_cols() == n && x.size() == n && b.size() == n);
+
+    for (size_type i = 0; i < n; ++i)
+        x(i) = b(i);
+
+    // U^H z = b. U^H is LOWER triangular with diagonal conj(U(i,i)), and
+    // (U^H)(i,j) = conj(U(j,i)) = conj(LU(j,i)) for j < i.
+    for (size_type i = 0; i < n; ++i) {
+        auto sum = math::zero<value_type>();
+        for (size_type j = 0; j < i; ++j)
+            sum += conj_t::apply(LU(j, i)) * x(j);
+        x(i) = (x(i) - sum) / conj_t::apply(LU(i, i));
+    }
+
+    // L^H w = z. L^H is UPPER triangular with UNIT diagonal, and
+    // (L^H)(i,j) = conj(L(j,i)) = conj(LU(j,i)) for j > i.
+    for (size_type ii = 0; ii < n; ++ii) {
+        const size_type i = n - 1 - ii;
+        auto sum = math::zero<value_type>();
+        for (size_type j = i + 1; j < n; ++j)
+            sum += conj_t::apply(LU(j, i)) * x(j);
+        x(i) = x(i) - sum;
+    }
+
+    // x = P^-1 w: the interchanges of lu_solve, in reverse.
+    for (size_type ii = 0; ii < n; ++ii) {
+        const size_type i = n - 1 - ii;
+        if (pivot[i] != i) {
+            auto tmp = x(i);
+            x(i) = x(pivot[i]);
+            x(pivot[i]) = tmp;
+        }
+    }
 }
 
 /// Convenience: factor and solve A*x = b in one call.

--- a/tests/unit/itl/test_preconditioner_adjoint.cpp
+++ b/tests/unit/itl/test_preconditioner_adjoint.cpp
@@ -24,6 +24,7 @@
 #include <mtl/itl/pc/diagonal.hpp>
 #include <mtl/itl/pc/ilu_0.hpp>
 #include <mtl/itl/pc/ic_0.hpp>
+#include <mtl/itl/pc/block_diagonal.hpp>
 
 using namespace mtl;
 
@@ -90,6 +91,15 @@ TEST_CASE("preconditioner adjoint_solve really is the adjoint (#394)",
             itl::pc::diagonal<SMat> M(A);
             const double v = adjoint_violation(M, n);
             INFO("diagonal, " << what << ", violation = " << v);
+            CHECK(v < 1e-12);
+        }
+        {
+            // Also #394. A diagonal BLOCK of a non-symmetric A is itself
+            // non-symmetric, so delegating to solve() applied the wrong
+            // operator; now each block uses lu_adjoint_solve.
+            itl::pc::block_diagonal<SMat> M(A, 4);
+            const double v = adjoint_violation(M, n);
+            INFO("block_diagonal, " << what << ", violation = " << v);
             CHECK(v < 1e-12);
         }
         {

--- a/tests/unit/operation/test_lu.cpp
+++ b/tests/unit/operation/test_lu.cpp
@@ -176,3 +176,79 @@ TEST_CASE("LU inverse of Pascal matrix", "[operation][lu][generator]") {
             REQUIRE_THAT(I_approx(i, j), Catch::Matchers::WithinAbs(expected, 1e-10));
         }
 }
+
+// ---------------------------------------------------------------------------
+// #394: lu_adjoint_solve -- solve A^H x = b from the LU of A.
+//
+// lu_factor gives P*A = L*U, so A = P^-1*L*U and A^H = U^H*L^H*P (P is a real
+// permutation, so P^-H = P). The solve is therefore the mirror of lu_solve: the
+// triangular factors conjugated and in the opposite order, and the permutation
+// moved to the END and inverted -- the same interchanges in reverse.
+//
+// Needed by bicg and qmr, the only solvers that ask for M^-H, via the
+// block_diagonal preconditioner.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("lu_adjoint_solve solves A^H x = b (#394)", "[operation][lu][regression]") {
+    // Sizes chosen to span the pivoting behaviour: n = 1 and 2 exercise the
+    // degenerate paths, the larger ones actually permute rows.
+    for (std::size_t n : {std::size_t{1}, std::size_t{2}, std::size_t{5},
+                          std::size_t{17}, std::size_t{40}}) {
+        INFO("n = " << n);
+        mat::dense2D<double> A(n, n);
+        for (std::size_t i = 0; i < n; ++i)
+            for (std::size_t j = 0; j < n; ++j)
+                A(i, j) = std::sin(static_cast<double>(3 * i + 7 * j + 1))
+                        + (i == j ? 4.0 * static_cast<double>(n) : 0.0);
+
+        mat::dense2D<double> LU(A);
+        std::vector<std::size_t> pivot;
+        REQUIRE(lu_factor(LU, pivot) == 0);
+
+        vec::dense_vector<double> b(n), x(n);
+        for (std::size_t i = 0; i < n; ++i)
+            b[i] = 1.0 + 0.5 * std::cos(static_cast<double>(i));
+
+        lu_adjoint_solve(LU, pivot, x, b);
+
+        // Residual of A^H x - b, computed directly from the ORIGINAL A. For a
+        // real A, A^H is A^T, so column i of A dotted with x.
+        double bnorm = 0.0, resid = 0.0;
+        for (std::size_t i = 0; i < n; ++i) bnorm = std::max(bnorm, std::abs(b(i)));
+        for (std::size_t i = 0; i < n; ++i) {
+            double s = 0.0;
+            for (std::size_t j = 0; j < n; ++j) s += A(j, i) * x(j);
+            resid = std::max(resid, std::abs(s - b(i)));
+        }
+        REQUIRE(resid / bnorm < 1e-10);
+    }
+}
+
+TEST_CASE("lu_adjoint_solve is the adjoint of lu_solve (#394)",
+          "[operation][lu][regression]") {
+    // The defining property, which is sharper than a residual check and is what
+    // the preconditioners are ultimately relied on for:
+    //     <A^-1 b, c> == <b, A^-H c>
+    const std::size_t n = 24;
+    mat::dense2D<double> A(n, n);
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j)
+            A(i, j) = std::sin(static_cast<double>(5 * i + 2 * j))
+                    + (i == j ? 8.0 : 0.0);
+
+    mat::dense2D<double> LU(A);
+    std::vector<std::size_t> pivot;
+    REQUIRE(lu_factor(LU, pivot) == 0);
+
+    vec::dense_vector<double> b(n), c(n), Ab(n), AHc(n);
+    for (std::size_t i = 0; i < n; ++i) {
+        b[i] = std::cos(static_cast<double>(i) * 1.7);
+        c[i] = std::sin(static_cast<double>(i) * 0.9);
+    }
+    lu_solve(LU, pivot, Ab, b);
+    lu_adjoint_solve(LU, pivot, AHc, c);
+
+    double lhs = 0.0, rhs = 0.0;
+    for (std::size_t i = 0; i < n; ++i) { lhs += Ab(i) * c(i); rhs += b(i) * AHc(i); }
+    REQUIRE(std::abs(lhs - rhs) / std::max(1.0, std::abs(lhs)) < 1e-12);
+}


### PR DESCRIPTION
## Summary

Completes #394. `block_diagonal` is **fixed**; `ssor` is deliberately **not changed** — only its documentation — for reasons measured below.

## block_diagonal

`adjoint_solve` delegated to `solve()`, commented *"approximate"*. A diagonal **block** of a non-symmetric A is itself non-symmetric, so it applied the wrong operator and `bicg`/`qmr` did not converge at all.

Adds **`mtl::lu_adjoint_solve`** to `operation/lu.hpp` — solve `Aᴴx = b` from the LU of A. `lu_factor` gives `P·A = L·U`, so `Aᴴ = Uᴴ·Lᴴ·P` (P is a real permutation, hence `P⁻ᴴ = P`). The solve is the mirror of `lu_solve`: factors conjugated and in the opposite order, and the permutation moved to the **end** and inverted — the same interchanges in reverse.

Verified three ways, not by convergence alone:

| check | result |
|---|---|
| `‖Aᴴx − b‖/‖b‖` over n = 1, 2, 5, 17, 40, against the **original** dense A | ≤ 5.0e-16 (covers the pivoted cases) |
| `⟨A⁻¹b, c⟩ = ⟨b, A⁻ᴴc⟩` for `lu_adjoint_solve` | < 1e-12 |
| `⟨M⁻¹b, c⟩ = ⟨b, M⁻ᴴc⟩` for the preconditioner, non-symmetric A | **1.6e-01 → 6.7e-16** |
| `bicg`/`qmr` + `block_diagonal`, non-symmetric 144×144 | **no convergence → 29 iterations**, rel 2e-12 (symmetric unchanged at 28) |

## ssor: documentation only, deliberately

Its comments claimed *"SSOR is symmetric"*. Measured, it is **not self-adjoint even for a symmetric A** — violation **1.119e-01** — and reversing the sweep order does not give the adjoint either (8.177e-02).

The cause is that `solve()` is not the classical SSOR operator. It runs two SOR **sweeps from x = b**, where `M = (D/ω+L)(D/ω)⁻¹(D/ω+U)` is applied as two **triangular solves**. The implemented operator has no simple adjoint because it is not that factorization.

**But nothing visibly breaks**, and that is why the behaviour is left alone:

| | with ssor |
|---|---|
| `cg` | **17 iterations** — vs 33 with `pc::diagonal`; ssor is the better preconditioner |
| `gmres` | 13 iterations |
| `bicg`/`qmr`, symmetric A | 17 iterations, converges |
| `bicg`/`qmr`, **non-symmetric A** | **fails** — the only actual failure |

Eight of the ten solvers never call `adjoint_solve`. Reimplementing `ssor` in the factored form would make it genuinely self-adjoint and give it a real adjoint, but it would change the iteration counts of **every solver that uses it**, including the multigrid smoothers. That is a performance-affecting rewrite of a working component, filed as **#398** with the before/after it needs.

So what is fixed here is the **false claim**: the header and both `adjoint_solve` overloads now state what the operator actually is, what it costs, and where it may and may not be used. A reader relying on that comment was being misled; a reader of the new one is not.

## Final state of #394

| preconditioner | symmetric A | non-symmetric A | |
|---|---|---|---|
| `identity`, `diagonal` | ok | ok | |
| `ic_0`, `ildl` | ok | (n/a) | self-adjoint **by construction** |
| `ilu_0` | ok | ok | #397 |
| **`block_diagonal`** | ok | **ok** | **here** |
| `ssor` | not self-adjoint — documented, #398 | | |

With #392, #393, #397 and this, `bicg` and `qmr` work with **identity, diagonal, ic_0, ildl, ilu_0 and block_diagonal** on symmetric *and* non-symmetric systems. Before this sequence they worked with `identity` and nothing else.

## Test results

| target | gcc build | gcc test | clang build | clang test |
|---|---|---|---|---|
| `op_test_lu` | OK | PASS (60 assertions / 9 cases) | OK | PASS |
| `itl_test_preconditioner_adjoint` | OK | PASS (9 assertions / 2 cases) | OK | PASS |
| full unit suite | OK | **162/162** | OK | **162/162** |

## Test plan
- [ ] Fast CI passes (gcc + clang)
- [ ] Promote to ready when satisfied

Resolves #394

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for solving systems involving conjugate-transposed matrices using existing LU factorizations.
  * Improved block-diagonal preconditioner support for adjoint solves.

* **Bug Fixes**
  * Corrected adjoint solving for block-diagonal systems, including non-symmetric matrices.

* **Documentation**
  * Clarified SSOR behavior, including its two-sweep implementation and non-self-adjoint limitations.

* **Tests**
  * Added regression coverage for LU adjoint solves and block-diagonal preconditioner adjoint identities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->