### PR TITLE
test(operation): exact double-double reference for fast GEMM, and a tighter tolerance

### DIFF
--- a/tests/unit/operation/test_fast_gemm_numeric.cpp
+++ b/tests/unit/operation/test_fast_gemm_numeric.cpp
@@ -4,11 +4,22 @@
 // floating-point rounding across orientations, alpha/beta, rectangular and
 // multi-block sizes.
 //
-// Reference: the same T-rounded inputs accumulated in long double (the trusted
-// high-precision generic triple product). native-fast accumulates in T, so it
-// may differ by up to ~k * eps(T); we allow a generous multiple of that and
-// take the worst element per configuration (one assertion each). A real bug is
-// O(1) off and trips this immediately.
+// Reference: the same T-rounded inputs accumulated in DOUBLE-DOUBLE via FMA --
+// an exact two-product plus a Knuth two-sum, giving ~106 bits. native-fast
+// accumulates in T, so it may differ by up to ~k * eps(T); we allow a multiple
+// of that and take the worst element per configuration (one assertion each). A
+// real bug is O(1) off and trips this immediately.
+//
+// The reference used to be `long double`, which is 80-bit on x86-64, 64-bit --
+// i.e. plain double -- on Apple ARM64 and MSVC, and 128-bit on ARM64 Linux.
+// That is a ~60-bit spread across targets this repo already builds on, for a
+// value described as "the trusted high-precision" reference. Double-double
+// needs only IEEE double and is therefore identical everywhere (#386).
+//
+// Measured before the change: the observed error sits at ~0.002 of the
+// tolerance, so no assertion was ever at risk from the reference width -- the
+// portability problem was real but the exposure was not. What the exact
+// reference DOES buy is room to tighten: see tol_for below.
 //
 // MTL5_NATIVE_FAST_GEMM is defined before mult.hpp so mtl::mult routes through
 // gemm_blocked / gemv for this translation unit.
@@ -38,11 +49,56 @@ using rowmaj = mtl::mat::parameters<mtl::tag::row_major>;
 using colmaj = mtl::mat::parameters<mtl::tag::col_major>;
 
 // Relative tolerance for a length-k contraction accumulated in T.
+//
+// This is an EMPIRICAL tolerance calibrated to the data this file generates,
+// not a worst-case bound. Saying so matters, because the obvious citation does
+// not actually support a bound here:
+//
+//   Higham (Accuracy and Stability of Numerical Algorithms, 3.1) gives
+//       |fl(x.y) - x.y|  <=  gamma_k * sum_i |x_i||y_i|,
+//       gamma_k = k*u/(1 - k*u) ~ k*u,   u = unit roundoff = eps/2
+//
+//   Note two things. The bound is against sum|x_i||y_i|, NOT against |x.y|,
+//   and this test compares relative to (|ref| + 1). The ratio between them is
+//   the dot product's condition number, ~sqrt(k) for the random +-1 data used
+//   here, so the worst-case RELATIVE error is ~k^1.5 * u. No modest multiple of
+//   k*eps dominates that as k grows.
+//
+// What justifies the number is measurement, not the bound: random data
+// accumulates far below the worst case because the rounding errors partially
+// cancel, giving ~sqrt(k)*u in practice. Every configuration in this file
+// passes at a factor of 0.125, so 4 leaves roughly 32x over the worst measured
+// case.
+//
+// 4 * k * eps is therefore 16x TIGHTER THAN THE PREVIOUS 64 -- that is the only
+// comparison being claimed -- while keeping deliberate headroom for targets
+// that cannot be measured here (ARM64, MSVC, and the FP-contract lane, where
+// contraction changes the rounding). It is not, and should not be read as, a
+// proven bound.
 template <typename T>
-long double tol_for(std::size_t k) {
-    return 64.0L * static_cast<long double>(k) *
-           static_cast<long double>(std::numeric_limits<T>::epsilon());
+double tol_for(std::size_t k) {
+    return 4.0 * static_cast<double>(k) *
+           static_cast<double>(std::numeric_limits<T>::epsilon());
 }
+
+// Exact-ish accumulation in double-double: Knuth two-sum plus an FMA-based
+// exact two-product. Needs only IEEE double, so it is bit-identical on every
+// target -- unlike long double.
+struct dd_acc {
+    double hi{}, lo{};
+    void add(double x) {                       // two-sum
+        const double s  = hi + x;
+        const double bb = s - hi;
+        lo += (hi - (s - bb)) + (x - bb);
+        hi = s;
+    }
+    void add_product(double a, double b) {     // exact a*b, both halves
+        const double p = a * b;
+        add(p);
+        add(std::fma(a, b, -p));
+    }
+    double value() const { return hi + lo; }
+};
 
 // C = A*B via mtl::mult (native-fast) vs a long-double reference over the same
 // T-rounded inputs. MatA/MatB/MatC fix the orientations. Returns true if every
@@ -60,14 +116,15 @@ bool gemm_ok(std::size_t m, std::size_t n, std::size_t k, std::uint64_t seed) {
 
     mtl::mult(A, B, C);
 
-    const long double tol = tol_for<T>(k);
+    const double tol = tol_for<T>(k);
     for (std::size_t i = 0; i < m; ++i)
         for (std::size_t j = 0; j < n; ++j) {
-            long double ref = 0.0L;
+            dd_acc acc;
             for (std::size_t p = 0; p < k; ++p)
-                ref += static_cast<long double>(A(i, p)) * static_cast<long double>(B(p, j));
-            const long double err = std::fabs(static_cast<long double>(C(i, j)) - ref);
-            if (err > tol * (std::fabs(ref) + 1.0L)) return false;
+                acc.add_product(static_cast<double>(A(i, p)), static_cast<double>(B(p, j)));
+            const double ref = acc.value();
+            const double err = std::fabs(static_cast<double>(C(i, j)) - ref);
+            if (err > tol * (std::fabs(ref) + 1.0)) return false;
         }
     return true;
 }
@@ -86,12 +143,13 @@ bool gemv_ok(std::size_t m, std::size_t n, std::uint64_t seed) {
 
     mtl::mult(A, x, y);
 
-    const long double tol = tol_for<T>(n);
+    const double tol = tol_for<T>(n);
     for (std::size_t i = 0; i < m; ++i) {
-        long double ref = 0.0L;
+        dd_acc acc;
         for (std::size_t j = 0; j < n; ++j)
-            ref += static_cast<long double>(A(i, j)) * static_cast<long double>(x(j));
-        if (std::fabs(static_cast<long double>(y(i)) - ref) > tol * (std::fabs(ref) + 1.0L))
+            acc.add_product(static_cast<double>(A(i, j)), static_cast<double>(x(j)));
+        const double ref = acc.value();
+        if (std::fabs(static_cast<double>(y(i)) - ref) > tol * (std::fabs(ref) + 1.0))
             return false;
     }
     return true;
@@ -151,16 +209,17 @@ TEMPLATE_TEST_CASE("fast GEMM: alpha/beta numeric (gemm_blocked)", "[operation][
     mtl::detail::gemm_blocked<TestType>(m, n, k, alpha, A.data(), (std::ptrdiff_t)k, 1,
                                         B.data(), (std::ptrdiff_t)n, 1, beta, C.data(), n);
 
-    const long double tol = tol_for<TestType>(k);
+    const double tol = tol_for<TestType>(k);
     bool ok = true;
     for (std::size_t i = 0; i < m && ok; ++i)
         for (std::size_t j = 0; j < n && ok; ++j) {
-            long double prod = 0.0L;
+            dd_acc acc;
             for (std::size_t p = 0; p < k; ++p)
-                prod += static_cast<long double>(A[i * k + p]) * static_cast<long double>(B[p * n + j]);
-            const long double ref = static_cast<long double>(beta) * static_cast<long double>(C0[i * n + j])
-                                  + static_cast<long double>(alpha) * prod;
-            if (std::fabs(static_cast<long double>(C[i * n + j]) - ref) > tol * (std::fabs(ref) + 1.0L))
+                acc.add_product(static_cast<double>(A[i * k + p]), static_cast<double>(B[p * n + j]));
+            // beta*C0 + alpha*(A*B), the scalings applied to the exact product.
+            const double ref = static_cast<double>(beta) * static_cast<double>(C0[i * n + j])
+                             + static_cast<double>(alpha) * acc.value();
+            if (std::fabs(static_cast<double>(C[i * n + j]) - ref) > tol * (std::fabs(ref) + 1.0))
                 ok = false;
         }
     CHECK(ok);

--- a/tests/unit/operation/test_fast_gemm_numeric.cpp
+++ b/tests/unit/operation/test_fast_gemm_numeric.cpp
@@ -60,11 +60,13 @@ using colmaj = mtl::mat::parameters<mtl::tag::col_major>;
 //
 //   Note two things. The bound is against sum|x_i||y_i|, NOT against |x.y|,
 //   and this test compares relative to (|ref| + 1). The ratio between them is
-//   the dot product's condition number, ~sqrt(k) for the random +-1 data used
-//   here, so the worst-case RELATIVE error is ~k^1.5 * u. No modest multiple of
-//   k*eps dominates that as k grows.
+//   the dot product's condition number. For the zero-mean uniform [-1, 1]
+//   entries this file generates that is ~sqrt(k) -- E|x*y| = 1/4 gives
+//   sum|x_i y_i| ~ k/4, while the sum itself is ~sqrt(k)/3 -- so the worst-case
+//   RELATIVE error is ~k^1.5 * u. No modest multiple of k*eps dominates that as
+//   k grows.
 //
-// What justifies the number is measurement, not the bound: random data
+// What justifies the number is measurement, not the bound: uniform [-1, 1] data
 // accumulates far below the worst case because the rounding errors partially
 // cancel, giving ~sqrt(k)*u in practice. Every configuration in this file
 // passes at a factor of 0.125, so 4 leaves roughly 32x over the worst measured

--- a/tests/unit/operation/test_gemm_blocked.cpp
+++ b/tests/unit/operation/test_gemm_blocked.cpp
@@ -146,3 +146,50 @@ TEMPLATE_TEST_CASE("mult() native-fast dispatch matches naive (row- and col-majo
     CHECK(mult_matches<mtl::mat::dense2D<TestType, rowmaj>>(A, B, m, n, k));  // row-major C
     CHECK(mult_matches<mtl::mat::dense2D<TestType, colmaj>>(A, B, m, n, k));  // col-major C
 }
+
+// ---------------------------------------------------------------------------
+// Zero-dimension GEMM (#386 review).
+//
+// kEdge starts at 1, so no test anywhere covered m, n or k == 0 for GEMM.
+// test_gemv.cpp does cover them for GEMV -- its kDims starts at 0 -- so this
+// closes the matching gap on the matrix side.
+//
+// The behaviour is already correct; these pin it. k == 0 is the interesting
+// one: the product is empty, so C must be the zero matrix for mult (which
+// assigns rather than accumulates), and gemm_blocked must still apply beta to
+// the incoming C rather than skipping the scaling along with the contraction.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("gemm: zero dimensions", "[operation][gemm][edge]") {
+    using Mat = mtl::mat::dense2D<double>;
+
+    SECTION("k == 0 gives the zero matrix, not untouched C") {
+        Mat A(3, 0), B(0, 4), C(3, 4);
+        for (std::size_t i = 0; i < 3; ++i)
+            for (std::size_t j = 0; j < 4; ++j) C(i, j) = 7.0;
+        mtl::mult(A, B, C);
+        for (std::size_t i = 0; i < 3; ++i)
+            for (std::size_t j = 0; j < 4; ++j) {
+                INFO("i=" << i << " j=" << j);
+                CHECK(C(i, j) == 0.0);
+            }
+    }
+
+    SECTION("m == 0 and n == 0 are no-ops that do not crash") {
+        { Mat A(0, 5), B(5, 4), C(0, 4); CHECK_NOTHROW(mtl::mult(A, B, C)); }
+        { Mat A(3, 5), B(5, 0), C(3, 0); CHECK_NOTHROW(mtl::mult(A, B, C)); }
+        { Mat A(0, 0), B(0, 0), C(0, 0); CHECK_NOTHROW(mtl::mult(A, B, C)); }
+    }
+
+    SECTION("gemm_blocked applies beta even when k == 0") {
+        // The contraction contributes nothing, but C <- beta*C must still run.
+        std::vector<double> A, B, C(6, 5.0);
+        mtl::detail::gemm_blocked<double, double>(
+            2, 3, 0, /*alpha=*/1.5, A.data(), 0, 1, B.data(), 0, 1,
+            /*beta=*/-0.75, C.data(), 3);
+        for (std::size_t t = 0; t < 6; ++t) {
+            INFO("t=" << t);
+            CHECK(C[t] == -3.75);   // -0.75 * 5.0, exact in binary
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Removes the last `long double` from the test suite, and tightens a tolerance that was **500× looser** than the numbers it was judging.

## The portability fix

The reference was accumulated in `long double`, described in the header as *"the trusted high-precision generic triple product"*. But `long double` is 80-bit on x86-64, **64-bit — plain `double` — on Apple ARM64 and MSVC**, and 128-bit on ARM64 Linux: a ~60-bit spread across targets this repo already builds on.

Now **double-double via FMA** — an exact two-product plus a Knuth two-sum, ~106 bits — which needs only IEEE double and is therefore identical everywhere.

## Correcting #386, which I filed

That issue claims the `64×` factor was *"absorbing reference error"* for `T=double` on the 64-bit-`long double` targets.

**Measured, that is wrong.** The observed error is **~0.002 of the tolerance** — a margin of roughly 500×. The reference width never came close to mattering.

Also: **`float` had no exposure at all.** `double` is 29 bits more precise than `float`, so a double-width reference is already effectively exact for it — all three candidate references agree to the digit. Only `T=double` was ever in question.

So this is portability hygiene, not a bug that was about to bite.

## The tolerance

`64 · k · eps` was arbitrary. It is now **`4 · k · eps` — 16× tighter** — and that comparison **against the previous value** is the only one being claimed.

### A correction to an earlier draft of this PR

I first justified the number as *"4× the theoretical bound"*, citing Higham. **That was wrong twice over**, and is recorded so it is not reintroduced:

- **The direction.** If `k·eps` were the worst case, then `4·k·eps` sits **above** it. Exceeding a bound is the *minimum* a correct tolerance must do — not a tightening *of the bound*. The bound is a floor, not a target.
- **The citation does not give that bound anyway.** Higham §3.1 bounds the error against `sum_i |x_i||y_i|`, **not** against `|x.y|`, and this test compares relative to `(|ref| + 1)`. The ratio between them is the dot product's condition number, ~`sqrt(k)` for random ±1 data — so the worst-case **relative** error is ~`k^1.5 * u`, which no modest multiple of `k·eps` dominates as `k` grows. (And `gamma_k ~ k*u` with `u = eps/2`, so the earlier text was a further 2× off.)

### What actually justifies 4

**Measurement.** Random data accumulates far below the worst case because rounding errors partially cancel — ~`sqrt(k)*u` in practice. Every configuration in this file passes even at a factor of **0.125**, so `4` leaves roughly **32× over the worst measured case** while keeping headroom for targets that cannot be measured here: ARM64, MSVC, and the FP-contract lane, where contraction changes the rounding.

The comment in the file now says this plainly — that it is an **empirical tolerance calibrated to this data distribution**, not a proven bound, and should not be read as one. Dressing an empirical number in a citation that does not support it is worse than stating it is empirical.

## Verification

Three configurations, **162/162** each (1226 assertions in this file):

| configuration | result |
|---|---|
| gcc Debug | 162/162 |
| clang Debug | 162/162 |
| **Release + `-march=x86-64-v3`** — the FP-contract lane from #389 | 1226 assertions pass |

That third one is the important check: it is where a tightened tolerance and an FMA-contracted kernel meet, and it is the configuration this file had never been built in before #389.

## Test plan
- [ ] Fast CI passes (gcc + clang, incl. the FP-contract lane)
- [ ] Promote to ready when satisfied

Resolves #386

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved matrix operation validation to be more consistent across platforms.
  * Tightened numeric checks for matrix multiplication, vector multiplication, and scaling behavior to catch small accuracy regressions earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->