### PR TITLE
fix(mg): include mat/operators.hpp so multigrid.hpp is self-contained

### DIFF
--- a/include/mtl/itl/mg/multigrid.hpp
+++ b/include/mtl/itl/mg/multigrid.hpp
@@ -8,6 +8,14 @@
 #include <functional>
 #include <mtl/vec/dense_vector.hpp>
 #include <mtl/mat/compressed2D.hpp>
+// vcycle/wcycle form the residual with `levels_[l] * x`, whose operator* lives
+// in mat/operators.hpp. Without this the header compiled only when the caller
+// happened to have included that first, which made it order-dependent (#401).
+//
+// The failure needs INSTANTIATION to surface: A*x is a dependent expression
+// inside a class template, so merely including this header succeeded and hid
+// the problem.
+#include <mtl/mat/operators.hpp>
 #include <mtl/operation/norms.hpp>
 #include <mtl/itl/mg/restriction.hpp>
 #include <mtl/itl/mg/prolongation.hpp>

--- a/tests/unit/itl/test_multigrid_self_contained.cpp
+++ b/tests/unit/itl/test_multigrid_self_contained.cpp
@@ -1,0 +1,80 @@
+// Self-containment of mtl/itl/mg/multigrid.hpp (#401).
+//
+// vcycle and wcycle form the residual with `levels_[l] * x`, whose operator*
+// lives in mtl/mat/operators.hpp. That header was not included, so multigrid.hpp
+// compiled only when the CALLER had already pulled it in -- order-dependent, and
+// a translation unit that included multigrid.hpp alone failed.
+//
+// Two things make this easy to miss, and both are the reason this file exists
+// separately rather than as another case in test_multigrid.cpp:
+//
+//   1. Merely INCLUDING the header succeeds. `A*x` is a dependent expression
+//      inside a class template, so the lookup is deferred to instantiation. A
+//      naive "does it compile on its own" check passes. The cycles have to
+//      actually be called.
+//
+//   2. test_multigrid.cpp includes mtl/operation/operators.hpp (which pulls in
+//      mat/operators.hpp) at line 7, BEFORE multigrid.hpp at line 16. It
+//      satisfies the missing dependency itself, so it could never have caught
+//      this no matter how much multigrid behaviour it exercised.
+//
+// THE INCLUDE LIST BELOW IS LOAD-BEARING. Adding mtl/operation/operators.hpp,
+// mtl/mat/operators.hpp, or anything that pulls them in silently disables this
+// test -- it will still pass, but it will have stopped checking anything.
+// mat/inserter.hpp is verified not to pull them.
+#include <catch2/catch_test_macros.hpp>
+
+#include <mtl/itl/mg/multigrid.hpp>
+#include <mtl/mat/inserter.hpp>
+
+namespace {
+
+using SMat = mtl::mat::compressed2D<double>;
+using Vec  = mtl::vec::dense_vector<double>;
+
+SMat tridiag(std::size_t n) {
+    SMat A(n, n);
+    mtl::mat::inserter<SMat> ins(A);
+    for (std::size_t i = 0; i < n; ++i) {
+        ins[i][i] << 2.0;
+        if (i)         ins[i][i - 1] << -1.0;
+        if (i + 1 < n) ins[i][i + 1] << -1.0;
+    }
+    return A;
+}
+
+}  // namespace
+
+TEST_CASE("mg/multigrid.hpp is self-contained (#401)", "[itl][mg][regression]") {
+    // The assertions are almost beside the point: this test's value is that the
+    // translation unit COMPILES while instantiating both cycles.
+    const std::size_t nf = 7, nc = 3;
+    SMat Af = tridiag(nf), Ac = tridiag(nc);
+
+    SMat R(nc, nf), P(nf, nc);
+    { mtl::mat::inserter<SMat> ins(R); for (std::size_t i = 0; i < nc; ++i) ins[i][2 * i + 1] << 1.0; }
+    { mtl::mat::inserter<SMat> ins(P); for (std::size_t i = 0; i < nc; ++i) ins[2 * i + 1][i] << 1.0; }
+
+    auto smoother_factory = [](const SMat&) {
+        return [](Vec& x, const Vec& b) { for (std::size_t i = 0; i < x.size(); ++i) x(i) = 0.5 * b(i); };
+    };
+    auto coarse_solver = [](Vec& x, const Vec& b) {
+        for (std::size_t i = 0; i < x.size(); ++i) x(i) = 0.5 * b(i);
+    };
+
+    mtl::itl::mg::multigrid<double> mg({Af, Ac}, {R}, {P}, smoother_factory, coarse_solver, 1, 1);
+
+    Vec b(nf, 1.0);
+
+    SECTION("vcycle instantiates and runs") {
+        Vec x(nf, 0.0);
+        REQUIRE_NOTHROW(mg.vcycle(x, b));
+        REQUIRE(x.size() == nf);
+    }
+
+    SECTION("wcycle instantiates and runs") {
+        Vec x(nf, 0.0);
+        REQUIRE_NOTHROW(mg.wcycle(x, b));
+        REQUIRE(x.size() == nf);
+    }
+}


### PR DESCRIPTION
## Summary

`vcycle`/`wcycle` form the residual with `levels_[l] * x`, whose `operator*` lives in `mtl/mat/operators.hpp`. That header was not included, so `multigrid.hpp` compiled **only when the caller had already pulled it in** — order-dependent, and a translation unit including `multigrid.hpp` alone failed:

```
multigrid.hpp:84: error: no match for 'operator*' (operand types are
  'mtl::mat::compressed2D<double>' and 'mtl::vec::dense_vector<double>')
```

Same at `:122` for `wcycle`. One-line include, exactly as #401 diagnosed.

## Two reasons this was easy to miss

**1. Including the header succeeds.** `A*x` is a dependent expression inside a class template, so lookup is deferred to instantiation and a naive *"does this header compile on its own"* check **passes**. The cycles have to actually be *called*. My first reproduction attempt did exactly the naive check and saw nothing.

**2. `test_multigrid.cpp` could never have caught it.** It includes `mtl/operation/operators.hpp` — which pulls in `mat/operators.hpp` — at **line 7**, before `multigrid.hpp` at **line 16**. It satisfies the missing dependency itself, so no amount of multigrid behaviour exercised there would surface this.

## The test

A **separate translation unit**, because the property under test is a property *of* the translation unit. It includes `mg/multigrid.hpp` and `mat/inserter.hpp` (verified not to pull operators) and nothing else, then instantiates both cycles.

The include list is load-bearing and the file says so:

> **THE INCLUDE LIST BELOW IS LOAD-BEARING.** Adding `mtl/operation/operators.hpp`, `mtl/mat/operators.hpp`, or anything that pulls them in silently disables this test — it will still pass, but it will have stopped checking anything.

That warning is not hypothetical: it is precisely how `test_multigrid.cpp` ended up unable to see this.

**Negative control:** reverting the include fails the new test at **both** sites (84 and 122) while the existing test still builds with **0 errors** — demonstrating the masking directly rather than by argument.

## Filed alongside

**#402** — the issue's unrelated observation, confirmed: `compressed2D * compressed2D` returns **`dense2D`**. Not a correctness bug (the values are right), but it means the Galerkin triple product `R * A * P` — the standard way to build the coarse levels `multigrid`'s own constructor asks for — materialises a dense intermediate at fine-grid size. The one product a multigrid user most needs to stay sparse is the one that does not. MTL5 already has the sparse accumulator (`sparse/util/scatter.hpp`) that a Gustavson implementation would sit on.

## Changes

| file | what |
|---|---|
| `include/mtl/itl/mg/multigrid.hpp` | `#include <mtl/mat/operators.hpp>`, with the reason and the instantiation subtlety in a comment |
| `tests/unit/itl/test_multigrid_self_contained.cpp` | new TU that can actually fail |

## Test results

| target | gcc build | gcc test | clang build | clang test |
|---|---|---|---|---|
| `itl_test_multigrid_self_contained` | OK | PASS (4 assertions / 1 case) | OK | PASS |
| full unit suite | OK | **163/163** | OK | **163/163** |

## Test plan
- [ ] Fast CI passes (gcc + clang)
- [ ] Promote to ready when satisfied

Resolves #401

Generated with [Claude Code](https://claude.com/claude-code)