### PR TITLE
feat(interface): zheev/cheev dispatch for the Hermitian eigenproblem + native cross-validation

### DIFF
--- a/include/mtl/interface/dispatch_traits.hpp
+++ b/include/mtl/interface/dispatch_traits.hpp
@@ -3,6 +3,7 @@
 // Used by operation files to select hardware-accelerated paths when available.
 
 #include <type_traits>
+#include <complex>
 #include <mtl/tag/orientation.hpp>
 #include <mtl/mat/compressed2D.hpp>
 
@@ -12,6 +13,13 @@ namespace mtl::interface {
 template <typename T>
 inline constexpr bool is_blas_scalar_v =
     std::is_same_v<T, float> || std::is_same_v<T, double>;
+
+/// True for complex scalar types backed by LAPACK (complex<float>, complex<double>).
+/// These route Hermitian eigensolves to cheev/zheev.
+template <typename T>
+inline constexpr bool is_lapack_complex_v = false;
+template <typename T>
+inline constexpr bool is_lapack_complex_v<std::complex<T>> = is_blas_scalar_v<T>;
 
 /// Whether the requested accumulator policy permits a hardware-fixed BLAS /
 /// native-fast path. External BLAS/LAPACK (and the blocked native GEMM)
@@ -29,6 +37,19 @@ inline constexpr bool accumulator_allows_blas_v = std::is_void_v<Accumulator>;
 template <typename M>
 concept BlasDenseMatrix =
     is_blas_scalar_v<typename M::value_type> &&
+    requires(const M& m) {
+        { m.data() } -> std::convertible_to<const typename M::value_type*>;
+        { m.num_rows() };
+        { m.num_cols() };
+    };
+
+/// Concept satisfied by dense matrix types eligible for complex-Hermitian
+/// LAPACK dispatch (cheev/zheev). Same shape as BlasDenseMatrix but for a
+/// complex<float/double> value_type. The caller is responsible for the matrix
+/// actually being Hermitian; only the storage/scalar shape is checked here.
+template <typename M>
+concept BlasHermitianMatrix =
+    is_lapack_complex_v<typename M::value_type> &&
     requires(const M& m) {
         { m.data() } -> std::convertible_to<const typename M::value_type*>;
         { m.num_rows() };

--- a/include/mtl/interface/lapack.hpp
+++ b/include/mtl/interface/lapack.hpp
@@ -6,6 +6,7 @@
 #ifdef MTL5_HAS_LAPACK
 
 #include <cstddef>
+#include <complex>
 
 // -- Fortran LAPACK declarations ----------------------------------------
 extern "C" {
@@ -43,6 +44,15 @@ void ssyev_(const char* jobz, const char* uplo, const int* n,
 void dsyev_(const char* jobz, const char* uplo, const int* n,
             double* A, const int* lda, double* W,
             double* work, const int* lwork, int* info);
+
+// Hermitian eigenvalue (complex Hermitian). Eigenvalues W are REAL; WORK is
+// complex and there is an extra REAL rwork array of length max(1, 3n-2).
+void cheev_(const char* jobz, const char* uplo, const int* n,
+            std::complex<float>* A, const int* lda, float* W,
+            std::complex<float>* work, const int* lwork, float* rwork, int* info);
+void zheev_(const char* jobz, const char* uplo, const int* n,
+            std::complex<double>* A, const int* lda, double* W,
+            std::complex<double>* work, const int* lwork, double* rwork, int* info);
 
 // General (non-symmetric) eigenvalue + optional left/right eigenvectors
 void sgeev_(const char* jobvl, const char* jobvr, const int* n,
@@ -166,6 +176,21 @@ inline int syev(char jobz, char uplo, int n, double* A, int lda,
                 double* W, double* work, int lwork) {
     int info = 0;
     dsyev_(&jobz, &uplo, &n, A, &lda, W, work, &lwork, &info);
+    return info;
+}
+
+// -- Hermitian eigenvalue (complex) -------------------------------------
+
+inline int heev(char jobz, char uplo, int n, std::complex<float>* A, int lda,
+                float* W, std::complex<float>* work, int lwork, float* rwork) {
+    int info = 0;
+    cheev_(&jobz, &uplo, &n, A, &lda, W, work, &lwork, rwork, &info);
+    return info;
+}
+inline int heev(char jobz, char uplo, int n, std::complex<double>* A, int lda,
+                double* W, std::complex<double>* work, int lwork, double* rwork) {
+    int info = 0;
+    zheev_(&jobz, &uplo, &n, A, &lda, W, work, &lwork, rwork, &info);
     return info;
 }
 

--- a/include/mtl/operation/eigenvalue_symmetric.hpp
+++ b/include/mtl/operation/eigenvalue_symmetric.hpp
@@ -162,9 +162,11 @@ auto eigenvalue_symmetric_generic(const M& A,
 
 /// Compute eigenvalues of a symmetric/Hermitian matrix via implicit QR on
 /// tridiagonal form. Returns eigenvalues (real: magnitude_t<value_type>) sorted
-/// in ascending order. Dispatches to LAPACK syev when available and the type
-/// qualifies (real float/double); complex Hermitian input falls through to
-/// eigenvalue_symmetric_generic.
+/// in ascending order. When MTL5_HAS_LAPACK is defined and the type qualifies,
+/// dispatches to LAPACK syev (real float/double) or heev == cheev/zheev (complex
+/// Hermitian); otherwise uses the in-house eigenvalue_symmetric_generic. The
+/// LAPACK Hermitian path is what test_lapack_dispatch cross-checks the native
+/// complex reduction against.
 template <Matrix M>
 auto eigenvalue_symmetric(const M& A,
                           magnitude_t<typename M::value_type> tol = 1e-10,
@@ -194,6 +196,40 @@ auto eigenvalue_symmetric(const M& A,
 
         // LAPACK returns eigenvalues in ascending order
         vec::dense_vector<value_type> result(n);
+        for (size_type i = 0; i < n; ++i)
+            result(i) = W[i];
+        return result;
+    } else if constexpr (interface::BlasHermitianMatrix<M> && !interface::is_row_major_v<M>) {
+        using value_type = typename M::value_type;         // std::complex<T>
+        using size_type  = typename M::size_type;
+        using real_t     = magnitude_t<value_type>;
+        const size_type n = A.num_rows();
+        assert(n == A.num_cols());
+        if (n == 0) return vec::dense_vector<real_t>(0);
+        // LAPACK zheev/cheev: eigenvalues only ('N'), lower triangle ('L').
+        // Work on a column-major copy; a Hermitian A is its own conjugate
+        // transpose, so 'L' reads a consistent triangle regardless of the copy's
+        // orientation. Eigenvalues W are REAL; heev also needs a real rwork array
+        // of length max(1, 3n-2) alongside the complex work.
+        std::vector<value_type> A_copy(n * n);
+        for (size_type i = 0; i < n; ++i)
+            for (size_type j = 0; j < n; ++j)
+                A_copy[j * n + i] = A(i, j);
+
+        std::vector<real_t> W(n);
+        std::vector<real_t> rwork(std::max<size_type>(size_type(1), 3 * n - 2));
+        // Workspace query: the optimal lwork comes back in the real part of work_opt.
+        value_type work_opt;
+        interface::lapack::heev('N', 'L', static_cast<int>(n),
+            A_copy.data(), static_cast<int>(n), W.data(), &work_opt, -1, rwork.data());
+        int lwork = static_cast<int>(work_opt.real());
+        if (lwork < 1) lwork = 1;
+        std::vector<value_type> work(static_cast<size_type>(lwork));
+        interface::lapack::heev('N', 'L', static_cast<int>(n),
+            A_copy.data(), static_cast<int>(n), W.data(), work.data(), lwork, rwork.data());
+
+        // LAPACK returns eigenvalues in ascending order (real for Hermitian).
+        vec::dense_vector<real_t> result(n);
         for (size_type i = 0; i < n; ++i)
             result(i) = W[i];
         return result;

--- a/tests/unit/interface/test_lapack_dispatch.cpp
+++ b/tests/unit/interface/test_lapack_dispatch.cpp
@@ -17,10 +17,12 @@
 #include <mtl/math/identity.hpp>
 #include <vector>
 #include <cmath>
+#include <complex>
 #include <algorithm>
 
 using namespace mtl;
 using Catch::Matchers::WithinAbs;
+using cplxd = std::complex<double>;
 
 // -- LU dispatch -------------------------------------------------------------
 
@@ -195,4 +197,79 @@ TEST_CASE("eigenvalue_symmetric on 2x2 SPD", "[interface][lapack]") {
     REQUIRE(eigs.size() == 2);
     REQUIRE_THAT(eigs(0), WithinAbs(1.0, 1e-8));
     REQUIRE_THAT(eigs(1), WithinAbs(3.0, 1e-8));
+}
+
+// -- Complex Hermitian eigenvalue dispatch (cheev/zheev) ---------------------
+// eigenvalue_symmetric routes a complex Hermitian matrix to LAPACK heev when
+// MTL5_HAS_LAPACK is defined AND the matrix is column-major (LAPACK is
+// column-major; the dispatch guards on !is_row_major_v<M>, exactly as the real
+// syev / geev / BLAS-L3 dispatch tests do). dense2D defaults to row-major, so
+// these tests use col-major explicitly -- otherwise the call silently takes the
+// generic path and the cross-check proves nothing. eigenvalue_symmetric_generic
+// is ALWAYS the in-house path, so comparing the two is the genuine native-vs-
+// LAPACK cross-check the self-consistent #414 tests could not do. (In a build
+// without LAPACK, eigenvalue_symmetric also runs generic, so the comparison
+// degenerates to a still-valid native self-check.)
+using col_params = mat::parameters<tag::col_major>;
+using cmat       = mat::dense2D<cplxd, col_params>;
+
+// Hermitian A = 2*I + v*v^H has eigenvalues {2 (mult n-1), 2+||v||^2}. With
+// v = {1, i, 1+i, 2}, ||v||^2 = 8, so the spectrum is {2, 2, 2, 10} -- a known,
+// degenerate spectrum that also stresses the repeated-eigenvalue subspace.
+static cmat hermitian_rank1_update() {
+    const std::size_t n = 4;
+    cplxd v[4] = { cplxd(1,0), cplxd(0,1), cplxd(1,1), cplxd(2,0) };
+    cmat A(n, n);
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j)
+            A(i, j) = (i == j ? cplxd(2,0) : cplxd(0,0)) + v[i] * std::conj(v[j]);
+    return A;
+}
+
+TEST_CASE("heev dispatch: complex Hermitian 2x2 known spectrum",
+          "[interface][lapack][complex]") {
+    // [[2, i], [-i, 2]] has eigenvalues 1 and 3.
+    cmat A(2, 2);
+    A(0,0) = cplxd(2,0);  A(0,1) = cplxd(0,1);
+    A(1,0) = cplxd(0,-1); A(1,1) = cplxd(2,0);
+
+    auto eigs = eigenvalue_symmetric(A);   // zheev under LAPACK, generic otherwise
+    REQUIRE(eigs.size() == 2);
+    REQUIRE_THAT(eigs(0), WithinAbs(1.0, 1e-9));
+    REQUIRE_THAT(eigs(1), WithinAbs(3.0, 1e-9));
+}
+
+TEST_CASE("heev dispatch: known degenerate spectrum {2,2,2,10}",
+          "[interface][lapack][complex]") {
+    auto A = hermitian_rank1_update();
+    auto eigs = eigenvalue_symmetric(A);
+    REQUIRE(eigs.size() == 4);
+    REQUIRE_THAT(eigs(0), WithinAbs(2.0,  1e-9));
+    REQUIRE_THAT(eigs(1), WithinAbs(2.0,  1e-9));
+    REQUIRE_THAT(eigs(2), WithinAbs(2.0,  1e-9));
+    REQUIRE_THAT(eigs(3), WithinAbs(10.0, 1e-9));
+}
+
+TEST_CASE("heev vs native: eigenvalues agree on a dense 5x5 Hermitian",
+          "[interface][lapack][complex]") {
+    constexpr std::size_t n = 5;
+    cmat A(n, n);
+    for (std::size_t i = 0; i < n; ++i) {
+        A(i, i) = cplxd(double(2 * i + 1), 0.0);
+        for (std::size_t j = i + 1; j < n; ++j) {
+            cplxd z(0.5 * double(i + 1) - 0.25 * double(j),
+                    0.3 * double(j + 1) - 0.2 * double(i));
+            A(i, j) = z;
+            A(j, i) = std::conj(z);
+        }
+    }
+
+    auto native = eigenvalue_symmetric_generic(A);  // in-house reduction + QR
+    auto disp   = eigenvalue_symmetric(A);           // LAPACK zheev when available
+
+    REQUIRE(native.size() == n);
+    REQUIRE(disp.size()   == n);
+    // Both ascending; compare elementwise. Under LAPACK this is native vs zheev.
+    for (std::size_t i = 0; i < n; ++i)
+        REQUIRE_THAT(disp(i), WithinAbs(native(i), 1e-9));
 }


### PR DESCRIPTION
## Summary
Gives the complex Hermitian eigenvalues from #414 a **LAPACK reference oracle**. `eigenvalue_symmetric` now routes a column-major complex Hermitian matrix to `heev` (`cheev`/`zheev`) under `MTL5_HAS_LAPACK`, mirroring the existing real `syev` path; complex falls through to the in-house `eigenvalue_symmetric_generic` otherwise.

This closes the gap flagged during #414: the self-consistent invariants (`A·v=λ·v`, reconstruction, `Qᴴ·Q=I`) catch a *phase* bug, but only an independent solver catches an algorithm that is *self-consistently wrong*. Now the native reduction is cross-checked against zheev.

## Changes
- `interface/lapack.hpp` — `cheev_`/`zheev_` externs + `heev()` wrappers. Eigenvalues `W` are **real**; `heev` also needs a real `rwork` array of length `max(1, 3n-2)` alongside the complex `work`, and the optimal `lwork` comes back in the **real part** of the query's `work[0]`.
- `interface/dispatch_traits.hpp` — `is_lapack_complex_v` + `BlasHermitianMatrix` concept (complex analogue of `BlasDenseMatrix`).
- `operation/eigenvalue_symmetric.hpp` — `else if constexpr (BlasHermitianMatrix<M> && !is_row_major_v<M>)` branch; `0×0` guarded before the `3n-2` rwork sizing.
- `tests/unit/interface/test_lapack_dispatch.cpp` — known spectra (2×2; a degenerate `{2,2,2,10}` from `2I + v·vᴴ`) + **native vs LAPACK** eigenvalue agreement on a dense 5×5.

## ⚠️ Finding — why the tests are column-major (please read)
`dense2D` **defaults to `tag::row_major`**, and the eigenvalue dispatch guards on `!is_row_major_v<M>` (LAPACK is column-major). So a plain row-major `dense2D` **never** takes the LAPACK path — and the **pre-existing real `syev` "dispatch" test in this file was silently running the generic path** for the same reason. The new tests use `mat::parameters<tag::col_major>` so the dispatch actually fires.

I verified this isn't vacuous: the built objects carry an **undefined `zheev_` symbol** and link `liblapack` (a row-major test would carry neither, and the cross-check would prove nothing):
```
$ nm -uC iface_test_lapack_dispatch | grep zheev  →  U zheev_
$ ldd  iface_test_lapack_dispatch | grep lapack   →  liblapack.so.3
```
The broader implication — **LAPACK eigen dispatch is effectively dead for the default (row-major) matrix type**, for real `syev` too — is pre-existing and left for a separate change (the explicit column-major copy inside the branch already makes relaxing the guard plausible, but that touches the real path and wants its own PR).

## Test Results
| Config | zheev linked | dispatch suite | eigen suite |
|---|---|---|---|
| gcc 13 + LAPACK | `U zheev_` ✓ | PASS (50) — native==zheev@1e-9 | PASS |
| clang 18 + LAPACK | `U zheev_` ✓ | PASS (50) | PASS (52) |
| clang 18, no LAPACK | none (generic) ✓ | PASS (50) | — |

## Test plan
- [ ] Fast CI passes (gcc + clang)
- [ ] **LAPACK CI job** (`Linux x64 LAPACK g++-13/clang++-18`) exercises the real native-vs-zheev comparison
- [ ] Promote to ready when satisfied

Relates to #415 (can `Resolves` if we treat the row-major dispatch gap as its own issue)

Generated with [Claude Code](https://claude.com/claude-code)