### PR TITLE
perf(operation): dispatch row-major dense matrices to LAPACK for eigen/SVD (#417 Category A)

### DIFF
--- a/include/mtl/operation/eigenvalue.hpp
+++ b/include/mtl/operation/eigenvalue.hpp
@@ -182,8 +182,8 @@ void eig_lu_solve(const std::vector<Complex>& M, const std::vector<std::size_t>&
 /// Throws std::runtime_error if the QR iteration fails to converge.
 ///
 /// Dispatches to LAPACK geev when MTL5_HAS_LAPACK is defined and the type
-/// qualifies (column-major dense2D<float/double>); otherwise uses the in-house
-/// path above, which also serves custom number types (posits, LNS, ...).
+/// qualifies (dense2D<float/double>, either orientation); otherwise uses the
+/// in-house path above, which also serves custom number types (posits, LNS, ...).
 template <Matrix M>
 auto eigenvalue(const M& A, typename M::value_type tol = 1e-10,
                 typename M::size_type max_iter = 0) {
@@ -199,10 +199,12 @@ auto eigenvalue(const M& A, typename M::value_type tol = 1e-10,
     if (n == 0) return eigs;
 
 #ifdef MTL5_HAS_LAPACK
-    // Accelerate real float/double column-major dense matrices via LAPACK geev
-    // (mirrors the symmetric syev dispatch). Custom number types and other
-    // orientations fall through to the in-house double-shift QR below.
-    if constexpr (interface::BlasDenseMatrix<M> && !interface::is_row_major_v<M>) {
+    // Accelerate real float/double dense matrices via LAPACK geev (mirrors the
+    // symmetric syev dispatch). lapack_geev builds its column-major copy through
+    // the (i,j) accessor, so this is correct for any orientation of M -- no
+    // !is_row_major_v guard (see #417). Custom number types fall through to the
+    // in-house double-shift QR below.
+    if constexpr (interface::BlasDenseMatrix<M>) {
         detail::lapack_geev(A, eigs, static_cast<mat::dense2D<complex_type>*>(nullptr));
         return eigs;
     }
@@ -387,8 +389,8 @@ auto eigenvalue(const M& A, typename M::value_type tol = 1e-10,
 /// spectra of strongly non-normal matrices are resolved accurately here too.
 ///
 /// Dispatches to LAPACK geev (eigenvalues + right eigenvectors) when
-/// MTL5_HAS_LAPACK is defined and the type qualifies (column-major
-/// dense2D<float/double>); otherwise uses the in-house path above.
+/// MTL5_HAS_LAPACK is defined and the type qualifies (dense2D<float/double>,
+/// either orientation); otherwise uses the in-house path above.
 template <Matrix M>
 auto eigen(const M& A, typename M::value_type tol = 1e-10,
            typename M::size_type max_iter = 0) {
@@ -411,8 +413,10 @@ auto eigen(const M& A, typename M::value_type tol = 1e-10,
 
 #ifdef MTL5_HAS_LAPACK
     // LAPACK geev computes eigenvalues and right eigenvectors together for real
-    // float/double column-major dense matrices (mirrors the eigenvalue dispatch).
-    if constexpr (interface::BlasDenseMatrix<M> && !interface::is_row_major_v<M>) {
+    // float/double dense matrices (mirrors the eigenvalue dispatch). lapack_geev
+    // copies through the (i,j) accessor, so any orientation of M is correct --
+    // no !is_row_major_v guard (see #417).
+    if constexpr (interface::BlasDenseMatrix<M>) {
         vec::dense_vector<complex_type> eigs_l(n);
         mat::dense2D<complex_type> V_l(n, n);
         detail::lapack_geev(A, eigs_l, &V_l);

--- a/include/mtl/operation/eigenvalue_symmetric.hpp
+++ b/include/mtl/operation/eigenvalue_symmetric.hpp
@@ -172,7 +172,11 @@ auto eigenvalue_symmetric(const M& A,
                           magnitude_t<typename M::value_type> tol = 1e-10,
                           typename M::size_type max_iter = 0) {
 #ifdef MTL5_HAS_LAPACK
-    if constexpr (interface::BlasDenseMatrix<M> && !interface::is_row_major_v<M>) {
+    // No orientation guard: the branch builds an explicit column-major copy
+    // through the (i,j) accessor below, so it is correct for a row-major OR a
+    // column-major M. (dense2D defaults to row-major; gating on !is_row_major_v
+    // would leave the default matrix type on the generic path -- see #417.)
+    if constexpr (interface::BlasDenseMatrix<M>) {
         using value_type = typename M::value_type;
         using size_type  = typename M::size_type;
         const size_type n = A.num_rows();
@@ -199,7 +203,7 @@ auto eigenvalue_symmetric(const M& A,
         for (size_type i = 0; i < n; ++i)
             result(i) = W[i];
         return result;
-    } else if constexpr (interface::BlasHermitianMatrix<M> && !interface::is_row_major_v<M>) {
+    } else if constexpr (interface::BlasHermitianMatrix<M>) {
         using value_type = typename M::value_type;         // std::complex<T>
         using size_type  = typename M::size_type;
         using real_t     = magnitude_t<value_type>;

--- a/include/mtl/operation/svd.hpp
+++ b/include/mtl/operation/svd.hpp
@@ -51,7 +51,10 @@ void svd(const M& A,
     const size_type mn = std::min(m, n);
 
 #ifdef MTL5_HAS_LAPACK
-    if constexpr (interface::BlasDenseMatrix<M> && !interface::is_row_major_v<M>) {
+    // No orientation guard: the branch copies A into a column-major buffer via
+    // the (i,j) accessor and writes U/S/V back via (i,j), so it is correct for
+    // row-major and column-major M alike (see #417).
+    if constexpr (interface::BlasDenseMatrix<M>) {
         // LAPACK gesdd: A_copy is overwritten, returns U, S_vec, VT
         U.change_dim(m, m);
         S.change_dim(m, n);

--- a/tests/unit/interface/test_lapack_dispatch.cpp
+++ b/tests/unit/interface/test_lapack_dispatch.cpp
@@ -11,6 +11,7 @@
 #include <mtl/operation/cholesky.hpp>
 #include <mtl/operation/svd.hpp>
 #include <mtl/operation/eigenvalue_symmetric.hpp>
+#include <mtl/operation/eigenvalue.hpp>
 #include <mtl/operation/mult.hpp>
 #include <mtl/operation/norms.hpp>
 #include <mtl/operation/operators.hpp>
@@ -272,4 +273,70 @@ TEST_CASE("heev vs native: eigenvalues agree on a dense 5x5 Hermitian",
     // Both ascending; compare elementwise. Under LAPACK this is native vs zheev.
     for (std::size_t i = 0; i < n; ++i)
         REQUIRE_THAT(disp(i), WithinAbs(native(i), 1e-9));
+}
+
+// -- #417: the DEFAULT (row-major) dense2D now dispatches to LAPACK too -------
+// The eigen/SVD/geev dispatches build a column-major copy through the (i,j)
+// accessor, so the old !is_row_major_v guard was redundant and only kept the
+// default matrix type on the generic path. These tests use the DEFAULT
+// (row-major) dense2D -- no col_params -- and check the LAPACK result matches the
+// in-house path. (Verified out-of-band that a row-major-only eigen translation
+// unit references dsyev_/zheev_ after the guard drop; before it, none did, so the
+// dispatch really was dead for row-major.)
+
+TEST_CASE("row-major dispatch: real symmetric eigenvalues match generic",
+          "[interface][lapack][rowmajor]") {
+    constexpr std::size_t n = 4;
+    mat::dense2D<double> A(n, n);   // default row-major
+    for (std::size_t i = 0; i < n; ++i) {
+        A(i, i) = double(i + 1);
+        for (std::size_t j = i + 1; j < n; ++j) {
+            double v = 0.3 * double(i + 1) - 0.1 * double(j);
+            A(i, j) = v; A(j, i) = v;
+        }
+    }
+    auto disp = eigenvalue_symmetric(A);            // dsyev under LAPACK (row-major now)
+    auto gen  = eigenvalue_symmetric_generic(A);    // in-house
+    REQUIRE(disp.size() == n);
+    for (std::size_t i = 0; i < n; ++i)
+        REQUIRE_THAT(disp(i), WithinAbs(gen(i), 1e-9));
+}
+
+TEST_CASE("row-major dispatch: complex Hermitian eigenvalues match generic",
+          "[interface][lapack][rowmajor][complex]") {
+    constexpr std::size_t n = 4;
+    mat::dense2D<cplxd> A(n, n);   // default row-major -- the case #416 could not cover
+    for (std::size_t i = 0; i < n; ++i) {
+        A(i, i) = cplxd(double(i + 2), 0.0);
+        for (std::size_t j = i + 1; j < n; ++j) {
+            cplxd z(0.4 * double(i + 1) - 0.1 * double(j),
+                    0.25 * double(j) - 0.15 * double(i + 1));
+            A(i, j) = z; A(j, i) = std::conj(z);
+        }
+    }
+    auto disp = eigenvalue_symmetric(A);            // zheev under LAPACK (row-major now)
+    auto gen  = eigenvalue_symmetric_generic(A);    // in-house reduction + QR
+    REQUIRE(disp.size() == n);
+    for (std::size_t i = 0; i < n; ++i)
+        REQUIRE_THAT(disp(i), WithinAbs(gen(i), 1e-9));
+}
+
+TEST_CASE("row-major dispatch: general eigenvalue (geev) known real spectrum",
+          "[interface][lapack][rowmajor]") {
+    // Upper-triangular, so the eigenvalues are the diagonal {2, 3, 5}. Not
+    // symmetric -> exercises the general geev dispatch, not syev.
+    mat::dense2D<double> A(3, 3);   // default row-major
+    A(0,0)=2; A(0,1)=1; A(0,2)=0;
+    A(1,0)=0; A(1,1)=3; A(1,2)=1;
+    A(2,0)=0; A(2,1)=0; A(2,2)=5;
+
+    auto eigs = eigenvalue(A);      // geev under LAPACK (row-major now), else in-house QR
+    REQUIRE(eigs.size() == 3);
+    std::vector<double> re{ eigs(0).real(), eigs(1).real(), eigs(2).real() };
+    std::sort(re.begin(), re.end());
+    REQUIRE_THAT(re[0], WithinAbs(2.0, 1e-9));
+    REQUIRE_THAT(re[1], WithinAbs(3.0, 1e-9));
+    REQUIRE_THAT(re[2], WithinAbs(5.0, 1e-9));
+    for (std::size_t i = 0; i < 3; ++i)
+        REQUIRE_THAT(eigs(i).imag(), WithinAbs(0.0, 1e-9));
 }


### PR DESCRIPTION
## Summary
`dense2D` **defaults to `tag::row_major`**, and the `syev`/`heev`/`geev`/`gesdd` dispatches guarded on `!is_row_major_v<M>` — so the **default matrix type never took the LAPACK path**. Each of these branches already builds a column-major copy *through the `(i,j)` accessor* and writes results back through `(i,j)`, so the guard was purely redundant and only disabled acceleration for the common case. This drops it (Category A of #417).

## Changes
Removed `&& !interface::is_row_major_v<M>` from the five copy-based dispatch sites:
- `operation/eigenvalue_symmetric.hpp` — `syev` + `heev` (cheev/zheev)
- `operation/eigenvalue.hpp` — `geev` (eigenvalues; and eigenvalues+vectors)
- `operation/svd.hpp` — `gesdd`

Custom number types still fall through to the in-house paths (the concepts gate on `float`/`double` / `complex<float/double>`).

## ⚠️ Category B deliberately NOT touched — #417 stays open
`qr` (`geqrf`), `lu` (`getrf`), `cholesky` (`potrf`) pass the **raw `A.data()`** buffer to Fortran, so a row-major buffer is the *transpose* of what LAPACK reads. Enabling them needs a transpose-copy (or a `uplo` flip for symmetric `potrf`) — its own change. This PR does not close #417.

## Proof it isn't a vacuous dispatch test
A numeric test can't tell LAPACK from generic (both correct). So I checked the symbols directly — a **row-major-only** eigen/SVD translation unit, compiled `-DMTL5_HAS_LAPACK`:
```
this branch (guards dropped):  U dsyev_  U zheev_  U dgeev_  U dgesdd_
parent commit (guards present): (none)
```
Before the change, row-major referenced **no** LAPACK symbols — confirming the dispatch really was dead for the default type.

## Tests
Row-major (default `dense2D`) cases added: real symmetric, **complex Hermitian** (the case #416 could only cover column-major), and general `geev` — each vs the in-house path / a known spectrum. Existing SVD and real-symmetric row-major tests now transfer onto the LAPACK path automatically.

| Config | eigen/dispatch/svd suites |
|---|---|
| gcc 13 + LAPACK | PASS (dispatch 67, eigenvalue 71, eigen_hermitian 52, svd 2332, geev 11) |
| clang 18 + LAPACK | PASS |
| clang 18, no LAPACK | PASS (generic path) |

## Test plan
- [ ] Fast CI + **LAPACK CI job** (exercises the newly-enabled row-major path)
- [ ] Promote when satisfied

Relates to #417 (Category A only; B — qr/lu/cholesky — remains)

Generated with [Claude Code](https://claude.com/claude-code)