### PR TITLE
perf(operation): dispatch row-major dense matrices to LAPACK for LU/QR/Cholesky (#417 Category B)

### DIFF
--- a/include/mtl/operation/cholesky.hpp
+++ b/include/mtl/operation/cholesky.hpp
@@ -23,6 +23,7 @@
 #include <cmath>
 #include <cstddef>
 #include <type_traits>
+#include <vector>
 #include <mtl/concepts/matrix.hpp>
 #include <mtl/concepts/vector.hpp>
 #include <mtl/concepts/magnitude.hpp>
@@ -78,11 +79,33 @@ int cholesky_factor(M& A) {
         "which compute A = L*L^H (#353).");
 
 #ifdef MTL5_HAS_LAPACK
-    if constexpr (interface::BlasDenseMatrix<M> && !interface::is_row_major_v<M>) {
-        int n_int = static_cast<int>(n);
-        int info = interface::lapack::potrf('L', n_int,
-                       const_cast<value_type*>(A.data()), n_int);
-        return (info > 0) ? info : 0;
+    if constexpr (interface::BlasDenseMatrix<M>) {
+        // potrf('L') factors the lower triangle in place into L (A = L*L^T). A
+        // column-major dense2D is a valid column-major buffer; a row-major one is
+        // factored via a column-major scratch built through the (i,j) accessor
+        // and copied back through (i,j), so cholesky_solve reads L(i,j) exactly
+        // as on the column-major path. For a symmetric A the copied-in lower
+        // triangle is the same matrix either way (#417).
+        // n == 0 would make lda == 0, which LAPACK rejects (XERBLA); an empty
+        // matrix is trivially factored, so skip the call and fall through.
+        if (n > 0) {
+            int n_int = static_cast<int>(n);
+            int info;
+            if constexpr (interface::is_row_major_v<M>) {
+                std::vector<value_type> buf(static_cast<std::size_t>(n) * static_cast<std::size_t>(n));
+                for (size_type i = 0; i < n; ++i)
+                    for (size_type j = 0; j < n; ++j)
+                        buf[static_cast<std::size_t>(j) * n + i] = A(i, j);
+                info = interface::lapack::potrf('L', n_int, buf.data(), n_int);
+                for (size_type i = 0; i < n; ++i)
+                    for (size_type j = 0; j < n; ++j)
+                        A(i, j) = buf[static_cast<std::size_t>(j) * n + i];
+            } else {
+                info = interface::lapack::potrf('L', n_int,
+                           const_cast<value_type*>(A.data()), n_int);
+            }
+            return (info > 0) ? info : 0;
+        }
     }
 #endif
 
@@ -172,6 +195,20 @@ int cholesky_h_factor(M& A) {
     using std::sqrt;
     const size_type n = A.num_rows();
     assert(A.num_cols() == n);
+
+#ifdef MTL5_HAS_LAPACK
+    // For a REAL element type A = L*L^H is exactly A = L*L^T, so reuse
+    // cholesky_factor. This keeps the two entry points BIT-IDENTICAL -- the
+    // invariant test_cholesky.cpp pins with == -- now that cholesky_factor
+    // dispatches to LAPACK potrf (#417); factoring here independently would
+    // diverge from it in the low bits. It also gives cholesky_h_factor the same
+    // dispatch (row- and column-major). Complex Hermitian types are not
+    // BlasDenseMatrix (float/double only), so they skip this and take the
+    // generic L*L^H below -- the only correct path for them.
+    if constexpr (interface::BlasDenseMatrix<M>) {
+        return cholesky_factor(A);
+    }
+#endif
 
     // A Hermitian matrix has a REAL diagonal. If a complex-symmetric matrix
     // arrives here by mistake, taking the real part below would silently

--- a/include/mtl/operation/lu.hpp
+++ b/include/mtl/operation/lu.hpp
@@ -38,14 +38,33 @@ int lu_factor(M& A, std::vector<typename M::size_type>& pivot) {
 
 #ifdef MTL5_HAS_LAPACK
     if constexpr (interface::BlasDenseMatrix<M>) {
-        // LAPACK getrf expects column-major. For column-major dense2D, dispatch directly.
-        // For row-major, factoring A_row is equivalent to factoring A_col^T = U^T * L^T,
-        // which gives an LU of the transpose. We dispatch only for column-major.
-        if constexpr (!interface::is_row_major_v<M>) {
+        // getrf works in-place on a column-major buffer, overwriting it with L\U
+        // and returning a forward interchange sequence in ipiv (the same pivot
+        // convention lu_solve expects, once shifted 1->0 based). A column-major
+        // dense2D IS that buffer; a row-major one is factored via a column-major
+        // scratch built through the (i,j) accessor, then copied back through
+        // (i,j) so the accessor-based lu_solve / lu_adjoint_solve read it exactly
+        // as they read the column-major path (#417). Direct-dispatch on the raw
+        // row-major buffer would factor A^T instead -- hence the copy.
+        // n == 0 would make lda == 0, which LAPACK rejects (XERBLA); an empty
+        // matrix is trivially factored, so skip the call and fall through.
+        if (n > 0) {
             int m_int = static_cast<int>(n);
             std::vector<int> ipiv(n);
-            int info = interface::lapack::getrf(m_int, m_int,
+            int info;
+            if constexpr (interface::is_row_major_v<M>) {
+                std::vector<value_type> buf(static_cast<std::size_t>(n) * static_cast<std::size_t>(n));
+                for (size_type i = 0; i < n; ++i)
+                    for (size_type j = 0; j < n; ++j)
+                        buf[static_cast<std::size_t>(j) * n + i] = A(i, j);
+                info = interface::lapack::getrf(m_int, m_int, buf.data(), m_int, ipiv.data());
+                for (size_type i = 0; i < n; ++i)
+                    for (size_type j = 0; j < n; ++j)
+                        A(i, j) = buf[static_cast<std::size_t>(j) * n + i];
+            } else {
+                info = interface::lapack::getrf(m_int, m_int,
                            const_cast<value_type*>(A.data()), m_int, ipiv.data());
+            }
             // Convert 1-based Fortran pivots to 0-based size_type pivots
             for (size_type i = 0; i < n; ++i)
                 pivot[i] = static_cast<size_type>(ipiv[i] - 1);

--- a/include/mtl/operation/qr.hpp
+++ b/include/mtl/operation/qr.hpp
@@ -33,20 +33,44 @@ int qr_factor(M& A, vec::dense_vector<typename M::value_type>& tau) {
     tau.change_dim(k);
 
 #ifdef MTL5_HAS_LAPACK
-    if constexpr (interface::BlasDenseMatrix<M> && !interface::is_row_major_v<M>) {
-        int m_int = static_cast<int>(m);
-        int n_int = static_cast<int>(n);
-        // Workspace query
-        value_type work_opt;
-        interface::lapack::geqrf(m_int, n_int,
-            const_cast<value_type*>(A.data()), m_int,
-            tau.data(), &work_opt, -1);
-        int lwork = static_cast<int>(work_opt);
-        std::vector<value_type> work(lwork);
-        int info = interface::lapack::geqrf(m_int, n_int,
-            const_cast<value_type*>(A.data()), m_int,
-            tau.data(), work.data(), lwork);
-        return info;
+    if constexpr (interface::BlasDenseMatrix<M>) {
+        // A zero dimension makes lda == 0, which LAPACK rejects (XERBLA); an
+        // empty factorization is trivial, so skip the call and fall through.
+        if (m > 0 && n > 0) {
+            int m_int = static_cast<int>(m);
+            int n_int = static_cast<int>(n);
+            // geqrf works in-place on a column-major buffer. A column-major
+            // dense2D IS that buffer -- point straight at A.data(). A row-major
+            // dense2D is not, so copy it into a column-major scratch through the
+            // (i,j) accessor, factor there, and copy the result (R + packed
+            // reflectors) back through (i,j); the generic qr_extract_Q / qr_solve
+            // then read it exactly as on the column-major path, and tau is filled
+            // the same way (#417).
+            std::vector<value_type> buf;
+            value_type* aptr;
+            if constexpr (interface::is_row_major_v<M>) {
+                buf.resize(static_cast<std::size_t>(m) * static_cast<std::size_t>(n));
+                for (size_type i = 0; i < m; ++i)
+                    for (size_type j = 0; j < n; ++j)
+                        buf[static_cast<std::size_t>(j) * m + i] = A(i, j);
+                aptr = buf.data();
+            } else {
+                aptr = const_cast<value_type*>(A.data());
+            }
+            // Workspace query
+            value_type work_opt;
+            interface::lapack::geqrf(m_int, n_int, aptr, m_int, tau.data(), &work_opt, -1);
+            int lwork = static_cast<int>(work_opt);
+            std::vector<value_type> work(lwork);
+            int info = interface::lapack::geqrf(m_int, n_int, aptr, m_int,
+                tau.data(), work.data(), lwork);
+            if constexpr (interface::is_row_major_v<M>) {
+                for (size_type i = 0; i < m; ++i)
+                    for (size_type j = 0; j < n; ++j)
+                        A(i, j) = buf[static_cast<std::size_t>(j) * m + i];
+            }
+            return info;
+        }
     }
 #endif
 

--- a/tests/unit/operation/test_factorization_mt.cpp
+++ b/tests/unit/operation/test_factorization_mt.cpp
@@ -29,6 +29,17 @@
 
 using namespace mtl;
 
+// Element type for the factorization determinism checks below. Their point is
+// that MTL5's parallel_for LU/Cholesky kernels are BIT-IDENTICAL to a serial
+// reference -- a property of the GENERIC path. Since #417 routes float/double
+// dense factorizations to LAPACK (a different algorithm, so not bit-identical to
+// the reference), use a non-BLAS element type: long double is never float/double,
+// so is_blas_scalar_v is false, BlasDenseMatrix<dense2D<det_t>> is false, and the
+// generic parallel_for path is taken in LAPACK and non-LAPACK builds alike. The
+// apply_householder_* tests further below stay double -- those kernels never
+// dispatch to LAPACK.
+using det_t = long double;
+
 namespace {
 
 // Size the process-wide pool multithreaded before its first (lazy) use.
@@ -81,8 +92,9 @@ void ref_chol(mat::dense2D<T>& A) {
     }
 }
 
-// Row-major dense2D exercises the generic (parallelized) path even when LAPACK
-// is linked (the LAPACK LU/Cholesky dispatch fires only for column-major).
+// Instantiated with det_t (a non-BLAS element type), so dense2D<T> takes the
+// generic parallel_for factorization path even when LAPACK is linked -- #417
+// routes float/double dense factorizations to LAPACK regardless of orientation.
 template <typename T>
 mat::dense2D<T> random_diagdom(std::size_t n, std::uint64_t seed) {
     mat::dense2D<T> A(n, n);
@@ -122,11 +134,11 @@ TEST_CASE("Threaded LU factorization is bit-identical to serial (#297)",
         WARN("single-core runner: threading not exercised");
     }
     const std::size_t n = 512;   // large enough that the trailing update splits
-    auto A = random_diagdom<double>(n, 12345);
+    auto A = random_diagdom<det_t>(n, 12345);
     auto Aref = A;               // copy for the serial reference
 
-    std::vector<mat::dense2D<double>::size_type> piv;
-    int info = lu_factor(A, piv);              // library (threaded) path
+    std::vector<mat::dense2D<det_t>::size_type> piv;
+    int info = lu_factor(A, piv);              // library (threaded) generic path
     REQUIRE(info == 0);
 
     std::vector<std::size_t> rpiv;
@@ -140,13 +152,13 @@ TEST_CASE("Threaded LU factorization is bit-identical to serial (#297)",
     }
 
     // Correctness: the factorization solves a system to a tiny residual.
-    vec::dense_vector<double> xexact(n), b(n, 0.0);
-    for (std::size_t i = 0; i < n; ++i) xexact[i] = 1.0 + 0.001 * double(i % 13);
-    auto A0 = random_diagdom<double>(n, 12345);
-    for (std::size_t i = 0; i < n; ++i) { double s = 0.0; for (std::size_t j = 0; j < n; ++j) s += A0(i, j) * xexact[j]; b[i] = s; }
-    vec::dense_vector<double> x(n, 0.0);
+    vec::dense_vector<det_t> xexact(n), b(n, det_t(0));
+    for (std::size_t i = 0; i < n; ++i) xexact[i] = det_t(1.0 + 0.001 * double(i % 13));
+    auto A0 = random_diagdom<det_t>(n, 12345);
+    for (std::size_t i = 0; i < n; ++i) { det_t s = det_t(0); for (std::size_t j = 0; j < n; ++j) s += A0(i, j) * xexact[j]; b[i] = s; }
+    vec::dense_vector<det_t> x(n, det_t(0));
     lu_solve(A, piv, x, b);
-    double err = 0.0;
+    det_t err = det_t(0);
     for (std::size_t i = 0; i < n; ++i) err = std::max(err, std::abs(x[i] - xexact[i]));
     REQUIRE(err < 1e-9);
 }
@@ -157,10 +169,10 @@ TEST_CASE("Threaded Cholesky factorization is bit-identical to serial (#297)",
         WARN("single-core runner: threading not exercised");
     }
     const std::size_t n = 768;   // large enough that the column update splits
-    auto A = random_spd<double>(n, 6789);
+    auto A = random_spd<det_t>(n, 6789);
     auto Aref = A;
 
-    int info = cholesky_factor(A);             // library (threaded) path
+    int info = cholesky_factor(A);             // library (threaded) generic path
     REQUIRE(info == 0);
 
     ref_chol(Aref);                            // serial golden reference
@@ -171,13 +183,13 @@ TEST_CASE("Threaded Cholesky factorization is bit-identical to serial (#297)",
             REQUIRE(A(i, j) == Aref(i, j));
 
     // Correctness: L*L^T reconstructs the original SPD matrix.
-    auto A0 = random_spd<double>(n, 6789);
-    double resid = 0.0;
+    auto A0 = random_spd<det_t>(n, 6789);
+    det_t resid = det_t(0);
     for (std::size_t i = 0; i < n; ++i)
         for (std::size_t j = 0; j <= i; ++j) {
-            double llt = 0.0;
+            det_t llt = det_t(0);
             for (std::size_t k = 0; k <= j; ++k) llt += A(i, k) * A(j, k);
-            resid = std::max(resid, std::abs(llt - double(A0(i, j))));
+            resid = std::max(resid, std::abs(llt - A0(i, j)));
         }
     REQUIRE(resid < 1e-8);
 }
@@ -189,9 +201,9 @@ TEST_CASE("Threaded factorizations degrade correctly at the single-chunk boundar
     // reference bit-for-bit. Explicit (deterministic) tiny matrices so the SPD /
     // diagonally-dominant property never depends on the RNG.
 
-    auto check_lu = [](mat::dense2D<double> A) {
+    auto check_lu = [](mat::dense2D<det_t> A) {
         auto Aref = A;
-        std::vector<mat::dense2D<double>::size_type> piv;
+        std::vector<mat::dense2D<det_t>::size_type> piv;
         REQUIRE(lu_factor(A, piv) == 0);
         std::vector<std::size_t> rpiv;
         ref_lu(Aref, rpiv);
@@ -201,7 +213,7 @@ TEST_CASE("Threaded factorizations degrade correctly at the single-chunk boundar
             for (std::size_t j = 0; j < n; ++j) REQUIRE(A(i, j) == Aref(i, j));
         }
     };
-    auto check_chol = [](mat::dense2D<double> A) {
+    auto check_chol = [](mat::dense2D<det_t> A) {
         auto Aref = A;
         REQUIRE(cholesky_factor(A) == 0);
         ref_chol(Aref);
@@ -211,14 +223,14 @@ TEST_CASE("Threaded factorizations degrade correctly at the single-chunk boundar
     };
 
     SECTION("1x1") {
-        mat::dense2D<double> A(1, 1); A(0, 0) = 4.0;
+        mat::dense2D<det_t> A(1, 1); A(0, 0) = det_t(4);
         check_lu(A);
         check_chol(A);
     }
     SECTION("2x2") {
-        mat::dense2D<double> A(2, 2);
-        A(0, 0) = 4.0; A(0, 1) = 1.0;
-        A(1, 0) = 1.0; A(1, 1) = 3.0;   // symmetric, SPD, diagonally dominant
+        mat::dense2D<det_t> A(2, 2);
+        A(0, 0) = det_t(4); A(0, 1) = det_t(1);
+        A(1, 0) = det_t(1); A(1, 1) = det_t(3);   // symmetric, SPD, diagonally dominant
         check_lu(A);
         check_chol(A);
     }


### PR DESCRIPTION
## Summary
Completes **#417**. `lu_factor`/`qr_factor`/`cholesky_factor` dispatched to `getrf`/`geqrf`/`potrf` only for **column-major** dense2D, because those pass the raw `A.data()` buffer to Fortran and a row-major buffer is the *transpose* of what LAPACK reads. This enables the default (row-major) type by factoring through a column-major scratch: copy A in via the `(i,j)` accessor, run LAPACK in place, copy the factor back via `(i,j)`. The accessor-based solves (`lu_solve`, `qr_solve`/`qr_extract_Q`, `cholesky_solve`) then read the factor exactly as on the column-major path; pivots/tau come out identically.

This is Category B of #417 — the harder half A (#418) left, since these dispatches can't just drop the guard.

## Changes
- `lu.hpp` / `qr.hpp` / `cholesky.hpp` — row-major copy-in → LAPACK → copy-out.
- `cholesky_h_factor` **delegates to `cholesky_factor`** for real BLAS types (`A = L*L^H` is `A = L*L^T` there). This keeps the two entry points **bit-identical** — the invariant `test_cholesky.cpp` pins with `==`, which independent factoring would break once `cholesky_factor` uses `potrf` — and extends the dispatch. Complex Hermitian stays generic.
- **Zero-dimension guard** on all three: LAPACK rejects `lda == 0` (XERBLA), so an empty matrix skips the call and falls through to the generic no-op. (Surfaced by the degenerate-sizes test via the cholesky delegation.)

## ⚠️ Behavior change caught by #297 — and how it's resolved
`test_factorization_mt` (#297) asserts the threaded factorization is **bit-identical to a serial *generic* reference** — a property of MTL5's `parallel_for` kernels, not of LAPACK. Since the default `double` path now dispatches to LAPACK (a *different* algorithm), that assertion no longer holds for `double`.

Per the chosen resolution, the determinism tests switch to a **non-BLAS element type** (`det_t = long double`, never `is_blas_scalar`), so `dense2D<det_t>` always takes the generic `parallel_for` kernel and the race-freedom check holds in **both** LAPACK and non-LAPACK builds. The `apply_householder_*` tests stay `double` — those kernels never dispatch. Correctness/residual checks still pass on `double` via the LAPACK path (the existing lu/qr/cholesky suites).

## Proof it isn't vacuous
```
this branch:     U dgetrf_  U dgeqrf_  U dpotrf_   (row-major factorization TU)
parent commit:   (none)
```

## Test Results
| Config | full suite / affected |
|---|---|
| gcc 13 + LAPACK | **163/163** (full ctest) |
| clang 18 + LAPACK | lu/qr/cholesky/factorization_mt/dispatch PASS |
| clang 18, no LAPACK | PASS (generic path; det_t compiles) |

## Test plan
- [ ] Fast CI + LAPACK CI job (exercises the row-major factorization dispatch)
- [ ] Tier-2 regression (dense solvers consume these factorizations)
- [ ] Promote when satisfied

Resolves #417

Generated with [Claude Code](https://claude.com/claude-code)