### PR TITLE
perf(sparse): reuse solve schedules in the LU refactor paths

### DIFF
--- a/include/mtl/sparse/factorization/sparse_lu.hpp
+++ b/include/mtl/sparse/factorization/sparse_lu.hpp
@@ -96,6 +96,33 @@ struct lu_numeric {
         has_factor_ = true;              // commit last: solve() is now valid
     }
 
+    /// True once factors (and their coupled schedules) have been installed.
+    bool has_factor() const { return has_factor_; }
+
+    /// Install recomputed VALUES on the already-installed factor pattern, keeping
+    /// the existing solve schedules. The schedules are value-agnostic -- they cache
+    /// positions into L_.values / U_.values, not the values -- so a same-pattern
+    /// refactorization can swap in new numbers and skip the O(nnz) schedule rebuild
+    /// set_factor pays. Only the value arrays change; col_ptr / row_ind are kept.
+    ///
+    /// Requires a factor already installed, and value arrays of exactly the
+    /// installed nnz -- a PATTERN change must go through set_factor. The schedules'
+    /// built_nnz staleness guards (the ones the solves assert on) are re-checked
+    /// here, so a schedule can never be left silently stale.
+    /// Strongly exception safe: all validation precedes any member replacement.
+    void set_factor_values(std::vector<Value> Lvals, std::vector<Value> Uvals) {
+        if (!has_factor_)
+            throw std::logic_error(
+                "lu_numeric::set_factor_values: no factor installed (call set_factor first)");
+        if (Lvals.size() != L_.values.size() || Uvals.size() != U_.values.size() ||
+            fwd_sched_.built_nnz != Lvals.size() || up_sched_.built_nnz != Uvals.size())
+            throw std::invalid_argument(
+                "lu_numeric::set_factor_values: value count does not match the installed "
+                "factor pattern (use set_factor for a pattern change)");
+        L_.values = std::move(Lvals);   // noexcept
+        U_.values = std::move(Uvals);   // noexcept
+    }
+
     /// Solve A*x = b using the LU factorization.
     /// P*A*Q = L*U, so A = P^T * L * U * Q^T
     /// A*x = b => P^T * L * U * Q^T * x = b
@@ -503,40 +530,58 @@ lu_numeric<Value> sparse_lu_numeric(
     return result;
 }
 
-/// Refactorize a matrix with the SAME sparsity pattern as a prior factorization,
-/// reusing that factorization's symbolic structure and pivot sequence. Only the
-/// numeric values are recomputed -- no BTF/ordering, no reach DFS, and no pivot
-/// search -- which is the fast path for repeated solves of a fixed pattern with
-/// changing values (e.g. SPICE transient analysis: one factor, many refactor).
+/// Refactorize IN PLACE: recompute `fac`'s numeric values from a matrix with the
+/// SAME sparsity pattern, reusing its symbolic structure and pivot sequence --
+/// no BTF/ordering, no reach DFS, no pivot search -- and install them while
+/// KEEPING the factor pattern and the coupled solve schedules (#310). This is the
+/// allocation-light form of the fast path for repeated solves of a fixed pattern
+/// with changing values (e.g. SPICE transient analysis: one factor, many
+/// refactor); nothing is copied but the recomputed values.
 ///
-/// Preconditions: A has the same column ordering (prev.symbolic) and the same
-/// nonzero pattern that produced prev. Relies on prev.L / prev.U columns being
+/// Preconditions: A has the same column ordering (fac.symbolic) and the same
+/// nonzero pattern that produced fac. Relies on fac.L / fac.U columns being
 /// stored in ascending row order (as sparse_lu_numeric produces).
+///
+/// Strong exception guarantee: the values are computed into scratch arrays and
+/// installed only after the last column succeeds, so a throw leaves `fac` exactly
+/// as it was -- still solvable with its previous values.
 ///
 /// \throws std::runtime_error if a reused pivot is numerically zero for the new
 ///         values (the prior pivot sequence is no longer valid).
 template <typename Value, typename Parameters>
     requires OrderedField<Value>
-lu_numeric<Value> sparse_lu_refactor(
+void sparse_lu_refactor_in_place(
     const mat::compressed2D<Value, Parameters>& A,
-    const lu_numeric<Value>& prev)
+    lu_numeric<Value>& fac)
 {
     using size_type = std::size_t;
-    size_type n = prev.symbolic.n;
+    size_type n = fac.symbolic.n;
     if (A.num_rows() != n || A.num_cols() != n) {
         throw std::invalid_argument(
             "sparse_lu_refactor: matrix dimensions do not match prior factorization");
     }
+    // The replay below indexes fac's factor pattern; with no factor installed
+    // those arrays are empty and the walk would run off the end.
+    if (!fac.has_factor()) {
+        throw std::logic_error(
+            "sparse_lu_refactor: prior factorization has no factor installed");
+    }
 
-    auto AQ = util::column_permute(A, prev.symbolic.col_perm);
+    auto AQ = util::column_permute(A, fac.symbolic.col_perm);
     auto C  = util::crs_to_csc(AQ);
 
-    const auto& pinv = prev.row_pinv;    // original row -> pivot position (fixed)
-    // Local mutable copies of the prior factors: same pattern, values recomputed
-    // in place below, then installed via set_factor (which rebuilds the coupled
-    // solve schedules). refactor throws on a zero pivot; no perturbation.
-    auto L = prev.factorL();
-    auto U = prev.factorU();
+    const auto& pinv = fac.row_pinv;     // original row -> pivot position (fixed)
+    // The installed factors' PATTERN is reused verbatim (read-only); only the
+    // values are recomputed, into scratch arrays laid out on that pattern. Every
+    // position is written by the column that owns it before any later column reads
+    // it, so the zero-initialization is just placeholder storage. Installing these
+    // via set_factor_values keeps the existing solve schedules (value-agnostic,
+    // and valid for an unchanged pattern) instead of rebuilding them. Throws on a
+    // zero pivot; no perturbation.
+    const util::csc_matrix<Value>& L = fac.factorL();
+    const util::csc_matrix<Value>& U = fac.factorU();
+    std::vector<Value> Lx(L.values.size(), Value{0});
+    std::vector<Value> Ux(U.values.size(), Value{0});
 
     std::vector<Value> x(n, Value{0});
 
@@ -554,9 +599,10 @@ lu_numeric<Value> sparse_lu_refactor(
             size_type j = U.row_ind[p];
             Value xj = x[j];
             if (xj == Value{0}) continue;
-            // L(:,j): diagonal (row j, value 1) is first -> skip it.
+            // L(:,j): diagonal (row j, value 1) is first -> skip it. j < k, so
+            // Lx(:,j) already holds this refactorization's values.
             for (size_type q = L.col_ptr[j] + 1; q < L.col_ptr[j + 1]; ++q)
-                x[L.row_ind[q]] -= L.values[q] * xj;
+                x[L.row_ind[q]] -= Lx[q] * xj;
         }
 
         Value pivot = x[k];
@@ -568,12 +614,12 @@ lu_numeric<Value> sparse_lu_refactor(
 
         // Write U(:,k) values (all rows <= k, including the diagonal = pivot).
         for (size_type p = ubeg; p < uend; ++p)
-            U.values[p] = x[U.row_ind[p]];
+            Ux[p] = x[U.row_ind[p]];
 
         // Write L(:,k): unit diagonal first, then x[row]/pivot below.
         for (size_type p = L.col_ptr[k]; p < L.col_ptr[k + 1]; ++p) {
             size_type r = L.row_ind[p];
-            L.values[p] = (r == k) ? Value{1} : x[r] / pivot;
+            Lx[p] = (r == k) ? Value{1} : x[r] / pivot;
         }
 
         // Clear the workspace. Clear the U/L pattern AND the scattered A column:
@@ -586,14 +632,30 @@ lu_numeric<Value> sparse_lu_refactor(
         for (size_type p = C.col_ptr[k]; p < C.col_ptr[k + 1]; ++p) x[pinv[C.row_ind[p]]] = Value{0};
     }
 
-    // Reuse the prior symbolic analysis and permutations; install the recomputed
-    // factors, which rebuilds the coupled solve schedules for the new values.
-    lu_numeric<Value> result;
-    result.symbolic = prev.symbolic;
-    result.row_perm = prev.row_perm;
-    result.row_pinv = prev.row_pinv;
-    result.num_perturbed = 0;   // refactor recomputes values without perturbing
-    result.set_factor(std::move(L), std::move(U));
+    // Install only the values: the symbolic analysis, permutations, factor pattern
+    // and both solve schedules stay exactly as they were. The schedules are
+    // value-agnostic and the pattern is unchanged, so rebuilding them here would
+    // reproduce them entry for entry at O(nnz) cost per refactor.
+    // The validating install goes first: everything after it is noexcept, so a
+    // rejected install leaves `fac` wholly unchanged.
+    fac.set_factor_values(std::move(Lx), std::move(Ux));
+    fac.num_perturbed = 0;      // refactor recomputes values without perturbing
+}
+
+/// Refactorize into a NEW factorization object, leaving `prev` untouched: a copy
+/// of prev (symbolic analysis, permutations, factor pattern and solve schedules)
+/// refactorized in place. Prefer sparse_lu_refactor_in_place in a transient loop
+/// that overwrites its factorization anyway -- it skips this copy.
+/// Same preconditions and exceptions as sparse_lu_refactor_in_place; on a throw
+/// `prev` is untouched (the copy is discarded).
+template <typename Value, typename Parameters>
+    requires OrderedField<Value>
+lu_numeric<Value> sparse_lu_refactor(
+    const mat::compressed2D<Value, Parameters>& A,
+    const lu_numeric<Value>& prev)
+{
+    lu_numeric<Value> result = prev;
+    sparse_lu_refactor_in_place(A, result);
     return result;
 }
 

--- a/include/mtl/sparse/factorization/supernodal_lu.hpp
+++ b/include/mtl/sparse/factorization/supernodal_lu.hpp
@@ -99,6 +99,31 @@ struct supernodal_lu_factor {
         has_factor_ = true;              // commit last: solve() is now valid
     }
 
+    /// True once factors (and their coupled schedules) have been installed.
+    bool has_factor() const { return has_factor_; }
+
+    /// Install recomputed VALUES on the already-installed factor pattern, keeping
+    /// the existing solve schedules (see lu_numeric::set_factor_values). The
+    /// schedules cache positions into L_.values / U_.values, not the values, so a
+    /// same-pattern refactorization skips the O(nnz) rebuild set_factor pays.
+    /// Requires a factor already installed and value arrays of exactly the
+    /// installed nnz; the schedules' built_nnz staleness guards are re-checked, so
+    /// a pattern change cannot slip through (use set_factor for that).
+    /// Strongly exception safe: all validation precedes any member replacement.
+    void set_factor_values(std::vector<Value> Lvals, std::vector<Value> Uvals) {
+        if (!has_factor_)
+            throw std::logic_error(
+                "supernodal_lu_factor::set_factor_values: no factor installed "
+                "(call set_factor first)");
+        if (Lvals.size() != L_.values.size() || Uvals.size() != U_.values.size() ||
+            fwd_sched_.built_nnz != Lvals.size() || up_sched_.built_nnz != Uvals.size())
+            throw std::invalid_argument(
+                "supernodal_lu_factor::set_factor_values: value count does not match the "
+                "installed factor pattern (use set_factor for a pattern change)");
+        L_.values = std::move(Lvals);   // noexcept
+        U_.values = std::move(Uvals);   // noexcept
+    }
+
     /// Solve A*x = b.  P*A*Q = L*U (identical to lu_numeric::solve).
     template <typename VecX, typename VecB>
     void solve(VecX& x, const VecB& b) const {
@@ -526,37 +551,47 @@ supernodal_lu_factor<Value> supernodal_lu_numeric(
     return result;
 }
 
-/// Refactorize a matrix with the SAME sparsity pattern as a prior factorization,
-/// reusing its analyze + pivot/supernode pattern. Only numeric values are
-/// recomputed: no ordering, no reach DFS, no pivot search, no supernode
-/// detection -- the fast path for repeated solves of a fixed pattern with
-/// changing values (transient SPICE: one analyze+factor, many refactors). The
-/// stored L/U columns are in topological (ascending-row) order, so the values
-/// replay directly. Mirrors sparse_lu_refactor.
+/// Refactorize IN PLACE: recompute `fac`'s numeric values from a matrix with the
+/// SAME sparsity pattern, reusing its analyze + pivot/supernode pattern -- no
+/// ordering, no reach DFS, no pivot search, no supernode detection -- and install
+/// them while KEEPING the factor pattern and the coupled solve schedules (#310).
+/// The allocation-light fast path for repeated solves of a fixed pattern with
+/// changing values (transient SPICE: one analyze+factor, many refactors); nothing
+/// is copied but the recomputed values. The stored L/U columns are in topological
+/// (ascending-row) order, so the values replay directly. Mirrors
+/// sparse_lu_refactor_in_place.
 ///
-/// Preconditions: A uses prev's column ordering and the same nonzero pattern.
+/// Preconditions: A uses fac's column ordering and the same nonzero pattern.
+/// Strong exception guarantee: values are computed into scratch arrays and
+/// installed only after the last column succeeds, so a throw leaves `fac` exactly
+/// as it was.
 /// \throws std::runtime_error if a reused pivot is numerically zero for the new
 ///         values (the prior pivot sequence is no longer valid).
 template <typename Value, typename Parameters>
     requires OrderedField<Value>
-supernodal_lu_factor<Value> supernodal_lu_refactor(
+void supernodal_lu_refactor_in_place(
     const mat::compressed2D<Value, Parameters>& A,
-    const supernodal_lu_factor<Value>& prev)
+    supernodal_lu_factor<Value>& fac)
 {
     using size_type = std::size_t;
-    const size_type n = prev.symbolic.n;
+    const size_type n = fac.symbolic.n;
     if (A.num_rows() != n || A.num_cols() != n)
         throw std::invalid_argument(
             "supernodal_lu_refactor: matrix dimensions do not match prior factorization");
+    // The replay below indexes fac's factor pattern; with no factor installed
+    // those arrays are empty and the walk would run off the end.
+    if (!fac.has_factor())
+        throw std::logic_error(
+            "supernodal_lu_refactor: prior factorization has no factor installed");
 
     using std::abs;
-    auto C = util::crs_to_csc(util::column_permute(A, prev.symbolic.col_perm));
-    const auto& pinv = prev.row_pinv;        // original row -> pivot position (fixed)
+    auto C = util::crs_to_csc(util::column_permute(A, fac.symbolic.col_perm));
+    const auto& pinv = fac.row_pinv;         // original row -> pivot position (fixed)
 
     // If the prior factorization was row-equilibrated, re-equilibrate the new
     // values (same pattern) and factor R*A; solve() row-scales the RHS by R.
-    std::vector<Value> row_scale;            // empty unless prev was equilibrated
-    if (!prev.row_scale.empty()) {
+    std::vector<Value> row_scale;            // empty unless fac was equilibrated
+    if (!fac.row_scale.empty()) {
         std::vector<Value> rmax(n, Value{0});
         for (size_type p = 0; p < C.values.size(); ++p) {
             Value a = abs(C.values[p]);
@@ -569,11 +604,17 @@ supernodal_lu_factor<Value> supernodal_lu_refactor(
             C.values[p] *= row_scale[C.row_ind[p]];
     }
 
-    // Local mutable copies of the prior factors: same pattern, values recomputed
-    // in place below, then installed via set_factor (which rebuilds the coupled
-    // solve schedules). refactor throws on a zero pivot; no perturbation.
-    auto L = prev.factorL();
-    auto U = prev.factorU();
+    // The installed factors' PATTERN is reused verbatim (read-only); only the
+    // values are recomputed, into scratch arrays laid out on that pattern. Every
+    // position is written by the column that owns it before any later column reads
+    // it, so the zero-initialization is just placeholder storage. Installing these
+    // via set_factor_values keeps the existing solve schedules (value-agnostic,
+    // and valid for an unchanged pattern) instead of rebuilding them. Throws on a
+    // zero pivot; no perturbation.
+    const util::csc_matrix<Value>& L = fac.factorL();
+    const util::csc_matrix<Value>& U = fac.factorU();
+    std::vector<Value> Lx(L.values.size(), Value{0});
+    std::vector<Value> Ux(U.values.size(), Value{0});
 
     std::vector<Value> x(n, Value{0});
     for (size_type k = 0; k < n; ++k) {
@@ -589,8 +630,9 @@ supernodal_lu_factor<Value> supernodal_lu_refactor(
             const size_type j = U.row_ind[p];
             const Value xj = x[j];
             if (xj == Value{0}) continue;
+            // j < k, so Lx(:,j) already holds this refactorization's values.
             for (size_type q = L.col_ptr[j] + 1; q < L.col_ptr[j + 1]; ++q)  // skip unit diagonal
-                x[L.row_ind[q]] -= L.values[q] * xj;
+                x[L.row_ind[q]] -= Lx[q] * xj;
         }
 
         const Value pivot = x[k];
@@ -599,10 +641,10 @@ supernodal_lu_factor<Value> supernodal_lu_refactor(
                 "supernodal_lu_refactor: zero pivot at column " + std::to_string(k)
                 + " (prior pivot sequence invalid for the new values)");
 
-        for (size_type p = ubeg; p < uend; ++p) U.values[p] = x[U.row_ind[p]];
+        for (size_type p = ubeg; p < uend; ++p) Ux[p] = x[U.row_ind[p]];
         for (size_type p = L.col_ptr[k]; p < L.col_ptr[k + 1]; ++p) {
             const size_type r = L.row_ind[p];
-            L.values[p] = (r == k) ? Value{1} : x[r] / pivot;
+            Lx[p] = (r == k) ? Value{1} : x[r] / pivot;
         }
 
         // Clear the workspace over the touched positions (U/L pattern and the
@@ -612,16 +654,31 @@ supernodal_lu_factor<Value> supernodal_lu_refactor(
         for (size_type p = C.col_ptr[k]; p < C.col_ptr[k + 1]; ++p) x[pinv[C.row_ind[p]]] = Value{0};
     }
 
-    // Reuse the prior symbolic analysis, permutations, and supernode boundaries;
-    // install the recomputed factors, which rebuilds the coupled solve schedules.
-    supernodal_lu_factor<Value> result;
-    result.symbolic = prev.symbolic;
-    result.row_perm = prev.row_perm;
-    result.row_pinv = prev.row_pinv;
-    result.lsuper_first = prev.lsuper_first;
-    result.row_scale = std::move(row_scale);
-    result.num_perturbed = 0;    // refactor replays values without perturbing (throws on zero pivot)
-    result.set_factor(std::move(L), std::move(U));
+    // Install only the values: the symbolic analysis, permutations, supernode
+    // boundaries, factor pattern and both solve schedules stay as they were. The
+    // schedules are value-agnostic and the pattern is unchanged, so rebuilding
+    // them here would reproduce them entry for entry at O(nnz) cost per refactor.
+    // The validating install goes first: everything after it is noexcept, so a
+    // rejected install leaves `fac` wholly unchanged (row scaling included).
+    fac.set_factor_values(std::move(Lx), std::move(Ux));
+    fac.row_scale = std::move(row_scale);   // recomputed above (empty if unscaled)
+    fac.num_perturbed = 0;   // refactor replays values without perturbing (throws on zero pivot)
+}
+
+/// Refactorize into a NEW factor object, leaving `prev` untouched: a copy of prev
+/// (symbolic analysis, permutations, supernode boundaries, factor pattern and
+/// solve schedules) refactorized in place. Prefer supernodal_lu_refactor_in_place
+/// in a transient loop that overwrites its factorization anyway -- it skips this
+/// copy. Same preconditions and exceptions as supernodal_lu_refactor_in_place; on
+/// a throw `prev` is untouched (the copy is discarded).
+template <typename Value, typename Parameters>
+    requires OrderedField<Value>
+supernodal_lu_factor<Value> supernodal_lu_refactor(
+    const mat::compressed2D<Value, Parameters>& A,
+    const supernodal_lu_factor<Value>& prev)
+{
+    supernodal_lu_factor<Value> result = prev;
+    supernodal_lu_refactor_in_place(A, result);
     return result;
 }
 

--- a/tests/unit/sparse/test_sparse_lu_refactor.cpp
+++ b/tests/unit/sparse/test_sparse_lu_refactor.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <stdexcept>
 #include <vector>
 
 #include <mtl/mat/compressed2D.hpp>
@@ -90,6 +91,108 @@ TEST_CASE("refactor solves a same-pattern matrix with new values",
         REQUIRE_THAT(x_re(static_cast<int>(i)),
                      WithinAbs(x_fresh(static_cast<int>(i)), 1e-9));
     REQUIRE(residual_inf(A2, x_re, b) < 1e-9);
+}
+
+// -- schedule reuse (#310) ---------------------------------------------------
+// refactor installs the recomputed values through set_factor_values, which keeps
+// the prior forward/upper solve schedules instead of rebuilding them. The
+// schedules are value-agnostic (positions into the factors' value arrays), and
+// the pattern is unchanged, so a rebuild would reproduce them entry for entry --
+// which is exactly what these assert, by comparing against the rebuild path.
+
+TEST_CASE("refactor's reused schedules solve bit-identically to rebuilt ones",
+          "[sparse][lu][refactor][schedule]") {
+    std::size_t n = 48;
+    auto num = sparse::factorization::sparse_lu_numeric(
+        tridiag(n, 4.0), sparse::factorization::sparse_lu_symbolic(tridiag(n, 4.0)));
+
+    auto A2 = tridiag(n, 6.25);
+    auto re = sparse::factorization::sparse_lu_refactor(A2, num);   // reuses schedules
+
+    // Same factors, installed through set_factor -- which REBUILDS both schedules.
+    sparse::factorization::lu_numeric<double> rebuilt;
+    rebuilt.symbolic = re.symbolic;
+    rebuilt.row_perm = re.row_perm;
+    rebuilt.row_pinv = re.row_pinv;
+    rebuilt.set_factor(re.factorL(), re.factorU());
+
+    vec::dense_vector<double> b(n), x_re(n, 0.0), x_rb(n, 0.0);
+    for (std::size_t i = 0; i < n; ++i)
+        b(static_cast<int>(i)) = 1.0 + 0.125 * static_cast<double>(i % 7);
+    re.solve(x_re, b);
+    rebuilt.solve(x_rb, b);
+
+    for (std::size_t i = 0; i < n; ++i)   // exact: identical schedules, identical values
+        REQUIRE(x_re(static_cast<int>(i)) == x_rb(static_cast<int>(i)));
+
+    // The pattern is carried over untouched -- that is what makes reuse valid.
+    REQUIRE(re.factorL().col_ptr == num.factorL().col_ptr);
+    REQUIRE(re.factorL().row_ind == num.factorL().row_ind);
+    REQUIRE(re.factorU().col_ptr == num.factorU().col_ptr);
+    REQUIRE(re.factorU().row_ind == num.factorU().row_ind);
+
+    // The in-place form (no copy at all) produces the identical factorization.
+    auto inplace = num;
+    sparse::factorization::sparse_lu_refactor_in_place(A2, inplace);
+    REQUIRE(inplace.factorL().values == re.factorL().values);
+    REQUIRE(inplace.factorU().values == re.factorU().values);
+    vec::dense_vector<double> x_ip(n, 0.0);
+    inplace.solve(x_ip, b);
+    for (std::size_t i = 0; i < n; ++i)
+        REQUIRE(x_ip(static_cast<int>(i)) == x_re(static_cast<int>(i)));
+}
+
+TEST_CASE("a failed in-place refactor leaves the factorization intact",
+          "[sparse][lu][refactor][schedule]") {
+    std::size_t n = 16;
+    auto A = tridiag(n, 4.0);
+    auto fac = sparse::factorization::sparse_lu_numeric(
+        A, sparse::factorization::sparse_lu_symbolic(A));
+    const auto Lvals = fac.factorL().values;
+    const auto Uvals = fac.factorU().values;
+
+    // Same pattern, zero diagonal -> the replayed pivot sequence hits a zero pivot.
+    REQUIRE_THROWS_AS(
+        sparse::factorization::sparse_lu_refactor_in_place(tridiag(n, 0.0), fac),
+        std::runtime_error);
+
+    // Values are installed only after the last column succeeds, so fac is unchanged
+    // and still solves the system it was factored from.
+    REQUIRE(fac.factorL().values == Lvals);
+    REQUIRE(fac.factorU().values == Uvals);
+    vec::dense_vector<double> b(n, 1.0), x(n, 0.0);
+    fac.solve(x, b);
+    REQUIRE(residual_inf(A, x, b) < 1e-10);
+}
+
+TEST_CASE("set_factor_values rejects a pattern change and a missing factor",
+          "[sparse][lu][refactor][schedule]") {
+    std::size_t n = 12;
+    auto A = tridiag(n, 4.0);
+    auto num = sparse::factorization::sparse_lu_numeric(
+        A, sparse::factorization::sparse_lu_symbolic(A));
+
+    // Value arrays of the installed nnz: accepted, and the solve still works.
+    auto Lx = num.factorL().values;
+    auto Ux = num.factorU().values;
+    REQUIRE_NOTHROW(num.set_factor_values(Lx, Ux));
+    vec::dense_vector<double> b(n, 1.0), x(n, 0.0);
+    num.solve(x, b);
+    REQUIRE(residual_inf(A, x, b) < 1e-10);
+
+    // A different nnz would leave the schedules stale -> rejected.
+    Lx.push_back(1.0);
+    REQUIRE_THROWS_AS(num.set_factor_values(Lx, Ux), std::invalid_argument);
+    Lx.pop_back();
+    Ux.pop_back();
+    REQUIRE_THROWS_AS(num.set_factor_values(Lx, Ux), std::invalid_argument);
+
+    // No factor installed: there is no pattern to install values on.
+    sparse::factorization::lu_numeric<double> empty;
+    empty.symbolic.n = n;
+    REQUIRE_THROWS_AS(empty.set_factor_values({}, {}), std::logic_error);
+    REQUIRE_THROWS_AS(sparse::factorization::sparse_lu_refactor(A, empty),
+                      std::logic_error);
 }
 
 TEST_CASE("repeated refactor is stable across many value updates",

--- a/tests/unit/sparse/test_supernodal_lu.cpp
+++ b/tests/unit/sparse/test_supernodal_lu.cpp
@@ -130,6 +130,72 @@ TEST_CASE("Supernodal LU refactor reuses the pattern", "[sparse][lu][supernodal]
     }
 }
 
+// ---- schedule reuse across refactor (#310) --------------------------------
+// refactor installs the recomputed values through set_factor_values, keeping the
+// prior forward/upper solve schedules. Those schedules are value-agnostic
+// (positions into the factors' value arrays) and the pattern is unchanged, so a
+// rebuild would reproduce them entry for entry -- asserted here by comparing the
+// solve against the same factors installed through the rebuilding set_factor.
+TEST_CASE("Supernodal LU refactor reuses the solve schedules",
+          "[sparse][lu][supernodal][refactor][schedule]") {
+    auto A1 = random_unsym(50, 0.08, 11);
+    auto sym = factorization::supernodal_lu_symbolic_analyze(A1, ordering::colamd{});
+    auto fac = factorization::supernodal_lu_numeric(A1, sym);
+
+    auto A2 = A1;   // same pattern, perturbed values
+    { auto& d = const_cast<std::vector<double>&>(A2.ref_data());
+      for (std::size_t k = 0; k < d.size(); ++k) d[k] *= (1.0 + 0.05 * std::cos(0.7 * k)); }
+
+    auto re = factorization::supernodal_lu_refactor(A2, fac);   // reuses schedules
+
+    // Pattern carried over untouched -- what makes the reuse valid.
+    REQUIRE(re.factorL().col_ptr == fac.factorL().col_ptr);
+    REQUIRE(re.factorL().row_ind == fac.factorL().row_ind);
+    REQUIRE(re.factorU().col_ptr == fac.factorU().col_ptr);
+    REQUIRE(re.factorU().row_ind == fac.factorU().row_ind);
+
+    // Same factors installed through set_factor, which REBUILDS both schedules.
+    factorization::supernodal_lu_factor<double> rebuilt;
+    rebuilt.symbolic = re.symbolic;
+    rebuilt.row_perm = re.row_perm;
+    rebuilt.row_pinv = re.row_pinv;
+    rebuilt.lsuper_first = re.lsuper_first;
+    rebuilt.row_scale = re.row_scale;
+    rebuilt.set_factor(re.factorL(), re.factorU());
+
+    const std::size_t n = A2.num_rows();
+    vec::dense_vector<double> b(n), x_re(n, 0.0), x_rb(n, 0.0);
+    for (std::size_t i = 0; i < n; ++i)
+        b(static_cast<int>(i)) = 1.0 + 0.125 * static_cast<double>(i % 7);
+    re.solve(x_re, b);
+    rebuilt.solve(x_rb, b);
+    for (std::size_t i = 0; i < n; ++i)   // exact: identical schedules, identical values
+        REQUIRE(x_re(static_cast<int>(i)) == x_rb(static_cast<int>(i)));
+
+    // The in-place form (no copy at all) produces the identical factorization.
+    auto inplace = fac;
+    factorization::supernodal_lu_refactor_in_place(A2, inplace);
+    REQUIRE(inplace.factorL().values == re.factorL().values);
+    REQUIRE(inplace.factorU().values == re.factorU().values);
+    vec::dense_vector<double> x_ip(n, 0.0);
+    inplace.solve(x_ip, b);
+    for (std::size_t i = 0; i < n; ++i)
+        REQUIRE(x_ip(static_cast<int>(i)) == x_re(static_cast<int>(i)));
+
+    // A value install that would leave the schedules stale is rejected, and so is
+    // a refactor from a factor-less prior.
+    auto Lx = re.factorL().values;
+    auto Ux = re.factorU().values;
+    REQUIRE_NOTHROW(re.set_factor_values(Lx, Ux));
+    Lx.push_back(1.0);
+    REQUIRE_THROWS_AS(re.set_factor_values(Lx, Ux), std::invalid_argument);
+
+    factorization::supernodal_lu_factor<double> empty;
+    empty.symbolic = sym;
+    REQUIRE_THROWS_AS(empty.set_factor_values({}, {}), std::logic_error);
+    REQUIRE_THROWS_AS(factorization::supernodal_lu_refactor(A2, empty), std::logic_error);
+}
+
 // ---- row equilibration / scaling (#185) -----------------------------------
 TEST_CASE("Supernodal LU row scaling", "[sparse][lu][supernodal][scale]") {
     // Badly row-scaled SPD-ish matrix: rows multiplied by a large dynamic range.


### PR DESCRIPTION
## Summary

The `*_refactor` fast paths reused a prior factorization's pattern and recomputed only numeric values, then installed through `set_factor` — which **always** rebuilds both level-solve schedules from the factor's pattern. That rebuild is O(nnz) of pure overhead on the transient hot path (mp-spice: one analyze/factor, many refactors).

The schedules are **value-agnostic** — they cache positions into the factor's value arrays, not the values — and a same-pattern refactor leaves `col_ptr`/`row_ind` byte-identical, so the prior schedules stay valid for the new values.

## Changes

- `include/mtl/sparse/factorization/sparse_lu.hpp`
  - `lu_numeric::has_factor()` and `lu_numeric::set_factor_values(Lvals, Uvals)` — value-only install that keeps the existing schedules. Validates that a factor is installed and that the value counts match both the installed nnz **and** the schedules' `built_nnz` staleness guards, so a pattern change cannot slip through silently; `set_factor` remains the entry point for that.
  - `sparse_lu_refactor_in_place(A, fac)` — new allocation-light entry point: replays the values on the installed pattern and installs them without copying or rebuilding anything. Values go into scratch arrays and are installed only after the last column succeeds, so a zero pivot leaves `fac` exactly as it was.
  - `sparse_lu_refactor(A, prev)` keeps its signature and is now a copy of `prev` refactorized in place.
- `include/mtl/sparse/factorization/supernodal_lu.hpp` — the same three additions for `supernodal_lu_factor` / `supernodal_lu_refactor`, with the row-equilibration recompute preserved.
- `native_klu_refactor` inherits the change through its per-block `sparse_lu_refactor` call (unmodified).
- `tests/unit/sparse/test_sparse_lu_refactor.cpp` — reused schedules solve **bit-identically** (`==`) to the same factors installed through the rebuilding `set_factor`; in-place and returning forms produce identical factors; pattern carried over untouched; `set_factor_values` rejects a stale-making install and a factor-less object; a failed in-place refactor leaves the factorization solvable with its previous values.
- `tests/unit/sparse/test_supernodal_lu.cpp` — the same coverage for the supernodal factor.

## Performance

6400-DOF 5-point grid, `nnz(L)+nnz(U) = 390K`, GCC -O2, 25 refactors/run, min of 5 runs:

| path | ms / refactor |
|------|---------------|
| `sparse_lu_refactor` (main) | 26.3 |
| `sparse_lu_refactor` (this PR) | 25.7 |
| `sparse_lu_refactor_in_place` (this PR) | **20.3** |

**23% faster** per refactor via the in-place path, with markedly less run-to-run variance (no large allocations). The returning form saves the rebuild but spends it again copying `prev`, so it lands roughly where it was — the in-place entry point is where the win is, and it is what a transient loop should call.

## Test Results

| Suite | gcc build | gcc test | clang build | clang test |
|-------|-----------|----------|-------------|------------|
| full unit suite (163 tests) | OK | 163/163 PASS | OK | 163/163 PASS |

## Test plan
- [ ] Tier 1 CI passes (8 platforms)
- [ ] Promote to ready when satisfied: `gh pr ready <N>`

Resolves #310

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-place sparse LU refactorization to update factor values while preserving sparsity patterns and solve schedules.
  * Added support for replacing installed factor values with validation.
  * Added factorization-state checks to identify whether factors are available.

* **Bug Fixes**
  * Refactorization now preserves the existing factorization if an update fails.
  * Improved validation for incompatible value arrays and missing factors.

* **Tests**
  * Added coverage for schedule reuse, rollback behavior, pattern preservation, and equivalent solve results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->