### PR TITLE
perf(mat): flatten the dense-matrix element-wise sweep over rows and columns

### DIFF
--- a/include/mtl/detail/ewise.hpp
+++ b/include/mtl/detail/ewise.hpp
@@ -46,7 +46,8 @@ inline void parallel_ewise(std::size_t n, std::size_t work_per_elem, Body&& body
 /// within a chunk is the serial nested loop's, every element is produced by
 /// exactly one chunk, and the per-element computation does not depend on which
 /// thread runs it -- so the result is BIT-IDENTICAL to the serial loop and to any
-/// other thread count. Serial (a single body call) at MTL5_NUM_THREADS=1.
+/// other thread count. At MTL5_NUM_THREADS=1 the whole space is one chunk on the
+/// calling thread -- no parallel dispatch -- with body still invoked per element.
 template <typename Body>
 inline void parallel_ewise_2d(std::size_t rows, std::size_t cols,
                               std::size_t work_per_elem, Body&& body) {

--- a/include/mtl/detail/ewise.hpp
+++ b/include/mtl/detail/ewise.hpp
@@ -7,9 +7,10 @@
 // shape. Because each output element is produced by exactly one contiguous chunk
 // and the per-element computation is identical regardless of which thread runs
 // it, contiguous deterministic chunking makes the parallel result BIT-IDENTICAL
-// to the serial loop -- no accumulation order to preserve. Serial (a single body
-// call) at MTL5_NUM_THREADS=1, so the default build pays zero overhead and stays
-// byte-identical to a plain loop.
+// to the serial loop -- no accumulation order to preserve. At MTL5_NUM_THREADS=1
+// the whole index space is one chunk on the calling thread (no parallel
+// dispatch; body is still invoked per index), so the default build pays zero
+// overhead and stays byte-identical to a plain loop.
 
 #include <algorithm>
 #include <cstddef>

--- a/include/mtl/detail/ewise.hpp
+++ b/include/mtl/detail/ewise.hpp
@@ -31,4 +31,36 @@ inline void parallel_ewise(std::size_t n, std::size_t work_per_elem, Body&& body
     });
 }
 
+/// Run body(r, c) for every element of a rows x cols index space, in row-major
+/// order, across the pool. The 2D space is FLATTENED to a linear element index
+/// [0, rows*cols) before chunking, so the work splits on the element count rather
+/// than the row count: a wide/short expression (1 x N) parallelizes exactly like a
+/// tall one (N x 1), which a row-per-unit decomposition cannot do (#313).
+///
+/// `work_per_elem` estimates the per-ELEMENT cost (1 for an ordinary element-wise
+/// expression), so the grain targets ~64K work units per chunk -- the same chunk
+/// size in elements the row-per-unit form produced for tall matrices.
+///
+/// Each chunk walks (r, c) incrementally from one division at its start, so the
+/// per-element cost is an increment and a compare, not a div/mod. The visit order
+/// within a chunk is the serial nested loop's, every element is produced by
+/// exactly one chunk, and the per-element computation does not depend on which
+/// thread runs it -- so the result is BIT-IDENTICAL to the serial loop and to any
+/// other thread count. Serial (a single body call) at MTL5_NUM_THREADS=1.
+template <typename Body>
+inline void parallel_ewise_2d(std::size_t rows, std::size_t cols,
+                              std::size_t work_per_elem, Body&& body) {
+    if (rows == 0 || cols == 0) return;   // nothing to sweep; keeps the % below safe
+    const std::size_t w = work_per_elem < 1 ? 1 : work_per_elem;
+    const std::size_t grain = std::max<std::size_t>(std::size_t{1}, std::size_t{65536} / w);
+    thread_pool::instance().parallel_for(
+        rows * cols, grain, [&](std::size_t b, std::size_t e) {
+            std::size_t r = b / cols, c = b % cols;
+            for (std::size_t t = b; t < e; ++t) {
+                body(r, c);
+                if (++c == cols) { c = 0; ++r; }
+            }
+        });
+}
+
 } // namespace mtl::detail

--- a/include/mtl/mat/dense2D.hpp
+++ b/include/mtl/mat/dense2D.hpp
@@ -152,12 +152,13 @@ public:
         : dense2D(static_cast<size_type>(expr.num_rows()),
                    static_cast<size_type>(expr.num_cols()))
     {
-        // Element-wise sweep over rows: each (r,c) element is independent, so the
-        // contiguous row chunking is bit-identical to the serial nested loop
-        // (serial at MTL5_NUM_THREADS=1). See mtl/detail/ewise.hpp.
-        detail::parallel_ewise(num_rows(), num_cols(), [&](std::size_t r) {
-            for (size_type c = 0; c < num_cols(); ++c)
-                (*this)(r, c) = static_cast<Value>(expr(r, c));
+        // Element-wise sweep over the FLATTENED (r,c) space: each element is
+        // independent, so the contiguous element chunking is bit-identical to the
+        // serial nested loop, and a wide/short expression splits just like a tall
+        // one (serial at MTL5_NUM_THREADS=1). See mtl/detail/ewise.hpp.
+        detail::parallel_ewise_2d(num_rows(), num_cols(), 1,
+                                  [&](std::size_t r, std::size_t c) {
+            (*this)(r, c) = static_cast<Value>(expr(r, c));
         });
     }
 
@@ -167,9 +168,9 @@ public:
     dense2D& operator=(const Expr& expr) {
         change_dim(static_cast<size_type>(expr.num_rows()),
                    static_cast<size_type>(expr.num_cols()));
-        detail::parallel_ewise(num_rows(), num_cols(), [&](std::size_t r) {
-            for (size_type c = 0; c < num_cols(); ++c)
-                (*this)(r, c) = static_cast<Value>(expr(r, c));
+        detail::parallel_ewise_2d(num_rows(), num_cols(), 1,
+                                  [&](std::size_t r, std::size_t c) {
+            (*this)(r, c) = static_cast<Value>(expr(r, c));
         });
         return *this;
     }
@@ -179,9 +180,9 @@ public:
                   && std::convertible_to<typename Expr::value_type, Value>)
     dense2D& operator+=(const Expr& expr) {
         assert(num_rows() == expr.num_rows() && num_cols() == expr.num_cols());
-        detail::parallel_ewise(num_rows(), num_cols(), [&](std::size_t r) {
-            for (size_type c = 0; c < num_cols(); ++c)
-                (*this)(r, c) += static_cast<Value>(expr(r, c));
+        detail::parallel_ewise_2d(num_rows(), num_cols(), 1,
+                                  [&](std::size_t r, std::size_t c) {
+            (*this)(r, c) += static_cast<Value>(expr(r, c));
         });
         return *this;
     }
@@ -191,9 +192,9 @@ public:
                   && std::convertible_to<typename Expr::value_type, Value>)
     dense2D& operator-=(const Expr& expr) {
         assert(num_rows() == expr.num_rows() && num_cols() == expr.num_cols());
-        detail::parallel_ewise(num_rows(), num_cols(), [&](std::size_t r) {
-            for (size_type c = 0; c < num_cols(); ++c)
-                (*this)(r, c) -= static_cast<Value>(expr(r, c));
+        detail::parallel_ewise_2d(num_rows(), num_cols(), 1,
+                                  [&](std::size_t r, std::size_t c) {
+            (*this)(r, c) -= static_cast<Value>(expr(r, c));
         });
         return *this;
     }

--- a/tests/unit/operation/test_ewise_sweep_mt.cpp
+++ b/tests/unit/operation/test_ewise_sweep_mt.cpp
@@ -15,11 +15,16 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdlib>
+#include <functional>
+#include <thread>
+#include <unordered_set>
+#include <vector>
 
 #include <mtl/vec/dense_vector.hpp>
 #include <mtl/vec/operators.hpp>
 #include <mtl/mat/dense2D.hpp>
 #include <mtl/mat/operators.hpp>
+#include <mtl/detail/ewise.hpp>
 #include <mtl/detail/thread_pool.hpp>
 
 using namespace mtl;
@@ -39,6 +44,32 @@ double vv(std::size_t i) { return 0.5 + std::sin(0.7 * static_cast<double>(i)); 
 double ww(std::size_t i) { return -0.25 + std::cos(0.31 * static_cast<double>(i)); }
 
 } // namespace
+
+/// Minimal matrix expression that records which thread evaluated each element, so
+/// a test can observe how a dense2D assignment distributed the sweep (#313).
+/// operator() is const and writes one distinct slot per (r,c) -- no race.
+/// At namespace scope (not unnamed) so the is_expression specialization below
+/// names it unambiguously.
+struct probe_expr {
+    using value_type = double;
+    using size_type  = std::size_t;
+
+    std::size_t R, C;
+    std::vector<std::size_t>* tid;   // R*C slots, hashed thread id per element
+
+    size_type num_rows() const { return R; }
+    size_type num_cols() const { return C; }
+    size_type size()     const { return R * C; }
+
+    value_type operator()(size_type r, size_type c) const {
+        (*tid)[r * C + c] = std::hash<std::thread::id>{}(std::this_thread::get_id());
+        return static_cast<double>(r * C + c);
+    }
+};
+
+namespace mtl::traits {
+template <> struct is_expression<::probe_expr> : std::true_type {};
+} // namespace mtl::traits
 
 TEST_CASE("ewise vector sweep == elementwise math, bit-exact",
           "[operation][ewise][vector][threading][mt]") {
@@ -108,6 +139,119 @@ TEST_CASE("ewise matrix sweep == elementwise math, bit-exact",
     }
 }
 
+// -- flattened 2D sweep (#313) ----------------------------------------------
+// The matrix sweep flattens (r,c) to a linear element index before chunking, so
+// the split follows the ELEMENT count, not the row count. A row-per-unit
+// decomposition leaves a 1 x N expression with a single work unit -- forever
+// serial no matter how much work the row holds.
+
+TEST_CASE("flattened 2D sweep covers the index space exactly once and splits",
+          "[operation][ewise][matrix][threading][mt]") {
+    const auto pool = mtl::detail::thread_pool::instance().size();
+    if (pool < 2)
+        WARN("pool < 2 workers: the parallel sweep is not exercised (set MTL5_NUM_THREADS)");
+
+    // 1 x 300000: one row, > grain*2 (65536*2) elements -> splits when flattened.
+    const std::size_t R = 1, C = 300000;
+    std::vector<int>         visits(R * C, 0);          // each element written by one chunk
+    std::vector<std::size_t> tid(R * C, 0);
+
+    mtl::detail::parallel_ewise_2d(R, C, 1, [&](std::size_t r, std::size_t c) {
+        visits[r * C + c] += 1;
+        tid[r * C + c] = std::hash<std::thread::id>{}(std::this_thread::get_id());
+    });
+
+    // Every (r,c) produced exactly once: a wrong flattening would double-visit one
+    // element and miss another, which this catches either way.
+    for (std::size_t i = 0; i < R * C; ++i) REQUIRE(visits[i] == 1);
+
+    // ... and the work actually reached more than one thread.
+    std::unordered_set<std::size_t> threads(tid.begin(), tid.end());
+    if (pool >= 2) REQUIRE(threads.size() > 1);
+
+    // The row-major decomposition maps the linear index back correctly.
+    std::vector<std::size_t> rr(R * C, 0), cc(R * C, 0);
+    mtl::detail::parallel_ewise_2d(R, C, 1, [&](std::size_t r, std::size_t c) {
+        rr[r * C + c] = r;
+        cc[r * C + c] = c;
+    });
+    for (std::size_t i = 0; i < R * C; ++i) {
+        REQUIRE(rr[i] == i / C);
+        REQUIRE(cc[i] == i % C);
+    }
+}
+
+TEST_CASE("a wide/short matrix assignment splits across the pool",
+          "[operation][ewise][matrix][threading][mt]") {
+    const auto pool = mtl::detail::thread_pool::instance().size();
+    if (pool < 2) {
+        WARN("pool < 2 workers: the parallel sweep is not exercised (set MTL5_NUM_THREADS)");
+        return;
+    }
+
+    // The acceptance criterion of #313, observed through the real assignment path:
+    // a 1 x 300000 expression has ONE row, so a row-per-work-unit sweep can never
+    // split it. Flattened, its 300000 elements chunk across the pool.
+    const std::size_t R = 1, C = 300000;
+    std::vector<std::size_t> tid(R * C, 0);
+    mat::dense2D<double> D(R, C);
+    D = probe_expr{R, C, &tid};
+
+    std::unordered_set<std::size_t> threads(tid.begin(), tid.end());
+    REQUIRE(threads.size() > 1);
+
+    // Every element still evaluated, exactly where it belongs.
+    for (std::size_t c = 0; c < C; ++c) REQUIRE(D(0, c) == static_cast<double>(c));
+
+    // A tall 300000 x 1 expression splits too -- the flattening did not trade one
+    // shape for the other.
+    std::vector<std::size_t> tid_tall(C * R, 0);
+    mat::dense2D<double> T(C, R);
+    T = probe_expr{C, R, &tid_tall};
+    std::unordered_set<std::size_t> threads_tall(tid_tall.begin(), tid_tall.end());
+    REQUIRE(threads_tall.size() > 1);
+}
+
+TEST_CASE("wide/short matrix sweep == elementwise math, bit-exact",
+          "[operation][ewise][matrix][threading][mt]") {
+    if (mtl::detail::thread_pool::instance().size() < 2)
+        WARN("pool < 2 workers: the parallel sweep is not exercised (set MTL5_NUM_THREADS)");
+
+    // Shapes with too few rows to split row-wise, but plenty of total elements.
+    auto check = [](std::size_t R, std::size_t C) {
+        mat::dense2D<double> A(R, C), B(R, C);
+        for (std::size_t r = 0; r < R; ++r)
+            for (std::size_t c = 0; c < C; ++c) {
+                A(r, c) = vv(r * C + c);
+                B(r, c) = ww(r * C + c);
+            }
+
+        mat::dense2D<double> D(R, C);
+        D = A + B;                                  // operator=
+        for (std::size_t r = 0; r < R; ++r)
+            for (std::size_t c = 0; c < C; ++c) REQUIRE(D(r, c) == A(r, c) + B(r, c));
+
+        mat::dense2D<double> E = A - B;             // construct
+        REQUIRE(E.num_rows() == R); REQUIRE(E.num_cols() == C);
+        for (std::size_t r = 0; r < R; ++r)
+            for (std::size_t c = 0; c < C; ++c) REQUIRE(E(r, c) == A(r, c) - B(r, c));
+
+        E += A + B;                                 // operator+=
+        for (std::size_t r = 0; r < R; ++r)
+            for (std::size_t c = 0; c < C; ++c)
+                REQUIRE(E(r, c) == (A(r, c) - B(r, c)) + (A(r, c) + B(r, c)));
+
+        E -= A - B;                                 // operator-=
+        for (std::size_t r = 0; r < R; ++r)
+            for (std::size_t c = 0; c < C; ++c)
+                REQUIRE(E(r, c) == ((A(r, c) - B(r, c)) + (A(r, c) + B(r, c)))
+                                   - (A(r, c) - B(r, c)));
+    };
+
+    SECTION("1 x 300000") { check(1, 300000); }
+    SECTION("2 x 150000") { check(2, 150000); }
+}
+
 TEST_CASE("ewise sweep boundary cases", "[operation][ewise][threading][mt][edge]") {
     // Empty and tiny (below the split threshold -> serial body) must still work.
     {
@@ -125,5 +269,19 @@ TEST_CASE("ewise sweep boundary cases", "[operation][ewise][threading][mt][edge]
         mat::dense2D<double> A(0, 0), B(0, 0), D;
         D = A + B;
         REQUIRE(D.num_rows() == 0);
+    }
+    {
+        // Degenerate 2D extents: the flattened sweep must not divide by a zero
+        // column count (it returns before the r = t / cols decomposition).
+        int calls = 0;
+        mtl::detail::parallel_ewise_2d(5, 0, 1, [&](std::size_t, std::size_t) { ++calls; });
+        mtl::detail::parallel_ewise_2d(0, 5, 1, [&](std::size_t, std::size_t) { ++calls; });
+        REQUIRE(calls == 0);
+
+        // Single element: below the split threshold -> one serial body call.
+        mtl::detail::parallel_ewise_2d(1, 1, 1, [&](std::size_t r, std::size_t c) {
+            ++calls; REQUIRE(r == 0); REQUIRE(c == 0);
+        });
+        REQUIRE(calls == 1);
     }
 }


### PR DESCRIPTION
## Summary

The `dense2D` expression-template sweeps made each **row** one `parallel_ewise` work unit, and `thread_pool::parallel_for` runs serially when `n < grain*2`. A wide/short expression — a `1 x 300000` result has `n == 1` — could therefore never split, however much work the row held. Same wide-shape gap #311 closed for GEMM.

`detail::parallel_ewise_2d` flattens the `(r, c)` space to a linear element index `[0, rows*cols)` **before** chunking, so the split follows the element count: `1 x N` now parallelizes exactly like `N x 1`.

Two details worth reviewing:

- **No div/mod per element.** Each chunk walks `(r, c)` incrementally from one division at its start; the per-element cost is an increment and a compare, not the `t / cols`, `t % cols` a naive flattening pays.
- **Chunk size is unchanged for existing shapes.** Passing `work_per_elem = 1` gives `grain = 65536` elements — exactly what the row form's `65536 / num_cols` rows produced. Only the boundary alignment changes (row-aligned → element-aligned), which element-wise results cannot observe.

Bit-identity holds by construction: row-major visit order is unchanged, each element is produced by exactly one chunk, and the per-element computation is thread-independent.

## Changes

- `include/mtl/detail/ewise.hpp` — new `parallel_ewise_2d(rows, cols, work_per_elem, body(r,c))`. `parallel_ewise` is untouched; the vector sweeps keep using it.
- `include/mtl/mat/dense2D.hpp` — the four expression sweeps (ctor, `=`, `+=`, `-=`) now flatten.
- `tests/unit/operation/test_ewise_sweep_mt.cpp` — see below.

## Acceptance criteria

| criterion | how it's verified |
|---|---|
| A wide/short expression splits across the pool | A probe expression records which thread evaluated each element, so this is observed **through the real assignment path**, not inferred: `1 x 300000` reaches >1 thread. Confirmed to fail on the row-per-unit sweep (`1 > 1`), so it's a real guard. A `300000 x 1` case asserts the flattening didn't trade one shape for the other. |
| Results bit-identical | Exact `==` against inline element-wise math for `1 x 300000` and `2 x 150000` through all four sweeps; the existing tall-matrix cases still pass. |
| TSan clean; GCC + Clang green | Full suite 163/163 on both compilers; `op_test_ewise_sweep_mt` built with `-DMTL5_SANITIZE=thread` and run at `MTL5_NUM_THREADS=4` — clean, exit 0. That target is already in the CI TSan lane. |

Also covered: `parallel_ewise_2d` visits every element exactly once and maps the linear index back to the right `(r, c)`; zero-extent inputs make no body call (nothing divides by a zero column count) and `1x1` makes exactly one.

## Scope note

The second half of the original #313 — the ~K× too-coarse grain for the opt-in lazy `mat_mat_times_expr` — has been **split out into #424**, since it adds a public trait (a per-element work-hint customization point) and deserves its own review. #313 is now scoped to the flattening alone, which this PR delivers in full, so it closes on merge.

Note the commit message predates the split and reads `Relates to #313`; the `Resolves #313` below is what does the closing.

## Test Results

| Target | gcc build | gcc test | clang build | clang test | TSan |
|--------|-----------|----------|-------------|------------|------|
| full unit suite (163 tests) | OK | 163/163 PASS | OK | 163/163 PASS | — |
| op_test_ewise_sweep_mt | OK | PASS (6 cases) | OK | PASS | CLEAN |

## Test plan
- [ ] Fast CI passes (gcc + clang, plus the TSan lane)
- [ ] Promote to ready when satisfied: `gh pr ready <N>`

Resolves #313
Relates to #424

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved parallel processing for dense matrix expressions, including wide, tall, and irregularly sized matrices.
  * Preserved deterministic traversal order and existing calculation results.

* **Bug Fixes**
  * Improved handling of empty matrices and single-element matrices during parallel operations.

* **Tests**
  * Added coverage for threaded evaluation, matrix assignment, arithmetic, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->