### PR TITLE
perf(simd): derive the GEMM cache blocks from the detected cache hierarchy

### DIFF
--- a/include/mtl/detail/gemm_blocked.hpp
+++ b/include/mtl/detail/gemm_blocked.hpp
@@ -153,11 +153,16 @@ void gemm_blocked(std::size_t m, std::size_t n, std::size_t k,
     constexpr simd::blocking_params bp = simd::default_blocking<TC>;
     constexpr std::size_t MR = bp.mr;   // register tile: must match the compiled
     constexpr std::size_t NR = bp.nr;   // micro-kernel, so compile-time only
-    // Cache blocks from the detected hierarchy (#222). rbp.mr/rbp.nr are equal to
-    // MR/NR by construction -- detection overrides only the cache fields, never
-    // the register-file or FMA terms the tile is derived from.
+    // L1/L2-sized blocks from the detected hierarchy (#222). rbp.mr/rbp.nr equal
+    // MR/NR by construction -- detection overrides only cache fields, never the
+    // register-file or FMA terms the tile is derived from.
     const simd::blocking_params& rbp = simd::runtime_blocking<TC>();
-    const std::size_t KC = rbp.kc, MC = rbp.mc, NC = rbp.nc;
+    const std::size_t KC = rbp.kc, MC = rbp.mc;
+    // NC stays compile-time: it sets the jc BLOCK COUNT, and this nest hands jc
+    // blocks to teams round-robin, so changing it perturbs the thread partition
+    // (measured regression; see with_detected_caches). Detection of L3 is
+    // deliberately not applied until the jc loop has a balanced_nc.
+    const std::size_t NC = bp.nc;
     // The ic-block size actually used. Equal to the cache bound MC everywhere
     // except the threaded nest, which lowers it to balance the m-partition once
     // ic_nt is known (#408). Captured by reference below and finalized before

--- a/include/mtl/detail/gemm_blocked.hpp
+++ b/include/mtl/detail/gemm_blocked.hpp
@@ -16,7 +16,12 @@
 //         jr (step nr) -- macro-kernel over packed panels
 //           ir (step mr) -> MICRO-KERNEL: mr x nr C tile in registers, kc deep
 //
-// kc/mc/nc and the mr x nr register tile come from simd::default_blocking<T>.
+// The mr x nr register tile comes from simd::default_blocking<T> (compile time --
+// it is a micro-kernel template argument); kc/mc/nc come from
+// simd::runtime_blocking<T>(), derived against the DETECTED cache hierarchy so
+// the cache blocks follow the machine rather than the Haswell-class defaults
+// (#222). On a machine whose caches match those defaults, or one where detection
+// is unavailable, the two agree and nothing changes.
 // Edge tiles (trailing rows < mr or cols < nr) are accumulated through a zeroed
 // mr x nr temporary so the micro-kernel only ever writes full tiles.
 //
@@ -146,9 +151,13 @@ void gemm_blocked(std::size_t m, std::size_t n, std::size_t k,
                   TC* C, std::size_t ldc,
                   unsigned nthreads = 1) {
     constexpr simd::blocking_params bp = simd::default_blocking<TC>;
-    constexpr std::size_t MR = bp.mr;
-    constexpr std::size_t NR = bp.nr;
-    const std::size_t KC = bp.kc, MC = bp.mc, NC = bp.nc;
+    constexpr std::size_t MR = bp.mr;   // register tile: must match the compiled
+    constexpr std::size_t NR = bp.nr;   // micro-kernel, so compile-time only
+    // Cache blocks from the detected hierarchy (#222). rbp.mr/rbp.nr are equal to
+    // MR/NR by construction -- detection overrides only the cache fields, never
+    // the register-file or FMA terms the tile is derived from.
+    const simd::blocking_params& rbp = simd::runtime_blocking<TC>();
+    const std::size_t KC = rbp.kc, MC = rbp.mc, NC = rbp.nc;
     // The ic-block size actually used. Equal to the cache bound MC everywhere
     // except the threaded nest, which lowers it to balance the m-partition once
     // ic_nt is known (#408). Captured by reference below and finalized before

--- a/include/mtl/simd/blocking.hpp
+++ b/include/mtl/simd/blocking.hpp
@@ -20,7 +20,8 @@
 
 #include <cstddef>
 
-#include <mtl/simd/batch.hpp>   // simd::width<T>
+#include <mtl/simd/batch.hpp>        // simd::width<T>
+#include <mtl/util/cache_info.hpp>   // util::cached_cache_info (#222)
 
 namespace mtl::simd {
 
@@ -173,8 +174,55 @@ constexpr blocking_params derive_blocking(std::size_t nvec,
 }
 
 /// Blocking parameters for `T` using the compiled SIMD width and the default
-/// hardware traits. (#90 will let the hw_traits be overridden per build.)
+/// hardware traits. Compile-time, and the source of the mr x nr register tile
+/// (a micro-kernel template argument) everywhere.
 template <typename T>
 inline constexpr blocking_params default_blocking = derive_blocking<T>(width<T>);
+
+/// `default_hw_traits` with the CACHE fields replaced by what the running machine
+/// reports (#222). Detected once per process; a field the platform could not
+/// report keeps its compile-time default, so an undetectable machine behaves
+/// exactly as it did before this existed.
+///
+/// The FMA latency/issue width and the vector register file are NOT overridden.
+/// They determine mr x nr, which is a template argument of the compiled
+/// micro-kernel: a runtime value could not be applied to it, and pretending
+/// otherwise would produce a tile the kernel does not implement. Keeping them
+/// compile-time is also what guarantees `runtime_blocking<T>().mr == default_blocking<T>.mr`
+/// (likewise nr), so the two agree on the register tile by construction and only
+/// the cache blocks can differ.
+/// Overlay detected cache figures on a base description, field by field. Pure,
+/// so the fallback is testable with hierarchies the host does not have.
+///
+/// A 0 field means NOT DETECTED and keeps the base value. That per-field guard is
+/// load-bearing, not defensive tidiness: `nc` is derived as l3_bytes/(kc*sdata),
+/// so letting an undetected L3 through as a literal zero would floor nc at nr --
+/// 8 columns per jc block, re-streaming A for every 8 columns of C. Machines that
+/// report no L3 are ordinary (Apple M-series has no L3 in the sysctl sense, and a
+/// container without sysfs reports nothing at all), so this is a case the model
+/// meets in practice rather than a hypothetical.
+constexpr hw_traits with_detected_caches(hw_traits base, const util::cache_info& c) {
+    if (c.l1d_bytes  != 0) base.l1_bytes   = c.l1d_bytes;
+    if (c.l1d_assoc  != 0) base.l1_assoc   = c.l1d_assoc;
+    if (c.line_bytes != 0) base.line_bytes = c.line_bytes;
+    if (c.l2_bytes   != 0) base.l2_bytes   = c.l2_bytes;
+    if (c.l3_bytes   != 0) base.l3_bytes   = c.l3_bytes;
+    return base;
+}
+
+inline const hw_traits& detected_hw_traits() {
+    static const hw_traits hw =
+        with_detected_caches(default_hw_traits, util::cached_cache_info());
+    return hw;
+}
+
+/// Blocking parameters for `T` derived against the DETECTED hardware. Use the
+/// kc/mc/nc from this; take mr/nr from `default_blocking<T>`, which is the tile
+/// the micro-kernel was instantiated with. Computed once per element type.
+template <typename T>
+inline const blocking_params& runtime_blocking() {
+    static const blocking_params bp = derive_blocking<T>(width<T>, detected_hw_traits());
+    return bp;
+}
 
 } // namespace mtl::simd

--- a/include/mtl/simd/blocking.hpp
+++ b/include/mtl/simd/blocking.hpp
@@ -194,19 +194,29 @@ inline constexpr blocking_params default_blocking = derive_blocking<T>(width<T>)
 /// Overlay detected cache figures on a base description, field by field. Pure,
 /// so the fallback is testable with hierarchies the host does not have.
 ///
-/// A 0 field means NOT DETECTED and keeps the base value. That per-field guard is
-/// load-bearing, not defensive tidiness: `nc` is derived as l3_bytes/(kc*sdata),
-/// so letting an undetected L3 through as a literal zero would floor nc at nr --
-/// 8 columns per jc block, re-streaming A for every 8 columns of C. Machines that
-/// report no L3 are ordinary (Apple M-series has no L3 in the sysctl sense, and a
-/// container without sysfs reports nothing at all), so this is a case the model
-/// meets in practice rather than a hypothetical.
+/// A 0 field means NOT DETECTED and keeps the base value.
+///
+/// L3 IS DELIBERATELY NOT APPLIED, though cache_info detects it. l3_bytes feeds
+/// only nc, and nc sets the jc BLOCK COUNT, njb = ceil(n/nc) -- which the
+/// threaded nest hands to jc-teams round-robin, so the critical path is
+/// ceil(njb/jc_nt) and an njb that is not a multiple of jc_nt leaves teams
+/// unequal. Measured (Xeon E5-2420 v2, 6 threads, m=96 n=16384 k=1024, fp64):
+/// applying the detected 15 MB L3 moved nc 2048 -> 3840 and njb 8 -> 5, so two
+/// teams took 3 and 2 blocks instead of 4 and 4 -- a 1.2x critical path and a
+/// measured 10-25% REGRESSION. kc and mc carry no such hazard: they size blocks
+/// within a partition rather than the number of partitioned units.
+///
+/// This is #408's failure mode one loop over -- there a register-tile change
+/// moved mc 64 -> 60 and nib 16 -> 18, unbalancing the ic partition. The ic loop
+/// has detail::balanced_mc to absorb it; the jc loop has no equivalent yet. Once
+/// a balanced_nc exists, L3 can be applied here. Tracked separately so that
+/// partition change gets its own measurement rather than riding along with cache
+/// detection.
 constexpr hw_traits with_detected_caches(hw_traits base, const util::cache_info& c) {
-    if (c.l1d_bytes  != 0) base.l1_bytes   = c.l1d_bytes;
+    if (c.l1d_bytes  != 0) base.l1_bytes   = c.l1d_bytes;   // -> kc
     if (c.l1d_assoc  != 0) base.l1_assoc   = c.l1d_assoc;
     if (c.line_bytes != 0) base.line_bytes = c.line_bytes;
-    if (c.l2_bytes   != 0) base.l2_bytes   = c.l2_bytes;
-    if (c.l3_bytes   != 0) base.l3_bytes   = c.l3_bytes;
+    if (c.l2_bytes   != 0) base.l2_bytes   = c.l2_bytes;    // -> mc
     return base;
 }
 
@@ -216,9 +226,10 @@ inline const hw_traits& detected_hw_traits() {
     return hw;
 }
 
-/// Blocking parameters for `T` derived against the DETECTED hardware. Use the
-/// kc/mc/nc from this; take mr/nr from `default_blocking<T>`, which is the tile
-/// the micro-kernel was instantiated with. Computed once per element type.
+/// Blocking parameters for `T` derived against the DETECTED hardware. Use kc and
+/// mc from this; take mr/nr from `default_blocking<T>` (the tile the micro-kernel
+/// was instantiated with) and nc from there too, since L3 is not overridden --
+/// see with_detected_caches. Computed once per element type.
 template <typename T>
 inline const blocking_params& runtime_blocking() {
     static const blocking_params bp = derive_blocking<T>(width<T>, detected_hw_traits());

--- a/include/mtl/simd/blocking.hpp
+++ b/include/mtl/simd/blocking.hpp
@@ -232,7 +232,19 @@ inline const hw_traits& detected_hw_traits() {
 /// see with_detected_caches. Computed once per element type.
 template <typename T>
 inline const blocking_params& runtime_blocking() {
-    static const blocking_params bp = derive_blocking<T>(width<T>, detected_hw_traits());
+    static const blocking_params bp = [] {
+        blocking_params p = derive_blocking<T>(width<T>, detected_hw_traits());
+        // Pin nc to the compile-time derivation. Withholding l3_bytes from
+        // with_detected_caches is NOT sufficient to hold nc still, because
+        // nc = round_down(l3/(kc*sdata), nr) and kc IS detected: a machine with a
+        // larger L1 gets a larger kc and therefore a smaller nc, from an
+        // unchanged L3. (Invisible on a 32 KB-L1 x86 host, where kc matches the
+        // default; an Apple M-series 128 KB L1d moves it four-fold.) Since the jc
+        // partition is what must not move (#429), pin the result rather than an
+        // input, and leave this struct saying exactly what the nest should use.
+        p.nc = default_blocking<T>.nc;
+        return p;
+    }();
     return bp;
 }
 

--- a/include/mtl/util/cache_info.hpp
+++ b/include/mtl/util/cache_info.hpp
@@ -1,0 +1,211 @@
+#pragma once
+// MTL5 -- runtime cache-hierarchy detection for the GEMM blocking model (#222).
+//
+// simd::derive_blocking sizes the cache blocks kc/mc/nc from a hw_traits
+// description whose figures were hardcoded to a Haswell-class core (32 KB L1 /
+// 256 KB L2 / 8 MB L3). This reads the real hierarchy at runtime so those blocks
+// follow the machine the binary is running on rather than the machine the model
+// was written on.
+//
+// SCOPE. Only the quantities derive_blocking actually consumes are detected:
+// L1d, L2, L3 and the line size (plus L1 associativity, which comes free from
+// the same CPUID registers). The FMA latency/issue width and the vector register
+// file are deliberately NOT detected -- they select the mr x nr register tile,
+// which is a compile-time template argument of the micro-kernel, so a runtime
+// value could not be applied to the compiled kernel anyway. Page size is not
+// detected because derive_blocking does not read it.
+//
+// This header is reachable from the core (blocking.hpp -> gemm), so unlike
+// system_info.hpp it deliberately does NOT include <windows.h>: the core must
+// not force the Win32 headers on every translation unit. That is a coverage gap
+// rather than a compromise -- on x86 the CPUID path covers every OS, Windows
+// included, and the one uncovered configuration is non-x86 Windows (ARM64),
+// which reports "unknown" and therefore keeps the compile-time defaults.
+//
+// Every field is best effort. 0 means NOT DETECTED and callers must fall back;
+// it never means "a cache of size zero".
+
+#include <cstddef>
+
+#include <mtl/util/cpuid.hpp>
+
+#if !MTL5_HAS_X86_CPUID
+#  if defined(__APPLE__)
+#    include <sys/sysctl.h>
+#  elif !defined(_WIN32)
+#    include <cstdlib>
+#    include <fstream>
+#    include <string>
+#  endif
+#endif
+
+namespace mtl::util {
+
+/// Detected data-cache hierarchy, in bytes. 0 = not detected.
+struct cache_info {
+    std::size_t l1d_bytes  = 0;   ///< per-core L1 DATA cache (never the I-cache)
+    std::size_t l1d_assoc  = 0;   ///< L1d ways
+    std::size_t l2_bytes   = 0;   ///< per-core L2
+    std::size_t l3_bytes   = 0;   ///< shared L3 (0 is legitimate: many cores have none)
+    std::size_t line_bytes = 0;   ///< cache line
+};
+
+namespace detail {
+
+#if MTL5_HAS_X86_CPUID
+
+/// CPUID deterministic-cache-parameters walk. Intel uses leaf 4; AMD publishes
+/// the identical encoding at extended leaf 0x8000001D. Sub-leaves enumerate the
+/// caches until the type field reads 0 (null).
+inline void fill_caches_x86(cache_info& c) {
+    unsigned regs[4];
+
+    cpuidex(0, 0, regs);
+    const unsigned max_leaf = regs[0];
+    char vendor[13] = {};
+    // EBX, EDX, ECX -- the order the vendor string is returned in.
+    vendor[0]  = static_cast<char>(regs[1] & 0xff);
+    vendor[1]  = static_cast<char>((regs[1] >> 8) & 0xff);
+    vendor[2]  = static_cast<char>((regs[1] >> 16) & 0xff);
+    vendor[3]  = static_cast<char>((regs[1] >> 24) & 0xff);
+    vendor[4]  = static_cast<char>(regs[3] & 0xff);
+    vendor[5]  = static_cast<char>((regs[3] >> 8) & 0xff);
+    vendor[6]  = static_cast<char>((regs[3] >> 16) & 0xff);
+    vendor[7]  = static_cast<char>((regs[3] >> 24) & 0xff);
+    vendor[8]  = static_cast<char>(regs[2] & 0xff);
+    vendor[9]  = static_cast<char>((regs[2] >> 8) & 0xff);
+    vendor[10] = static_cast<char>((regs[2] >> 16) & 0xff);
+    vendor[11] = static_cast<char>((regs[2] >> 24) & 0xff);
+
+    bool is_amd = vendor[0] == 'A' && vendor[1] == 'u' && vendor[2] == 't';  // AuthenticAMD
+    // Older AMD parts return zeros for leaf 4 and only populate 0x8000001D.
+    int leaf = 4;
+    if (is_amd) {
+        cpuidex(static_cast<int>(0x80000000u), 0, regs);
+        if (regs[0] >= 0x8000001Du) leaf = static_cast<int>(0x8000001Du);
+    }
+    if (leaf == 4 && max_leaf < 4) return;   // no deterministic-cache leaf at all
+
+    for (int i = 0; i < 32; ++i) {
+        cpuidex(leaf, i, regs);
+        const unsigned type = regs[0] & 0x1fu;
+        if (type == 0) break;                         // 0 = null: end of enumeration
+        const unsigned level = (regs[0] >> 5) & 0x7u;
+        const std::size_t line  = static_cast<std::size_t>(regs[1] & 0xfffu) + 1;
+        const std::size_t parts = static_cast<std::size_t>((regs[1] >> 12) & 0x3ffu) + 1;
+        const std::size_t ways  = static_cast<std::size_t>((regs[1] >> 22) & 0x3ffu) + 1;
+        const std::size_t sets  = static_cast<std::size_t>(regs[2]) + 1;
+        const std::size_t size  = ways * parts * line * sets;
+
+        if (c.line_bytes == 0) c.line_bytes = line;
+        // type 1 = data, 2 = instruction, 3 = unified. The I-cache must never be
+        // mistaken for L1d: they are the same size on most parts, so the error
+        // would be invisible in the numbers.
+        if (level == 1 && type == 1) { c.l1d_bytes = size; c.l1d_assoc = ways; }
+        else if (level == 2 && type != 2) { c.l2_bytes = size; }
+        else if (level == 3 && type != 2) { c.l3_bytes = size; }
+    }
+}
+
+#elif defined(__APPLE__)
+
+inline std::size_t sysctl_size(const char* name) {
+    std::size_t v = 0, len = sizeof(v);
+    if (::sysctlbyname(name, &v, &len, nullptr, 0) == 0) return v;
+    return 0;
+}
+
+/// Apple Silicon reports per-performance-level caches; hw.l*cachesize is the
+/// Intel-era spelling and is absent or zero on M-series.
+inline void fill_caches_apple(cache_info& c) {
+    c.l1d_bytes = sysctl_size("hw.perflevel0.l1dcachesize");
+    if (c.l1d_bytes == 0) c.l1d_bytes = sysctl_size("hw.l1dcachesize");
+    c.l2_bytes = sysctl_size("hw.perflevel0.l2cachesize");
+    if (c.l2_bytes == 0) c.l2_bytes = sysctl_size("hw.l2cachesize");
+    c.l3_bytes    = sysctl_size("hw.l3cachesize");   // typically absent on M-series
+    c.line_bytes  = sysctl_size("hw.cachelinesize");
+}
+
+#elif !defined(_WIN32)
+
+/// Read a whole sysfs attribute; empty on failure.
+inline std::string read_sysfs(const std::string& path) {
+    std::ifstream in(path);
+    std::string   s;
+    if (in) std::getline(in, s);
+    return s;
+}
+
+/// Parse the kernel's cache size spelling: a decimal with an optional K/M/G.
+inline std::size_t parse_size(const std::string& s) {
+    if (s.empty()) return 0;
+    char*             end = nullptr;
+    const unsigned long long v = std::strtoull(s.c_str(), &end, 10);
+    if (end == s.c_str()) return 0;
+    std::size_t mult = 1;
+    if (end && *end) {
+        switch (*end) {
+            case 'K': case 'k': mult = 1024; break;
+            case 'M': case 'm': mult = 1024 * 1024; break;
+            case 'G': case 'g': mult = 1024 * 1024 * 1024; break;
+            default: break;
+        }
+    }
+    return static_cast<std::size_t>(v) * mult;
+}
+
+/// Linux sysfs walk, for non-x86 (AArch64, RISC-V, POWER) where there is no
+/// CPUID. cpu0 is representative for the purposes of the blocking model; on a
+/// heterogeneous core layout it describes whichever core cpu0 is.
+inline void fill_caches_sysfs(cache_info& c) {
+    const std::string base = "/sys/devices/system/cpu/cpu0/cache/index";
+    for (int i = 0; i < 10; ++i) {
+        const std::string dir = base + std::to_string(i);
+        const std::string lvl = read_sysfs(dir + "/level");
+        if (lvl.empty()) break;                       // no more index<N> entries
+        const std::string type = read_sysfs(dir + "/type");
+        const std::size_t size = parse_size(read_sysfs(dir + "/size"));
+        const std::size_t line = parse_size(read_sysfs(dir + "/coherency_line_size"));
+        const int level = std::atoi(lvl.c_str());
+
+        if (c.line_bytes == 0 && line != 0) c.line_bytes = line;
+        const bool is_instruction = (type == "Instruction");
+        if (level == 1 && type == "Data") {
+            c.l1d_bytes = size;
+            c.l1d_assoc = parse_size(read_sysfs(dir + "/ways_of_associativity"));
+        } else if (level == 2 && !is_instruction) {
+            c.l2_bytes = size;
+        } else if (level == 3 && !is_instruction) {
+            c.l3_bytes = size;
+        }
+    }
+}
+
+#endif
+
+} // namespace detail
+
+/// Detect the data-cache hierarchy. Best effort: any field that could not be
+/// determined stays 0, and callers fall back rather than believing the zero.
+inline cache_info detect_caches() {
+    cache_info c;
+#if MTL5_HAS_X86_CPUID
+    detail::fill_caches_x86(c);
+#elif defined(__APPLE__)
+    detail::fill_caches_apple(c);
+#elif !defined(_WIN32)
+    detail::fill_caches_sysfs(c);
+#endif
+    // Non-x86 Windows falls through with everything 0 -- see the header note.
+    return c;
+}
+
+/// Detect once per process and reuse. The hierarchy cannot change under a
+/// running binary, and the CPUID walk / sysfs reads should not sit in any hot
+/// path. Thread-safe initialization is guaranteed by the static local.
+inline const cache_info& cached_cache_info() {
+    static const cache_info c = detect_caches();
+    return c;
+}
+
+} // namespace mtl::util

--- a/include/mtl/util/cpuid.hpp
+++ b/include/mtl/util/cpuid.hpp
@@ -1,0 +1,44 @@
+#pragma once
+// MTL5 -- minimal portable CPUID wrapper.
+//
+// Factored out of system_info.hpp (#222) so cache_info.hpp can issue CPUID leaves
+// without either header defining its own `cpuidex`: both live in `mtl::util`, so
+// two inline definitions of the same signature would collide in any translation
+// unit that included both.
+//
+// x86 only. `MTL5_HAS_X86_CPUID` is 0 on every other ISA, where the whole block
+// (including <cpuid.h> / <intrin.h>) disappears.
+
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
+#  define MTL5_HAS_X86_CPUID 1
+#else
+#  define MTL5_HAS_X86_CPUID 0
+#endif
+
+#if MTL5_HAS_X86_CPUID
+#  if defined(_MSC_VER)
+#    include <intrin.h>
+#  else
+#    include <cpuid.h>
+#  endif
+
+namespace mtl::util {
+
+/// Fill regs[eax, ebx, ecx, edx] for CPUID `leaf`/`subleaf`.
+inline void cpuidex(int leaf, int subleaf, unsigned regs[4]) {
+#  if defined(_MSC_VER)
+    int r[4];
+    __cpuidex(r, leaf, subleaf);
+    regs[0] = static_cast<unsigned>(r[0]);
+    regs[1] = static_cast<unsigned>(r[1]);
+    regs[2] = static_cast<unsigned>(r[2]);
+    regs[3] = static_cast<unsigned>(r[3]);
+#  else
+    unsigned a, b, c, d;
+    __cpuid_count(leaf, subleaf, a, b, c, d);
+    regs[0] = a; regs[1] = b; regs[2] = c; regs[3] = d;
+#  endif
+}
+
+} // namespace mtl::util
+#endif // MTL5_HAS_X86_CPUID

--- a/include/mtl/util/system_info.hpp
+++ b/include/mtl/util/system_info.hpp
@@ -21,22 +21,15 @@
 #include <string>
 #include <thread>
 
+#include <mtl/util/cpuid.hpp>   // MTL5_HAS_X86_CPUID, util::cpuidex
+
 // ---------------------------------------------------------------------------
 // Architecture detection (compile time)
 // ---------------------------------------------------------------------------
-#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
-#  define MTL5_SYSINFO_X86 1
-#else
-#  define MTL5_SYSINFO_X86 0
-#endif
-
-#if MTL5_SYSINFO_X86
-#  if defined(_MSC_VER)
-#    include <intrin.h>
-#  else
-#    include <cpuid.h>
-#  endif
-#endif
+// The CPUID wrapper and its <cpuid.h>/<intrin.h> include moved to cpuid.hpp so
+// cache_info.hpp can share them (#222); MTL5_SYSINFO_X86 is kept as the name the
+// rest of this header uses.
+#define MTL5_SYSINFO_X86 MTL5_HAS_X86_CPUID
 
 #if defined(_WIN32)
 #  ifndef WIN32_LEAN_AND_MEAN
@@ -101,22 +94,8 @@ struct system_info {
 namespace detail {
 
 #if MTL5_SYSINFO_X86
-/// Thin portable wrapper over CPUID: fills regs[eax,ebx,ecx,edx] for a leaf.
-inline void cpuidex(int leaf, int subleaf, unsigned regs[4]) {
-#  if defined(_MSC_VER)
-    int r[4];
-    __cpuidex(r, leaf, subleaf);
-    regs[0] = static_cast<unsigned>(r[0]);
-    regs[1] = static_cast<unsigned>(r[1]);
-    regs[2] = static_cast<unsigned>(r[2]);
-    regs[3] = static_cast<unsigned>(r[3]);
-#  else
-    unsigned a, b, c, d;
-    __cpuid_count(leaf, subleaf, a, b, c, d);
-    regs[0] = a; regs[1] = b; regs[2] = c; regs[3] = d;
-#  endif
-}
-
+// `cpuidex` resolves to mtl::util::cpuidex (cpuid.hpp) by enclosing-namespace
+// lookup from mtl::util::detail.
 inline void fill_cpu_x86(cpu_info& cpu) {
     unsigned regs[4];
 

--- a/tests/unit/util/test_cache_info.cpp
+++ b/tests/unit/util/test_cache_info.cpp
@@ -1,0 +1,188 @@
+// Runtime cache detection and the blocking parameters derived from it (#222).
+//
+// Detection is best effort and machine-dependent, so these assert INVARIANTS and
+// FALLBACK behaviour rather than specific sizes -- a test that hardcoded this
+// machine's 15 MB L3 would fail on the next machine, which is the very coupling
+// the change exists to remove. What is pinned:
+//
+//   * anything detected is physically plausible (powers of two, ordered by level)
+//   * anything NOT detected leaves the compile-time default untouched
+//   * the register tile mr x nr is IDENTICAL to default_blocking's, because the
+//     micro-kernel is instantiated on that tile and a runtime value must never
+//     be able to move it
+//
+// The detected values are reported via INFO so a failure elsewhere in the GEMM
+// suite can be read against the hierarchy the run actually used.
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+
+#include <cstddef>
+
+#include <mtl/util/cache_info.hpp>
+#include <mtl/simd/blocking.hpp>
+
+using namespace mtl;
+
+namespace {
+
+bool is_power_of_two(std::size_t v) { return v != 0 && (v & (v - 1)) == 0; }
+
+} // namespace
+
+TEST_CASE("detected cache sizes are plausible", "[util][cache][blocking]") {
+    const util::cache_info c = util::detect_caches();
+
+    INFO("l1d=" << c.l1d_bytes << " assoc=" << c.l1d_assoc
+         << " l2=" << c.l2_bytes << " l3=" << c.l3_bytes
+         << " line=" << c.line_bytes);
+
+    // Each field is either "not detected" (0) or a believable figure. The bounds
+    // are deliberately loose: they catch a misparse (an I-cache counted as L1d, a
+    // K/M suffix dropped, a CPUID field shifted) without encoding one machine.
+    if (c.line_bytes != 0) {
+        REQUIRE(is_power_of_two(c.line_bytes));
+        REQUIRE(c.line_bytes >= 16);
+        REQUIRE(c.line_bytes <= 256);
+    }
+    if (c.l1d_bytes != 0) {
+        REQUIRE(c.l1d_bytes >= 4u * 1024);
+        REQUIRE(c.l1d_bytes <= 1024u * 1024);
+    }
+    if (c.l2_bytes != 0) {
+        REQUIRE(c.l2_bytes >= 64u * 1024);
+        REQUIRE(c.l2_bytes <= 128u * 1024 * 1024);
+    }
+    if (c.l3_bytes != 0) {
+        REQUIRE(c.l3_bytes >= 256u * 1024);
+        REQUIRE(c.l3_bytes <= 2048u * 1024 * 1024ull);
+    }
+
+    // Level ordering, where both levels were detected. A cache that is not larger
+    // than the one above it means the levels were misidentified.
+    if (c.l1d_bytes != 0 && c.l2_bytes != 0) REQUIRE(c.l2_bytes >= c.l1d_bytes);
+    if (c.l2_bytes  != 0 && c.l3_bytes != 0) REQUIRE(c.l3_bytes >= c.l2_bytes);
+
+    // Detection is a pure read of fixed hardware: two calls must agree, and the
+    // cached accessor must agree with a fresh call.
+    const util::cache_info again = util::detect_caches();
+    REQUIRE(again.l1d_bytes  == c.l1d_bytes);
+    REQUIRE(again.l2_bytes   == c.l2_bytes);
+    REQUIRE(again.l3_bytes   == c.l3_bytes);
+    REQUIRE(again.line_bytes == c.line_bytes);
+    REQUIRE(util::cached_cache_info().l1d_bytes == c.l1d_bytes);
+    REQUIRE(util::cached_cache_info().l3_bytes  == c.l3_bytes);
+}
+
+TEST_CASE("detected_hw_traits overrides only what was detected",
+          "[util][cache][blocking]") {
+    const util::cache_info  c  = util::detect_caches();
+    const simd::hw_traits&  hw = simd::detected_hw_traits();
+    const simd::hw_traits&  def = simd::default_hw_traits;
+
+    // Cache fields: the detected value when there is one, the default otherwise.
+    // Stated as an if/else on each field so an undetectable platform (non-x86
+    // Windows, or a container without sysfs) is asserted to behave exactly as it
+    // did before detection existed.
+    if (c.l1d_bytes  != 0) REQUIRE(hw.l1_bytes   == c.l1d_bytes);
+    else                   REQUIRE(hw.l1_bytes   == def.l1_bytes);
+    if (c.l2_bytes   != 0) REQUIRE(hw.l2_bytes   == c.l2_bytes);
+    else                   REQUIRE(hw.l2_bytes   == def.l2_bytes);
+    if (c.l3_bytes   != 0) REQUIRE(hw.l3_bytes   == c.l3_bytes);
+    else                   REQUIRE(hw.l3_bytes   == def.l3_bytes);
+    if (c.line_bytes != 0) REQUIRE(hw.line_bytes == c.line_bytes);
+    else                   REQUIRE(hw.line_bytes == def.line_bytes);
+
+    // Non-cache fields are never touched: they select the register tile, which
+    // belongs to the compiled micro-kernel.
+    REQUIRE(hw.fma_latency   == def.fma_latency);
+    REQUIRE(hw.fma_units     == def.fma_units);
+    REQUIRE(hw.vec_registers == def.vec_registers);
+    REQUIRE(hw.page_bytes    == def.page_bytes);
+}
+
+TEMPLATE_TEST_CASE("runtime_blocking keeps the compiled register tile",
+                   "[util][cache][blocking]", float, double) {
+    const simd::blocking_params& rbp = simd::runtime_blocking<TestType>();
+    constexpr simd::blocking_params dbp = simd::default_blocking<TestType>;
+
+    INFO("runtime  mr=" << rbp.mr << " nr=" << rbp.nr
+         << " kc=" << rbp.kc << " mc=" << rbp.mc << " nc=" << rbp.nc);
+    INFO("default  mr=" << dbp.mr << " nr=" << dbp.nr
+         << " kc=" << dbp.kc << " mc=" << dbp.mc << " nc=" << dbp.nc);
+
+    // The load-bearing invariant: gemm_blocked instantiates the micro-kernel on
+    // default_blocking's mr/nr while taking kc/mc/nc from here. If detection
+    // could move mr or nr, the packed panels would no longer match the kernel.
+    REQUIRE(rbp.mr == dbp.mr);
+    REQUIRE(rbp.nr == dbp.nr);
+
+    // Cache blocks stay well-formed whatever was detected.
+    REQUIRE(rbp.kc >= 1);
+    REQUIRE(rbp.mc >= 1);
+    REQUIRE(rbp.nc >= rbp.nr);
+    REQUIRE(rbp.nc % rbp.nr == 0);
+
+    // Two calls return the same cached object.
+    REQUIRE(&simd::runtime_blocking<TestType>() == &rbp);
+}
+
+TEST_CASE("an undetected cache level keeps the compile-time default",
+          "[util][cache][blocking]") {
+    // Runs everywhere, unlike the host-dependent fallback branches above: feed
+    // `with_detected_caches` hierarchies this machine does not have.
+    const simd::hw_traits def = simd::default_hw_traits;
+
+    SECTION("nothing detected at all -> the defaults, unchanged") {
+        // A container without sysfs, or non-x86 Windows.
+        const simd::hw_traits hw = simd::with_detected_caches(def, util::cache_info{});
+        REQUIRE(hw.l1_bytes   == def.l1_bytes);
+        REQUIRE(hw.l2_bytes   == def.l2_bytes);
+        REQUIRE(hw.l3_bytes   == def.l3_bytes);
+        REQUIRE(hw.line_bytes == def.line_bytes);
+        REQUIRE(simd::derive_blocking<double>(4, hw).nc
+                == simd::derive_blocking<double>(4, def).nc);
+    }
+
+    SECTION("no L3 reported -> nc must not collapse to nr") {
+        // Apple M-series shape: a large L1/L2 and no L3 in the sysctl sense. If
+        // the zero reached derive_blocking, nc = l3/(kc*sdata) would floor at nr
+        // and the jc loop would re-stream A every nr columns.
+        util::cache_info m;
+        m.l1d_bytes = 128u * 1024;
+        m.l2_bytes  = 12u * 1024 * 1024;
+        m.l3_bytes  = 0;                      // not detected
+        m.line_bytes = 128;
+
+        const simd::hw_traits hw = simd::with_detected_caches(def, m);
+        REQUIRE(hw.l1_bytes   == 128u * 1024);       // detected values applied
+        REQUIRE(hw.l2_bytes   == 12u * 1024 * 1024);
+        REQUIRE(hw.line_bytes == 128);
+        REQUIRE(hw.l3_bytes   == def.l3_bytes);      // undetected one held back
+
+        const auto bp = simd::derive_blocking<double>(4, hw);
+        REQUIRE(bp.nc > bp.nr);                      // the collapse this prevents
+        REQUIRE(bp.kc > simd::derive_blocking<double>(4, def).kc);   // bigger L1 -> bigger kc
+        REQUIRE(bp.mc > simd::derive_blocking<double>(4, def).mc);   // bigger L2 -> bigger mc
+    }
+}
+
+TEST_CASE("derive_blocking tracks the cache figures it is given",
+          "[util][cache][blocking]") {
+    // The point of the change, exercised without depending on the host: a larger
+    // L3 must produce a larger nc, and a larger L2 a larger mc. Pinned here
+    // because the host-dependent tests above cannot assert a direction.
+    simd::hw_traits small = simd::default_hw_traits;
+    simd::hw_traits big   = simd::default_hw_traits;
+    big.l3_bytes = small.l3_bytes * 2;
+
+    const auto bp_small = simd::derive_blocking<double>(4, small);
+    const auto bp_big   = simd::derive_blocking<double>(4, big);
+    REQUIRE(bp_big.nc > bp_small.nc);
+    REQUIRE(bp_big.mr == bp_small.mr);   // cache size must not move the tile
+    REQUIRE(bp_big.nr == bp_small.nr);
+    REQUIRE(bp_big.kc == bp_small.kc);   // nor the L1-sized block
+
+    simd::hw_traits big_l2 = simd::default_hw_traits;
+    big_l2.l2_bytes = small.l2_bytes * 2;
+    REQUIRE(simd::derive_blocking<double>(4, big_l2).mc > bp_small.mc);
+}

--- a/tests/unit/util/test_cache_info.cpp
+++ b/tests/unit/util/test_cache_info.cpp
@@ -87,10 +87,16 @@ TEST_CASE("detected_hw_traits overrides only what was detected",
     else                   REQUIRE(hw.l1_bytes   == def.l1_bytes);
     if (c.l2_bytes   != 0) REQUIRE(hw.l2_bytes   == c.l2_bytes);
     else                   REQUIRE(hw.l2_bytes   == def.l2_bytes);
-    if (c.l3_bytes   != 0) REQUIRE(hw.l3_bytes   == c.l3_bytes);
-    else                   REQUIRE(hw.l3_bytes   == def.l3_bytes);
     if (c.line_bytes != 0) REQUIRE(hw.line_bytes == c.line_bytes);
     else                   REQUIRE(hw.line_bytes == def.line_bytes);
+
+    // L3 is detected but NOT applied, whatever the machine reports: it feeds only
+    // nc, and nc sets the jc block count that the threaded nest partitions
+    // round-robin. Applying a detected 15 MB L3 on this class of machine measured
+    // a 10-25% regression on wide/short threaded GEMM (njb 8 -> 5 across 2 teams).
+    // Unconditional, so it holds on a machine with a huge L3 as well as one with
+    // none -- if a future balanced_nc lets L3 back in, this is what fails first.
+    REQUIRE(hw.l3_bytes == def.l3_bytes);
 
     // Non-cache fields are never touched: they select the register tile, which
     // belongs to the compiled micro-kernel.
@@ -111,10 +117,15 @@ TEMPLATE_TEST_CASE("runtime_blocking keeps the compiled register tile",
          << " kc=" << dbp.kc << " mc=" << dbp.mc << " nc=" << dbp.nc);
 
     // The load-bearing invariant: gemm_blocked instantiates the micro-kernel on
-    // default_blocking's mr/nr while taking kc/mc/nc from here. If detection
-    // could move mr or nr, the packed panels would no longer match the kernel.
+    // default_blocking's mr/nr while taking kc/mc from here. If detection could
+    // move mr or nr, the packed panels would no longer match the kernel.
     REQUIRE(rbp.mr == dbp.mr);
     REQUIRE(rbp.nr == dbp.nr);
+
+    // nc must also be untouched by detection: it is the jc block count, and the
+    // threaded nest's team partition is sensitive to it. gemm_blocked takes NC
+    // from default_blocking, and this asserts the two cannot silently diverge.
+    REQUIRE(rbp.nc == dbp.nc);
 
     // Cache blocks stay well-formed whatever was detected.
     REQUIRE(rbp.kc >= 1);
@@ -144,9 +155,11 @@ TEST_CASE("an undetected cache level keeps the compile-time default",
     }
 
     SECTION("no L3 reported -> nc must not collapse to nr") {
-        // Apple M-series shape: a large L1/L2 and no L3 in the sysctl sense. If
-        // the zero reached derive_blocking, nc = l3/(kc*sdata) would floor at nr
-        // and the jc loop would re-stream A every nr columns.
+        // Apple M-series shape: a large L1/L2 and no L3 in the sysctl sense. Two
+        // guards keep the zero away from nc = l3/(kc*sdata), where it would floor
+        // at nr and make the jc loop re-stream A every nr columns: L3 is not
+        // applied at all today, and the per-field 0 check would hold it back even
+        // if it were. Asserted here so removing either one fails.
         util::cache_info m;
         m.l1d_bytes = 128u * 1024;
         m.l2_bytes  = 12u * 1024 * 1024;

--- a/tests/unit/util/test_cache_info.cpp
+++ b/tests/unit/util/test_cache_info.cpp
@@ -123,8 +123,11 @@ TEMPLATE_TEST_CASE("runtime_blocking keeps the compiled register tile",
     REQUIRE(rbp.nr == dbp.nr);
 
     // nc must also be untouched by detection: it is the jc block count, and the
-    // threaded nest's team partition is sensitive to it. gemm_blocked takes NC
-    // from default_blocking, and this asserts the two cannot silently diverge.
+    // threaded nest's team partition is sensitive to it (#429). Note this does
+    // NOT follow from withholding L3 -- nc = l3/(kc*sdata) and kc is detected, so
+    // a machine with a larger L1 would move nc from an unchanged L3. This caught
+    // exactly that on the ARM64 runners, where L1d is 64-128 KB against the 32 KB
+    // default; runtime_blocking pins nc for that reason.
     REQUIRE(rbp.nc == dbp.nc);
 
     // Cache blocks stay well-formed whatever was detected.
@@ -198,4 +201,27 @@ TEST_CASE("derive_blocking tracks the cache figures it is given",
     simd::hw_traits big_l2 = simd::default_hw_traits;
     big_l2.l2_bytes = small.l2_bytes * 2;
     REQUIRE(simd::derive_blocking<double>(4, big_l2).mc > bp_small.mc);
+}
+
+TEST_CASE("a detected L1 moves nc even with L3 held fixed",
+          "[util][cache][blocking]") {
+    // Why runtime_blocking pins nc rather than merely withholding l3_bytes.
+    // nc = round_down(l3/(kc*sdata), nr) and kc = (l1/2)/(nr*sdata), so a larger
+    // L1 raises kc and LOWERS nc from an unchanged L3. Withholding L3 alone would
+    // therefore still let the jc block count drift on any machine whose L1 is not
+    // the 32 KB default -- which is every ARM64 target in CI, and is why this only
+    // showed up there. Asserted on explicit traits so it runs on x86 as well.
+    simd::hw_traits base = simd::default_hw_traits;
+    simd::hw_traits big_l1 = base;
+    big_l1.l1_bytes = base.l1_bytes * 4;          // 32 KB -> 128 KB, M-series shape
+    REQUIRE(big_l1.l3_bytes == base.l3_bytes);    // L3 deliberately identical
+
+    const auto bp_base = simd::derive_blocking<double>(4, base);
+    const auto bp_l1   = simd::derive_blocking<double>(4, big_l1);
+    REQUIRE(bp_l1.kc > bp_base.kc);               // bigger L1 -> bigger kc
+    REQUIRE(bp_l1.nc < bp_base.nc);               // ... which drags nc down
+
+    // And the pin holds regardless: runtime_blocking reports the compile-time nc.
+    REQUIRE(simd::runtime_blocking<double>().nc == simd::default_blocking<double>.nc);
+    REQUIRE(simd::runtime_blocking<float>().nc  == simd::default_blocking<float>.nc);
 }


### PR DESCRIPTION
## Summary

First of the three workstreams in #222. `kc`/`mc` came from `hw_traits` figures hardcoded to a Haswell-class core (32 KB L1 / 256 KB L2 / 8 MB L3), so every machine was blocked for someone else's cache. They now come from the hierarchy detected at runtime.

**L3 is detected but deliberately not applied** — see the regression section below. `nc` still comes from the compile-time default, so the jc partition is byte-identical to `main`.

**What makes this small:** `mr x nr` is a *template argument* of the compiled micro-kernel and must stay compile-time — a runtime tile cannot be applied to the kernel that was instantiated — while `KC`/`MC` were already plain runtime locals in `gemm_blocked.hpp:151`. So detection feeds two loop bounds and touches no kernel. `default_blocking<T>` is unchanged and still supplies `mr`/`nr`/`nc`; tests pin that `runtime_blocking<T>()` agrees with it on all three.

## Changes

- **`include/mtl/util/cpuid.hpp`** (new) — the CPUID wrapper factored out of `system_info.hpp`. Both headers live in `mtl::util`, so two inline definitions of the same signature would collide in any TU including both. Call sites in `system_info.hpp` are unchanged (enclosing-namespace lookup finds it).
- **`include/mtl/util/cache_info.hpp`** (new) — CPUID leaf 4 (AMD: extended leaf `0x8000001D`) on x86 for every OS *including Windows*; sysfs on non-x86 Linux; sysctl on Apple Silicon; "unknown" on non-x86 Windows. Deliberately **no `<windows.h>`**: this header is reachable from the core, and `system_info.hpp` documents why the core must not force the Win32 headers on every TU. That leaves exactly one uncovered configuration (ARM64 Windows), which reports unknown and keeps today's defaults.
- **`include/mtl/simd/blocking.hpp`** — `with_detected_caches` (pure, per-field overlay; applies L1/L2/line, not L3), `detected_hw_traits()`, `runtime_blocking<T>()`. Additive; nothing existing changes.
- **`include/mtl/detail/gemm_blocked.hpp`** — `KC`/`MC` from `runtime_blocking<TC>()`; `MR`/`NR`/`NC` untouched.
- **`tests/unit/util/test_cache_info.cpp`** (new).

## The regression this PR does not ship (thanks to the review)

CodeRabbit flagged the shared-L3 budget. Measuring it found a **real regression**, though by a different mechanism than proposed.

`l3_bytes` feeds only `nc`, and `nc` is the jc **block count**: `njb = ceil(n/nc)`. The nest hands jc-blocks to teams round-robin, so the critical path is `ceil(njb/jc_nt)` and an `njb` that is not a multiple of `jc_nt` leaves teams unequal:

| nc | njb | teams | blocks/team | time |
|---|---|---|---|---|
| 2048 (compile-time default) | 8 | 2 | 4, 4 | **0.114 s** |
| 3840 (detected 15 MB L3) | 5 | 2 | **3, 2** | **0.126 s** — 10–25% slower |

Xeon E5-2420 v2, 6 threads, `m=96 n=16384 k=1024`, fp64, Highway, interleaved, min of 9. After excluding L3: **0.111 vs 0.113 s, parity.**

This is #408's failure mode one loop over — there a register-tile change moved `mc` 64 → 60 and `nib` 16 → 18, unbalancing the **ic** partition. The ic loop has `detail::balanced_mc` to absorb it; the jc loop has no equivalent yet. `kc` and `mc` carry no such hazard: they size blocks *within* a partition rather than the number of partitioned units.

**Why my original measurements missed it:** `ic_nt = min(budget, nib)` fills the thread budget first, so for square problems `nib = m/mc` (~240 here) far exceeds 6 threads and `jc_nt` is structurally **1** — one team, no imbalance possible. Only a wide/short shape (small `m`) produces multiple jc teams. Every size I had measured was square.

Applying L3 needs a `balanced_nc` first: **#429**, filed with this reproduction.

## Measured — including where there is no win

Detection reports L1d 32 KB/8-way, L2 256 KB, L3 15 MB, line 64 on this box, **matching sysfs exactly**. But this machine's L1/L2 *already* match the Haswell defaults, so with L3 excluded **this PR changes no blocking parameter here at runtime** — it is a no-op on this box, by construction, which is also why the GEMM numbers above show parity rather than a win.

Where it does move the model (ISA held fixed at 4 doubles, so only caches differ; `nc` shown for reference but not applied):

| hierarchy | kc | mc |
|---|---|---|
| Haswell (the hardcoded default) | 256 | 64 |
| Xeon E5-2420 v2 (this box) | 256 | 64 |
| Zen 3 (512K L2) | 256 | **128** |
| Apple M1 P-core (128K L1d, 12M L2) | **1024** | **768** |
| Sapphire Rapids (48K L1d, 2M L2) | **384** | **341** |

`kc` and `mc` bind at *every* size, unlike `nc`. They only move on machines whose L1/L2 differ from Haswell's — which is the case this change exists for, and which no machine available here exhibits.

## The guard worth reviewing

`with_detected_caches` keeps the default for any field that reads 0. That is load-bearing rather than defensive tidiness: `nc = l3_bytes/(kc*sdata)`, so an undetected L3 arriving as a literal zero would floor `nc` at `nr` — **8 columns per jc block**. Machines that report no L3 are ordinary (Apple M-series has none in the sysctl sense; a container without sysfs reports nothing). Belt and braces now that L3 is excluded entirely, but pinned by a test so removing either guard fails.

## Verification

- GCC **164/164**, Clang **164/164**.
- Detection cross-checked two ways on this host: forcing the non-x86 **sysfs** path on x86 returns values byte-identical to the CPUID walk. That validates the sysfs parser, which otherwise only compiles on the ARM CI runners.
- Previous CI run was green on all 42 checks, including macOS ARM64 and Linux ARM64 — the jobs that first *compile* the sysctl and sysfs branches — and both Windows jobs, confirming the no-`<windows.h>` claim.
- GEMM results bit-identical at every size and shape measured (checksums).

## Scope — #222 stays open

#222 bundles three workstreams and is part of the scale-out roadmap, so this is `Relates to`, not `Resolves`. Now tracked separately:

- **#427** — SVE/RVV scalable-vector `batch`: a redesign of `batch<T>`'s compile-time `size`, blocked on hardware
- **#428** — Highway runtime ISA dispatch: a build-model change
- **#429** — `balanced_nc`, then applying the detected L3 to `nc`

## Test plan
- [ ] Full CI green on the updated head
- [ ] Merge

Relates to #222

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime detection of processor cache characteristics across supported platforms.
  * GEMM cache-blocking parameters now adapt to detected hardware cache sizes.
  * Register-tile dimensions remain consistent with established defaults.
  * Added safe fallbacks when cache information is unavailable.

* **Bug Fixes**
  * Improved portability of processor feature detection across supported compilers and architectures.

* **Tests**
  * Added coverage for cache detection, fallback behavior, repeatability, and hardware-aware blocking parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->