### PR TITLE
perf(simd)!: make cache detection opt-in — measured slower than the defaults — plus the A/B harness that showed it

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -38,6 +38,18 @@ target_link_libraries(bench_sparse PRIVATE MTL5::mtl5)
 target_include_directories(bench_sparse PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
 set_target_properties(bench_sparse PROPERTIES FOLDER "Benchmarks")
 
+# Cache-blocking A/B (#426 / #432): the SAME source built twice, once with
+# runtime cache detection and once with MTL5_DISABLE_CACHE_DETECTION, so the two
+# binaries differ only in kc/mc. Driven by benchmarks/run_blocking_ab.sh, which
+# pins and interleaves them. The `-default` arm is the pre-#426 behaviour.
+foreach(_arm detected default)
+    add_executable(bench_blocking_ab_${_arm} bench_blocking_ab.cpp)
+    target_link_libraries(bench_blocking_ab_${_arm} PRIVATE MTL5::mtl5)
+    target_include_directories(bench_blocking_ab_${_arm} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
+    set_target_properties(bench_blocking_ab_${_arm} PROPERTIES FOLDER "Benchmarks")
+endforeach()
+target_compile_definitions(bench_blocking_ab_default PRIVATE MTL5_DISABLE_CACHE_DETECTION)
+
 # Future: individual focused benchmarks can be added here
 # add_executable(bench_gemm bench_gemm.cpp)
 # target_link_libraries(bench_gemm PRIVATE MTL5::mtl5)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -38,17 +38,18 @@ target_link_libraries(bench_sparse PRIVATE MTL5::mtl5)
 target_include_directories(bench_sparse PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
 set_target_properties(bench_sparse PROPERTIES FOLDER "Benchmarks")
 
-# Cache-blocking A/B (#426 / #432): the SAME source built twice, once with
-# runtime cache detection and once with MTL5_DISABLE_CACHE_DETECTION, so the two
-# binaries differ only in kc/mc. Driven by benchmarks/run_blocking_ab.sh, which
-# pins and interleaves them. The `-default` arm is the pre-#426 behaviour.
+# Cache-blocking A/B (#426 / #430 / #432): the SAME source built twice, once with
+# MTL5_ENABLE_CACHE_DETECTION and once without, so the two binaries differ only
+# in kc/mc. Driven by benchmarks/run_blocking_ab.sh, which pins and interleaves
+# them. The `-default` arm is what MTL5 ships; the `-detected` arm is the opt-in
+# under test, which measured a loss on the i7-12700K.
 foreach(_arm detected default)
     add_executable(bench_blocking_ab_${_arm} bench_blocking_ab.cpp)
     target_link_libraries(bench_blocking_ab_${_arm} PRIVATE MTL5::mtl5)
     target_include_directories(bench_blocking_ab_${_arm} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
     set_target_properties(bench_blocking_ab_${_arm} PROPERTIES FOLDER "Benchmarks")
 endforeach()
-target_compile_definitions(bench_blocking_ab_default PRIVATE MTL5_DISABLE_CACHE_DETECTION)
+target_compile_definitions(bench_blocking_ab_detected PRIVATE MTL5_ENABLE_CACHE_DETECTION)
 
 # Future: individual focused benchmarks can be added here
 # add_executable(bench_gemm bench_gemm.cpp)

--- a/benchmarks/analyze_blocking_ab.py
+++ b/benchmarks/analyze_blocking_ab.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Compare the two arms of the cache-blocking A/B (#426, #432).
+
+Reads the CSVs written by run_blocking_ab.sh and reports, per (shape, threads),
+the best of each arm and the ratio. Deliberately conservative about what counts
+as a difference:
+
+  * per point the arms are compared on their MINIMUM over all rounds, which is
+    the statistic run_blocking_ab.sh is built to produce;
+  * a point is only called a win or a loss when the arms' [min, max] ranges over
+    rounds do NOT overlap AND the difference clears a noise floor -- otherwise it
+    is reported as noise, however tempting the mean looks;
+  * if both arms compiled to the SAME blocking parameters, the run is a null
+    experiment by construction and no point is called at all. That is not a
+    hypothetical: on a machine whose L1/L2 already match the compile-time
+    defaults (e.g. xeon-e5-2420v2) detection changes nothing, and an early
+    version of this script duly reported a 4.8% "win" between two identical
+    configurations. Structural controls beat statistical ones;
+  * a checksum mismatch is a hard error, not a footnote: the arms must compute
+    the same result, and if they do not, no timing from that run means anything.
+"""
+import csv
+import sys
+from collections import defaultdict
+
+# Below this relative difference, a non-overlap is not worth believing.
+NOISE_FLOOR = 0.02
+# Fewer rounds than this and [min,max] is not a range, it is two samples.
+MIN_ROUNDS = 3
+
+
+def load(path):
+    rows = defaultdict(list)          # (dtype,m,n,k,threads) -> [row, ...]
+    params = {}
+    with open(path, newline="") as fh:
+        for r in csv.DictReader(fh):
+            key = (r["dtype"], int(r["m"]), int(r["n"]), int(r["k"]), int(r["threads"]))
+            rows[key].append(r)
+            params[r["dtype"]] = (r["mr"], r["nr"], r["kc"], r["mc"], r["nc"])
+    return rows, params
+
+
+def main(argv):
+    if len(argv) != 3:
+        print("usage: analyze_blocking_ab.py <detected.csv> <default.csv>", file=sys.stderr)
+        return 2
+    det, det_p = load(argv[1])
+    dfl, dfl_p = load(argv[2])
+
+    for dt in sorted(set(det_p) | set(dfl_p)):
+        print(f"blocking ({dt}):  detected mr,nr,kc,mc,nc = {det_p.get(dt)}"
+              f"   default = {dfl_p.get(dt)}")
+
+    # Structural control: identical parameters means the arms are the same
+    # program. Any timing difference is measurement noise, by construction.
+    null_run = all(det_p.get(dt) == dfl_p.get(dt) for dt in set(det_p) | set(dfl_p))
+    if null_run:
+        print("\n*** NULL RUN: both arms compiled to identical blocking parameters.")
+        print("*** Detection changes nothing on this machine (its L1/L2 already match")
+        print("*** the compile-time defaults), so every difference below is noise and")
+        print("*** no point is called. This is a useful harness self-test, not a result.")
+    print()
+
+    hdr = f"{'shape':>22} {'T':>3} {'default':>10} {'detected':>10} {'ratio':>7}  verdict"
+    print(hdr)
+    print("-" * len(hdr))
+
+    bad_checksum = []
+    wins = losses = noise = 0
+    for key in sorted(set(det) & set(dfl)):
+        dt, m, n, k, t = key
+        a, b = det[key], dfl[key]
+
+        ca = {round(float(r["checksum"]), 6) for r in a}
+        cb = {round(float(r["checksum"]), 6) for r in b}
+        if ca != cb:
+            bad_checksum.append((key, ca, cb))
+
+        a_s = sorted(float(r["min_s"]) for r in a)
+        b_s = sorted(float(r["min_s"]) for r in b)
+        a_best, b_best = a_s[0], b_s[0]
+        gf = lambda s: 2.0 * m * n * k / s / 1e9
+        ratio = b_best / a_best            # >1 => detected is faster
+
+        # A point is called only when the arms differ structurally, their ranges
+        # do not overlap, AND the effect clears the noise floor.
+        rounds = min(len(a_s), len(b_s))
+        if null_run:
+            verdict = "null (identical blocking)"
+            noise += 1
+        elif abs(ratio - 1.0) < NOISE_FLOOR:
+            verdict = f"noise (<{NOISE_FLOOR:.0%})"
+            noise += 1
+        elif rounds < MIN_ROUNDS:
+            verdict = f"unresolved (only {rounds} rounds)"
+            noise += 1
+        elif a_s[-1] < b_s[0]:
+            verdict = "detected faster"
+            wins += 1
+        elif b_s[-1] < a_s[0]:
+            verdict = "DEFAULT faster"
+            losses += 1
+        else:
+            verdict = "noise (ranges overlap)"
+            noise += 1
+
+        print(f"{m}x{n}x{k:>6}".rjust(22)
+              + f" {t:>3} {gf(b_best):>10.2f} {gf(a_best):>10.2f} {ratio:>7.3f}  {verdict}")
+
+    print()
+    print(f"{wins} faster, {losses} slower, {noise} indistinguishable "
+          f"(GFLOP/s columns; ratio > 1 means detection helped)")
+
+    if bad_checksum:
+        print("\nCHECKSUM MISMATCH -- the arms did not compute the same result. "
+              "Timings from this run are meaningless until this is explained:",
+              file=sys.stderr)
+        for key, ca, cb in bad_checksum:
+            print(f"  {key}: detected={ca} default={cb}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/benchmarks/analyze_blocking_ab.py
+++ b/benchmarks/analyze_blocking_ab.py
@@ -61,9 +61,31 @@ def main(argv):
         print("*** no point is called. This is a useful harness self-test, not a result.")
     print()
 
+    # Integrity gate. An A/B is only an A/B if both arms measured the same points
+    # the same number of times; comparing the intersection, or a 5-round arm
+    # against a 2-round one, yields confident verdicts from a partial run. Fail
+    # loudly rather than analysing what happens to be present.
+    only_det = sorted(set(det) - set(dfl))
+    only_dfl = sorted(set(dfl) - set(det))
+    uneven = [(k, len(det[k]), len(dfl[k])) for k in sorted(set(det) & set(dfl))
+              if len(det[k]) != len(dfl[k])]
+    if only_det or only_dfl or uneven:
+        print("INCOMPLETE A/B -- refusing to compare.", file=sys.stderr)
+        for k in only_det:
+            print(f"  only in detected: {k}", file=sys.stderr)
+        for k in only_dfl:
+            print(f"  only in default:  {k}", file=sys.stderr)
+        for k, na, nb in uneven:
+            print(f"  unequal rounds:   {k} detected={na} default={nb}", file=sys.stderr)
+        print("Re-run both arms over the same shapes and rounds.", file=sys.stderr)
+        return 2
+
     hdr = f"{'shape':>22} {'T':>3} {'default':>10} {'detected':>10} {'ratio':>7}  verdict"
     print(hdr)
     print("-" * len(hdr))
+
+    def gflops(m, n, k, secs):
+        return 2.0 * m * n * k / secs / 1e9
 
     bad_checksum = []
     wins = losses = noise = 0
@@ -79,12 +101,11 @@ def main(argv):
         a_s = sorted(float(r["min_s"]) for r in a)
         b_s = sorted(float(r["min_s"]) for r in b)
         a_best, b_best = a_s[0], b_s[0]
-        gf = lambda s: 2.0 * m * n * k / s / 1e9
         ratio = b_best / a_best            # >1 => detected is faster
 
         # A point is called only when the arms differ structurally, their ranges
         # do not overlap, AND the effect clears the noise floor.
-        rounds = min(len(a_s), len(b_s))
+        rounds = len(a_s)                  # == len(b_s), enforced by the gate above
         if null_run:
             verdict = "null (identical blocking)"
             noise += 1
@@ -105,11 +126,13 @@ def main(argv):
             noise += 1
 
         print(f"{m}x{n}x{k:>6}".rjust(22)
-              + f" {t:>3} {gf(b_best):>10.2f} {gf(a_best):>10.2f} {ratio:>7.3f}  {verdict}")
+              + f" {t:>3} {gflops(m, n, k, b_best):>10.2f}"
+              + f" {gflops(m, n, k, a_best):>10.2f} {ratio:>7.3f}  {verdict}")
 
     print()
     print(f"{wins} faster, {losses} slower, {noise} indistinguishable "
-          f"(GFLOP/s columns; ratio > 1 means detection helped)")
+          f"(GFLOP/s columns; ratio > 1 means detection helped; "
+          f"differences under {NOISE_FLOOR:.0%} are not called)")
 
     if bad_checksum:
         print("\nCHECKSUM MISMATCH -- the arms did not compute the same result. "

--- a/benchmarks/bench_blocking_ab.cpp
+++ b/benchmarks/bench_blocking_ab.cpp
@@ -30,6 +30,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -44,6 +45,15 @@ namespace {
 
 struct shape { std::size_t m, n, k; };
 
+bool mul_overflows(std::size_t a, std::size_t b) {
+    return a != 0 && b > std::numeric_limits<std::size_t>::max() / a;
+}
+
+/// Parse "m,n,k;m,n,k". Rejects anything whose buffer products would wrap: a
+/// wrapped m*k allocates a short vector while gemm_blocked still walks the
+/// original extents, which is an out-of-bounds write rather than a failed run.
+/// A shape that is merely too large for RAM is left alone -- that fails loudly
+/// as bad_alloc, which is a fine way to find out.
 std::vector<shape> parse_shapes(const std::string& spec) {
     std::vector<shape> out;
     std::size_t pos = 0;
@@ -52,8 +62,15 @@ std::vector<shape> parse_shapes(const std::string& spec) {
         if (end == std::string::npos) end = spec.size();
         const std::string one = spec.substr(pos, end - pos);
         std::size_t m = 0, n = 0, k = 0;
-        if (std::sscanf(one.c_str(), "%zu,%zu,%zu", &m, &n, &k) == 3 && m && n && k)
-            out.push_back({m, n, k});
+        if (std::sscanf(one.c_str(), "%zu,%zu,%zu", &m, &n, &k) != 3 || !m || !n || !k) {
+            std::fprintf(stderr, "bad shape '%s' (want m,n,k, all > 0)\n", one.c_str());
+            std::exit(2);
+        }
+        if (mul_overflows(m, k) || mul_overflows(k, n) || mul_overflows(m, n)) {
+            std::fprintf(stderr, "shape %zu,%zu,%zu overflows size_t\n", m, n, k);
+            std::exit(2);
+        }
+        out.push_back({m, n, k});
         pos = end + 1;
     }
     return out;
@@ -148,6 +165,22 @@ int main(int argc, char** argv) {
         }
         else if (!std::strcmp(argv[i], "--help")) { usage(); return 0; }
         else { std::fprintf(stderr, "unknown option: %s\n", argv[i]); usage(); return 2; }
+    }
+
+    // Validate before anything reaches a measurement. Each of these otherwise
+    // fails silently in a way that still writes a plausible-looking CSV row:
+    // an empty --threads makes max_element dereference an empty range; --reps 0
+    // leaves the 1e30 sentinel as the "time"; an unrecognised --dtype runs the
+    // double path while labelling the rows with whatever was asked for.
+    if (threads.empty()) {
+        std::fprintf(stderr, "--threads: needs at least one count\n"); return 2;
+    }
+    for (unsigned t : threads)
+        if (t == 0) { std::fprintf(stderr, "--threads: counts must be > 0\n"); return 2; }
+    if (reps <= 0) { std::fprintf(stderr, "--reps must be > 0\n"); return 2; }
+    if (dtype != "double" && dtype != "float") {
+        std::fprintf(stderr, "--dtype must be double or float (got '%s')\n", dtype.c_str());
+        return 2;
     }
 
     const unsigned tmax = *std::max_element(threads.begin(), threads.end());

--- a/benchmarks/bench_blocking_ab.cpp
+++ b/benchmarks/bench_blocking_ab.cpp
@@ -1,10 +1,14 @@
 // MTL5 -- A/B the detected cache blocking against the compile-time defaults.
 //
 // One question: on this machine, is GEMM faster with kc/mc derived from the
-// DETECTED cache hierarchy (#426) than with the hardcoded Haswell-class figures
-// it replaced? Both arms are this same source; they differ only by
-// MTL5_DISABLE_CACHE_DETECTION, so nothing but the blocking parameters changes.
+// DETECTED cache hierarchy than with the hardcoded Haswell-class figures MTL5
+// ships? Both arms are this same source; they differ only by
+// MTL5_ENABLE_CACHE_DETECTION, so nothing but the blocking parameters changes.
 // benchmarks/run_blocking_ab.sh builds both and interleaves them.
+//
+// The answer on an i7-12700K was NO -- detection lost on 9 of 10 points, which
+// is why it is opt-in (see simd/blocking.hpp). This harness is how that verdict
+// gets revisited on other hardware (#430) rather than assumed either way.
 //
 // Shapes are NOT hardcoded. The regime where the jc (n-dimension) loop actually
 // parallelizes is machine-dependent -- it needs
@@ -168,8 +172,10 @@ int main(int argc, char** argv) {
     std::fprintf(stderr, "arm=%s dtype=%s\n", label.c_str(), dtype.c_str());
     std::fprintf(stderr, "  detected l1d=%zu l2=%zu l3=%zu line=%zu\n",
                  ci.l1d_bytes, ci.l2_bytes, ci.l3_bytes, ci.line_bytes);
-#if defined(MTL5_DISABLE_CACHE_DETECTION)
-    std::fprintf(stderr, "  MTL5_DISABLE_CACHE_DETECTION is ON -- blocking uses the defaults\n");
+#if defined(MTL5_ENABLE_CACHE_DETECTION)
+    std::fprintf(stderr, "  MTL5_ENABLE_CACHE_DETECTION is ON -- blocking follows the detected caches\n");
+#else
+    std::fprintf(stderr, "  detection not enabled -- blocking uses the compile-time defaults (shipped)\n");
 #endif
     std::fprintf(stderr, "  fp64 mr=%zu nr=%zu kc=%zu mc=%zu nc=%zu\n",
                  bpd.mr, bpd.nr, bpd.kc, bpd.mc, bpd.nc);

--- a/benchmarks/bench_blocking_ab.cpp
+++ b/benchmarks/bench_blocking_ab.cpp
@@ -1,0 +1,221 @@
+// MTL5 -- A/B the detected cache blocking against the compile-time defaults.
+//
+// One question: on this machine, is GEMM faster with kc/mc derived from the
+// DETECTED cache hierarchy (#426) than with the hardcoded Haswell-class figures
+// it replaced? Both arms are this same source; they differ only by
+// MTL5_DISABLE_CACHE_DETECTION, so nothing but the blocking parameters changes.
+// benchmarks/run_blocking_ab.sh builds both and interleaves them.
+//
+// Shapes are NOT hardcoded. The regime where the jc (n-dimension) loop actually
+// parallelizes is machine-dependent -- it needs
+//
+//     nib = ceil(m/mc) <= T/2      (so the ic loop does not consume the budget)
+//     njb = ceil(n/nc) >= 2        (so there is more than one jc block)
+//
+// and both bounds contain this machine's own mc and nc. A fixed shape list
+// silently tests nothing on some machines: every measurement in #426 was square,
+// which is precisely the regime where jc_nt is structurally 1 and the effects
+// being hunted cannot appear. `--suggest-shapes` derives the list from the
+// running machine; the script derives it ONCE and passes the identical list to
+// both arms, so the two are never measured on different shapes.
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include <mtl/detail/gemm_blocked.hpp>
+#include <mtl/simd/blocking.hpp>
+#include <mtl/util/cache_info.hpp>
+#include <mtl/util/system_info.hpp>
+
+using clk = std::chrono::steady_clock;
+
+namespace {
+
+struct shape { std::size_t m, n, k; };
+
+std::vector<shape> parse_shapes(const std::string& spec) {
+    std::vector<shape> out;
+    std::size_t pos = 0;
+    while (pos < spec.size()) {
+        std::size_t end = spec.find(';', pos);
+        if (end == std::string::npos) end = spec.size();
+        const std::string one = spec.substr(pos, end - pos);
+        std::size_t m = 0, n = 0, k = 0;
+        if (std::sscanf(one.c_str(), "%zu,%zu,%zu", &m, &n, &k) == 3 && m && n && k)
+            out.push_back({m, n, k});
+        pos = end + 1;
+    }
+    return out;
+}
+
+/// Shapes derived from THIS machine's blocking parameters and thread budget:
+/// a square set (where jc_nt is normally 1 -- the control), and a wide/short set
+/// chosen to put the ic block count under half the budget so the jc loop is the
+/// one that parallelizes.
+template <typename T>
+std::vector<shape> suggest_shapes(unsigned threads) {
+    const auto& bp = mtl::simd::runtime_blocking<T>();
+    std::vector<shape> s;
+
+    for (std::size_t n : {std::size_t{1024}, std::size_t{2048}, std::size_t{4096}})
+        s.push_back({n, n, n});                       // square control
+
+    // Wide/short: m small enough that nib <= T/2, n past a couple of jc blocks.
+    const std::size_t m_jc = std::max<std::size_t>(bp.mr, bp.mc * std::max(1u, threads) / 2);
+    for (std::size_t mult : {std::size_t{2}, std::size_t{3}}) {
+        const std::size_t n_jc = bp.nc * mult;
+        if (n_jc == 0) continue;
+        s.push_back({m_jc, n_jc, 1024});
+    }
+    return s;
+}
+
+template <typename T>
+double run_one(const shape& sh, unsigned nt, int reps, double& checksum) {
+    std::vector<T> A(sh.m * sh.k), B(sh.k * sh.n), C(sh.m * sh.n, T(0));
+    for (std::size_t i = 0; i < A.size(); ++i) A[i] = T(1) + T(i % 17) * T(0.03125);
+    for (std::size_t i = 0; i < B.size(); ++i) B[i] = T(0.5) - T(i % 23) * T(0.015625);
+
+    double best = 1e30;
+    for (int r = 0; r < reps; ++r) {
+        const auto t0 = clk::now();
+        mtl::detail::gemm_blocked<T, T>(
+            sh.m, sh.n, sh.k, T(1),
+            A.data(), static_cast<std::ptrdiff_t>(sh.k), 1,
+            B.data(), static_cast<std::ptrdiff_t>(sh.n), 1,
+            T(0), C.data(), sh.n, nt);
+        const auto t1 = clk::now();
+        best = std::min(best, std::chrono::duration<double>(t1 - t0).count());
+    }
+    double sum = 0.0;                       // control: both arms must agree exactly
+    for (std::size_t i = 0; i < C.size(); i += 4097) sum += static_cast<double>(C[i]);
+    checksum = sum;
+    return best;
+}
+
+void usage() {
+    std::printf(
+        "Usage: bench_blocking_ab [options]\n"
+        "  --label <name>      arm label recorded in the CSV (e.g. detected|default)\n"
+        "  --csv <file>        append results here (header written if new)\n"
+        "  --threads <list>    comma list, default \"1\"\n"
+        "  --reps <n>          repetitions per point, min reported (default 5)\n"
+        "  --dtype <double|float>\n"
+        "  --shapes <m,n,k;..> explicit shapes; both arms MUST be given the same list\n"
+        "  --suggest-shapes    print shapes derived from this machine and exit\n");
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    std::string label = "unlabelled", csv, shapes_spec, dtype = "double";
+    std::vector<unsigned> threads{1};
+    int reps = 5;
+    bool suggest = false;
+
+    for (int i = 1; i < argc; ++i) {
+        const auto need = [&](const char* f) -> std::string {
+            if (i + 1 >= argc) { std::fprintf(stderr, "%s needs a value\n", f); std::exit(2); }
+            return argv[++i];
+        };
+        if      (!std::strcmp(argv[i], "--label"))   label = need("--label");
+        else if (!std::strcmp(argv[i], "--csv"))     csv = need("--csv");
+        else if (!std::strcmp(argv[i], "--reps"))    reps = std::atoi(need("--reps").c_str());
+        else if (!std::strcmp(argv[i], "--dtype"))   dtype = need("--dtype");
+        else if (!std::strcmp(argv[i], "--shapes"))  shapes_spec = need("--shapes");
+        else if (!std::strcmp(argv[i], "--suggest-shapes")) suggest = true;
+        else if (!std::strcmp(argv[i], "--threads")) {
+            threads.clear();
+            const std::string list = need("--threads");
+            std::size_t p = 0;
+            while (p < list.size()) {
+                std::size_t e = list.find(',', p);
+                if (e == std::string::npos) e = list.size();
+                threads.push_back(static_cast<unsigned>(std::strtoul(list.substr(p, e - p).c_str(), nullptr, 10)));
+                p = e + 1;
+            }
+        }
+        else if (!std::strcmp(argv[i], "--help")) { usage(); return 0; }
+        else { std::fprintf(stderr, "unknown option: %s\n", argv[i]); usage(); return 2; }
+    }
+
+    const unsigned tmax = *std::max_element(threads.begin(), threads.end());
+    if (suggest) {
+        const auto s = (dtype == "float") ? suggest_shapes<float>(tmax)
+                                          : suggest_shapes<double>(tmax);
+        for (std::size_t i = 0; i < s.size(); ++i)
+            std::printf("%s%zu,%zu,%zu", i ? ";" : "", s[i].m, s[i].n, s[i].k);
+        std::printf("\n");
+        return 0;
+    }
+
+    const auto shapes = shapes_spec.empty()
+        ? ((dtype == "float") ? suggest_shapes<float>(tmax) : suggest_shapes<double>(tmax))
+        : parse_shapes(shapes_spec);
+    if (shapes.empty()) { std::fprintf(stderr, "no shapes\n"); return 2; }
+
+    // Header: what this arm actually compiled to, so a CSV can be audited later.
+    const auto& bpd = mtl::simd::runtime_blocking<double>();
+    const auto& bpf = mtl::simd::runtime_blocking<float>();
+    const auto  ci  = mtl::util::detect_caches();
+    std::fprintf(stderr, "arm=%s dtype=%s\n", label.c_str(), dtype.c_str());
+    std::fprintf(stderr, "  detected l1d=%zu l2=%zu l3=%zu line=%zu\n",
+                 ci.l1d_bytes, ci.l2_bytes, ci.l3_bytes, ci.line_bytes);
+#if defined(MTL5_DISABLE_CACHE_DETECTION)
+    std::fprintf(stderr, "  MTL5_DISABLE_CACHE_DETECTION is ON -- blocking uses the defaults\n");
+#endif
+    std::fprintf(stderr, "  fp64 mr=%zu nr=%zu kc=%zu mc=%zu nc=%zu\n",
+                 bpd.mr, bpd.nr, bpd.kc, bpd.mc, bpd.nc);
+    std::fprintf(stderr, "  fp32 mr=%zu nr=%zu kc=%zu mc=%zu nc=%zu\n",
+                 bpf.mr, bpf.nr, bpf.kc, bpf.mc, bpf.nc);
+
+    std::vector<std::string> rows;
+    for (unsigned nt : threads) {
+        for (const auto& sh : shapes) {
+            double chk = 0.0;
+            const double secs = (dtype == "float") ? run_one<float>(sh, nt, reps, chk)
+                                                   : run_one<double>(sh, nt, reps, chk);
+            const auto& bp = (dtype == "float") ? bpf : bpd;
+            const double gf = 2.0 * double(sh.m) * double(sh.n) * double(sh.k) / secs / 1e9;
+            char buf[512];
+            std::snprintf(buf, sizeof buf,
+                "%s,%s,%zu,%zu,%zu,%u,%zu,%zu,%zu,%zu,%zu,%d,%.6f,%.3f,%.6f",
+                label.c_str(), dtype.c_str(), sh.m, sh.n, sh.k, nt,
+                bp.mr, bp.nr, bp.kc, bp.mc, bp.nc, reps, secs, gf, chk);
+            rows.emplace_back(buf);
+            std::fprintf(stderr, "  m=%zu n=%zu k=%zu T=%u  %.4f s  %.2f GFLOP/s\n",
+                         sh.m, sh.n, sh.k, nt, secs, gf);
+        }
+    }
+
+    if (csv.empty()) {
+        for (const auto& r : rows) std::printf("%s\n", r.c_str());
+        return 0;
+    }
+    const bool fresh = !std::ifstream(csv).good();
+    std::ofstream out(csv, std::ios::app);
+    if (!out) { std::fprintf(stderr, "cannot write %s\n", csv.c_str()); return 1; }
+    if (fresh)
+        out << "arm,dtype,m,n,k,threads,mr,nr,kc,mc,nc,reps,min_s,gflops,checksum\n";
+    for (const auto& r : rows) out << r << "\n";
+
+    // Sidecar, matching the convention bench_all uses, plus the cache figures --
+    // a result is not interpretable without the hierarchy it was blocked for.
+    if (std::ofstream si{csv + ".sysinfo"}) {
+        si << "label=" << label << "\n"
+           << mtl::util::to_keyvals(mtl::util::identify())
+           << "cache_l1d_bytes="  << ci.l1d_bytes  << "\n"
+           << "cache_l1d_assoc="  << ci.l1d_assoc  << "\n"
+           << "cache_l2_bytes="   << ci.l2_bytes   << "\n"
+           << "cache_l3_bytes="   << ci.l3_bytes   << "\n"
+           << "cache_line_bytes=" << ci.line_bytes << "\n";
+    }
+    return 0;
+}

--- a/benchmarks/run_blocking_ab.sh
+++ b/benchmarks/run_blocking_ab.sh
@@ -2,10 +2,13 @@
 # Cache-blocking A/B (#426, #432): does GEMM go faster with kc/mc derived from
 # the DETECTED cache hierarchy than with the hardcoded Haswell-class defaults?
 #
-# Both arms are the same source. `bench_blocking_ab_detected` uses the detection
-# merged in #426; `bench_blocking_ab_default` is built with
-# MTL5_DISABLE_CACHE_DETECTION and reproduces the pre-#426 blocking. Nothing else
-# differs, so a difference in throughput is a difference in kc/mc.
+# Both arms are the same source. `bench_blocking_ab_detected` is built with
+# MTL5_ENABLE_CACHE_DETECTION; `bench_blocking_ab_default` is what MTL5 ships.
+# Nothing else differs, so a difference in throughput is a difference in kc/mc.
+#
+# Detection is opt-in precisely because this harness found it losing by up to 45%
+# on an i7-12700K (see simd/blocking.hpp). Re-run this on new hardware before
+# concluding anything for that machine.
 #
 # Protocol, matching the discipline the rest of docs/benchmarks/ uses:
 #   * PINNED    -- one logical id per physical core. On a hybrid CPU this also

--- a/benchmarks/run_blocking_ab.sh
+++ b/benchmarks/run_blocking_ab.sh
@@ -14,8 +14,10 @@
 #   * PINNED    -- one logical id per physical core. On a hybrid CPU this also
 #                  decides which cache hierarchy is detected at all (#432), so an
 #                  unpinned run here is not merely noisy, it is ambiguous.
-#   * INTERLEAVED -- arms alternate within one session. A ratio is only
-#                  defensible when both sides come from the same session.
+#   * INTERLEAVED -- arms alternate within one session, and the ORDER within a
+#                  round alternates too, so warm-up and thermal drift do not
+#                  accrue to one arm. A ratio is only defensible when both sides
+#                  come from the same session.
 #   * MIN of N  -- the binary reports the minimum of --reps runs per point.
 #   * SHAPES DERIVED ONCE -- the shape list comes from the detected arm and is
 #                  passed verbatim to both, so the arms are never compared on
@@ -66,8 +68,23 @@ pin_for() {
     echo "$BENCH_PCPUS" | cut -d, -f1-"$t"
 }
 
+# Every requested thread count must be positive and must fit BENCH_PCPUS. `cut`
+# silently returns the whole (shorter) list when asked for more fields than it
+# has, so an oversized THREADS would run more workers than pinned cores while the
+# CSV still recorded the larger count -- a wrong number that looks like a result.
+NPCPUS=$(echo "$BENCH_PCPUS" | tr ',' '\n' | grep -c .)
 TMAX=0
-for t in $THREADS; do [ "$t" -gt "$TMAX" ] && TMAX=$t; done
+for t in $THREADS; do
+    if ! [ "$t" -ge 1 ] 2>/dev/null; then
+        echo "THREADS: '$t' is not a positive integer" >&2; exit 2
+    fi
+    if [ "$t" -gt "$NPCPUS" ]; then
+        echo "THREADS=$t exceeds the $NPCPUS cpu id(s) in BENCH_PCPUS ($BENCH_PCPUS)." >&2
+        echo "Set BENCH_PCPUS to one logical id per physical core on this machine." >&2
+        exit 2
+    fi
+    [ "$t" -gt "$TMAX" ] && TMAX=$t
+done
 
 # Shapes: derived ONCE, from the detected arm, at the largest thread count (the
 # wide/short shapes depend on the thread budget). Both arms then get this list.
@@ -78,17 +95,26 @@ CSV_DET="$OUTDIR/blocking_ab_detected.csv"
 CSV_DEF="$OUTDIR/blocking_ab_default.csv"
 rm -f "$CSV_DET" "$CSV_DEF" "$CSV_DET.sysinfo" "$CSV_DEF.sysinfo"
 
+run_arm() {   # bin label csv cpus threads
+    MTL5_NUM_THREADS=$5 taskset -c "$4" "$1" \
+        --label "$2" --dtype "$DTYPE" --threads "$5" --reps "$REPS" \
+        --shapes "$SHAPES" --csv "$3"
+}
+
 for round in $(seq 1 "$ROUNDS"); do
     for t in $THREADS; do
         cpus=$(pin_for "$t")
         echo "== round $round, T=$t, cpus=$cpus"
-        # Interleaved: detected then default, back to back, same session.
-        MTL5_NUM_THREADS=$t taskset -c "$cpus" "$DET" \
-            --label detected --dtype "$DTYPE" --threads "$t" --reps "$REPS" \
-            --shapes "$SHAPES" --csv "$CSV_DET"
-        MTL5_NUM_THREADS=$t taskset -c "$cpus" "$DEF" \
-            --label default  --dtype "$DTYPE" --threads "$t" --reps "$REPS" \
-            --shapes "$SHAPES" --csv "$CSV_DEF"
+        # Interleaved AND order-alternated. Running one arm first every round
+        # would fold warm-up, frequency ramp and thermal drift into the ratio in
+        # a fixed direction; alternating cancels it to first order.
+        if [ $((round % 2)) -eq 1 ]; then
+            run_arm "$DET" detected "$CSV_DET" "$cpus" "$t"
+            run_arm "$DEF" default  "$CSV_DEF" "$cpus" "$t"
+        else
+            run_arm "$DEF" default  "$CSV_DEF" "$cpus" "$t"
+            run_arm "$DET" detected "$CSV_DET" "$cpus" "$t"
+        fi
     done
 done
 

--- a/benchmarks/run_blocking_ab.sh
+++ b/benchmarks/run_blocking_ab.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Cache-blocking A/B (#426, #432): does GEMM go faster with kc/mc derived from
+# the DETECTED cache hierarchy than with the hardcoded Haswell-class defaults?
+#
+# Both arms are the same source. `bench_blocking_ab_detected` uses the detection
+# merged in #426; `bench_blocking_ab_default` is built with
+# MTL5_DISABLE_CACHE_DETECTION and reproduces the pre-#426 blocking. Nothing else
+# differs, so a difference in throughput is a difference in kc/mc.
+#
+# Protocol, matching the discipline the rest of docs/benchmarks/ uses:
+#   * PINNED    -- one logical id per physical core. On a hybrid CPU this also
+#                  decides which cache hierarchy is detected at all (#432), so an
+#                  unpinned run here is not merely noisy, it is ambiguous.
+#   * INTERLEAVED -- arms alternate within one session. A ratio is only
+#                  defensible when both sides come from the same session.
+#   * MIN of N  -- the binary reports the minimum of --reps runs per point.
+#   * SHAPES DERIVED ONCE -- the shape list comes from the detected arm and is
+#                  passed verbatim to both, so the arms are never compared on
+#                  different shapes (their own mc/nc differ, so each would
+#                  otherwise pick its own).
+#
+# Environment:
+#   BUILD_DIR    build tree containing the benchmarks (default: build-release)
+#   BENCH_PCPUS  comma list of logical ids, one per physical core, in the order
+#                to use. MUST match your topology -- see `lscpu -e=CPU,CORE`.
+#                  i7-12700K P-cores : 0,2,4,6,8,10,12,14   (E-cores excluded)
+#                  Xeon E5-2420 v2   : 0,1,2,3,4,5
+#                Default: 0,2,4,6,8,10,12,14
+#   THREADS      thread counts to sweep (default "1 8")
+#   REPS         repetitions per point (default 5)
+#   ROUNDS       interleaved A/B rounds (default 3)
+#   DTYPE        double | float (default double)
+#   SHAPES       override the derived shape list, "m,n,k;m,n,k". Use for a quick
+#                smoke run; prefer the derived list for real measurements, since
+#                it is what puts the jc loop in play on THIS machine.
+#   OUTDIR       where CSVs land (default benchmarks/data)
+set -euo pipefail
+
+BUILD_DIR=${BUILD_DIR:-build-release}
+BENCH_PCPUS=${BENCH_PCPUS:-0,2,4,6,8,10,12,14}
+THREADS=${THREADS:-"1 8"}
+REPS=${REPS:-5}
+ROUNDS=${ROUNDS:-3}
+DTYPE=${DTYPE:-double}
+OUTDIR=${OUTDIR:-benchmarks/data}
+
+DET="$BUILD_DIR/benchmarks/bench_blocking_ab_detected"
+DEF="$BUILD_DIR/benchmarks/bench_blocking_ab_default"
+for b in "$DET" "$DEF"; do
+    if [ ! -x "$b" ]; then
+        echo "missing $b" >&2
+        echo "build with:  cmake --preset release && cmake --build $BUILD_DIR --target bench_blocking_ab_detected bench_blocking_ab_default -j4" >&2
+        exit 1
+    fi
+done
+mkdir -p "$OUTDIR"
+
+# Pin to the first T ids of BENCH_PCPUS. On a hybrid part this is also what fixes
+# WHICH cache hierarchy gets detected, so it is applied to every run including
+# the single-threaded ones.
+pin_for() {
+    local t=$1
+    echo "$BENCH_PCPUS" | cut -d, -f1-"$t"
+}
+
+TMAX=0
+for t in $THREADS; do [ "$t" -gt "$TMAX" ] && TMAX=$t; done
+
+# Shapes: derived ONCE, from the detected arm, at the largest thread count (the
+# wide/short shapes depend on the thread budget). Both arms then get this list.
+SHAPES=${SHAPES:-$(taskset -c "$(pin_for "$TMAX")" "$DET" --suggest-shapes --threads "$TMAX" --dtype "$DTYPE")}
+echo "shapes: $SHAPES"
+
+CSV_DET="$OUTDIR/blocking_ab_detected.csv"
+CSV_DEF="$OUTDIR/blocking_ab_default.csv"
+rm -f "$CSV_DET" "$CSV_DEF" "$CSV_DET.sysinfo" "$CSV_DEF.sysinfo"
+
+for round in $(seq 1 "$ROUNDS"); do
+    for t in $THREADS; do
+        cpus=$(pin_for "$t")
+        echo "== round $round, T=$t, cpus=$cpus"
+        # Interleaved: detected then default, back to back, same session.
+        MTL5_NUM_THREADS=$t taskset -c "$cpus" "$DET" \
+            --label detected --dtype "$DTYPE" --threads "$t" --reps "$REPS" \
+            --shapes "$SHAPES" --csv "$CSV_DET"
+        MTL5_NUM_THREADS=$t taskset -c "$cpus" "$DEF" \
+            --label default  --dtype "$DTYPE" --threads "$t" --reps "$REPS" \
+            --shapes "$SHAPES" --csv "$CSV_DEF"
+    done
+done
+
+echo
+echo "wrote $CSV_DET and $CSV_DEF (+ .sysinfo sidecars)"
+echo "compare with: benchmarks/analyze_blocking_ab.py $CSV_DET $CSV_DEF"

--- a/docs/benchmarks/systems.md
+++ b/docs/benchmarks/systems.md
@@ -65,9 +65,41 @@ Two things follow, and both matter when reading any result from this machine:
    discount.
 
 Under this page's pinning policy (P-cores, E-cores excluded) the relevant row is
-the first: against the Haswell defaults MTL5 blocks with `kc` 512 -> 768 and `mc`
-32 -> 106 for fp64. Whether that is *faster* is the open question, measured by
-`benchmarks/run_blocking_ab.sh`.
+the first: against the Haswell defaults, detection blocks with a larger `kc` and
+`mc`. **It is slower.**
+
+### Cache-blocking A/B result — detection loses here
+
+`benchmarks/run_blocking_ab.sh`, AVX2 build (`MTL5_NATIVE_ARCH=ON`), fp64,
+P-cores pinned, 5 interleaved rounds, min of 5. Ratio is detected / default
+throughput, so below 1 is a loss:
+
+| shape | T=1 | T=8 |
+|---|---|---|
+| 1024³ | 0.965 | **0.551** |
+| 2048³ | 0.920 | 0.929 |
+| 4096³ | 0.901 | 0.985 |
+| 852 × 8192 × 1024 | 0.914 | 0.806 |
+| 852 × 12288 × 1024 | 0.906 | 0.675 |
+
+`detected kc=384 mc=213` against `default kc=256 mc=64`. Nine losses, one tie,
+no wins. Three separate causes, and only the first is about cache sizing:
+
+1. **At T=1 the larger blocks are just slower, by ~9% at every size.** No
+   threading is involved: the analytical "half of L1, half of L2" sizing is
+   beaten by the hand-tuned constants on Golden Cove.
+2. **A larger `mc` starves the thread partition.** `gemm_blocked` fixes
+   `ic_nt = min(budget, nib)` from the *unbalanced* block count, so `mc` 64 → 213
+   takes `nib` 16 → 5 at 1024³ and five threads of eight do the work.
+3. **A larger `kc` inflates the packed B panel**, and once the jc loop splits
+   into teams each holds one: 2 × 12.6 MB against a 25 MiB L3.
+
+Causes 2 and 3 are the #408 / #429 family — a cache-derived parameter moving a
+*block count* the thread partition is sensitive to — and are defects independent
+of detection, which merely exposed them. Because of this result, cache detection
+ships **opt-in** (`MTL5_ENABLE_CACHE_DETECTION`); MTL5's shipped blocking is the
+compile-time defaults. Re-run the harness before assuming this verdict holds on
+different hardware.
 
 ### Vendor libraries
 

--- a/docs/benchmarks/systems.md
+++ b/docs/benchmarks/systems.md
@@ -72,7 +72,8 @@ the first: against the Haswell defaults, detection blocks with a larger `kc` and
 
 `benchmarks/run_blocking_ab.sh`, AVX2 build (`MTL5_NATIVE_ARCH=ON`), fp64,
 P-cores pinned, 5 interleaved rounds, min of 5. Ratio is detected / default
-throughput, so below 1 is a loss:
+throughput; the analyzer does not call anything within **2%** of parity, so
+`0.985` counts as a tie and everything below `0.98` is a loss:
 
 | shape | T=1 | T=8 |
 |---|---|---|
@@ -85,9 +86,9 @@ throughput, so below 1 is a loss:
 `detected kc=384 mc=213` against `default kc=256 mc=64`. Nine losses, one tie,
 no wins. Three separate causes, and only the first is about cache sizing:
 
-1. **At T=1 the larger blocks are just slower, by ~9% at every size.** No
-   threading is involved: the analytical "half of L1, half of L2" sizing is
-   beaten by the hand-tuned constants on Golden Cove.
+1. **At T=1 the larger blocks are slower at every size** — by 3.5% at 1024³ and
+   8–10% at the other four. No threading is involved: the analytical "half of L1,
+   half of L2" sizing is beaten by the hand-tuned constants on Golden Cove.
 2. **A larger `mc` starves the thread partition.** `gemm_blocked` fixes
    `ic_nt = min(budget, nib)` from the *unbalanced* block count, so `mc` 64 → 213
    takes `nib` 16 → 5 at 1024³ and five threads of eight do the work.

--- a/docs/benchmarks/systems.md
+++ b/docs/benchmarks/systems.md
@@ -39,6 +39,36 @@ The primary MTL5 development machine.
 | Compiler | GCC 13.3.0, `-O3 -DNDEBUG` (CMake `Release`) |
 | CPU governor | `powersave` (`intel_pstate`; still boosts, but clocks are not pinned) |
 
+### Cache hierarchy — two hierarchies, not one
+
+This machine has **two different cache configurations in one socket**, and which
+one MTL5 detects depends on where the detecting thread is scheduled (#432). Both
+readings are recorded because neither is "the" answer for this CPU:
+
+| Pinned to | L1d | L2 | L3 | fp64 `kc` `mc` | fp32 `kc` `mc` |
+|---|---|---|---|---|---|
+| P-core, `taskset -c 0` (Golden Cove) | 48 KiB, 12-way | 1.25 MiB **private** | 25 MiB | `768` `106` | `768` `213` |
+| E-core, `taskset -c 16` (Gracemont) | 32 KiB, 8-way | 2 MiB **shared by 4 cores** | 25 MiB | `512` `256` | `512` `512` |
+| — Haswell defaults, for comparison | 32 KiB | 256 KiB | 8 MiB | `512` `32` | `512` `64` |
+
+Read with `util_test_cache_info -s` from a `ci`-preset build. Blocking figures are
+the 128-bit (SSE) build; an AVX2 build divides them by the wider SIMD width.
+
+Two things follow, and both matter when reading any result from this machine:
+
+1. **Unpinned detection is not reproducible here.** The same binary reports either
+   row depending on the scheduler. Every measurement on this machine must pin, and
+   must record which core class it pinned to.
+2. **The E-core L2 is shared by four cores**, so its 2 MiB supports about 512 KiB
+   per core — the `mc = 256` derived from it assumes roughly 4x the L2 a core
+   actually gets. The P-core's 1.25 MiB is genuinely private and needs no such
+   discount.
+
+Under this page's pinning policy (P-cores, E-cores excluded) the relevant row is
+the first: against the Haswell defaults MTL5 blocks with `kc` 512 -> 768 and `mc`
+32 -> 106 for fp64. Whether that is *faster* is the open question, measured by
+`benchmarks/run_blocking_ab.sh`.
+
 ### Vendor libraries
 
 | Backend | Version | Selected by |

--- a/include/mtl/simd/blocking.hpp
+++ b/include/mtl/simd/blocking.hpp
@@ -220,10 +220,23 @@ constexpr hw_traits with_detected_caches(hw_traits base, const util::cache_info&
     return base;
 }
 
+/// Define MTL5_DISABLE_CACHE_DETECTION to compile out the runtime detection and
+/// fall back to `default_hw_traits` everywhere. Two uses, both real:
+///
+///   * the A/B lever for measuring detection against the compile-time defaults
+///     on one machine (benchmarks/run_blocking_ab.sh builds both arms from the
+///     same source, so only the blocking parameters differ);
+///   * the mitigation if detection is found to pick the wrong cache on some
+///     topology -- a hybrid CPU reports whichever core the detecting thread was
+///     scheduled on, and its L2 may be shared rather than private (#432).
 inline const hw_traits& detected_hw_traits() {
+#if defined(MTL5_DISABLE_CACHE_DETECTION)
+    return default_hw_traits;   // constexpr object: static storage, safe to bind
+#else
     static const hw_traits hw =
         with_detected_caches(default_hw_traits, util::cached_cache_info());
     return hw;
+#endif
 }
 
 /// Blocking parameters for `T` derived against the DETECTED hardware. Use kc and

--- a/include/mtl/simd/blocking.hpp
+++ b/include/mtl/simd/blocking.hpp
@@ -220,22 +220,50 @@ constexpr hw_traits with_detected_caches(hw_traits base, const util::cache_info&
     return base;
 }
 
-/// Define MTL5_DISABLE_CACHE_DETECTION to compile out the runtime detection and
-/// fall back to `default_hw_traits` everywhere. Two uses, both real:
+/// Runtime cache detection is OPT-IN: define MTL5_ENABLE_CACHE_DETECTION to let
+/// the detected hierarchy feed kc/mc. Without it this returns the compile-time
+/// defaults, which is what MTL5 ships.
 ///
-///   * the A/B lever for measuring detection against the compile-time defaults
-///     on one machine (benchmarks/run_blocking_ab.sh builds both arms from the
-///     same source, so only the blocking parameters differ);
-///   * the mitigation if detection is found to pick the wrong cache on some
-///     topology -- a hybrid CPU reports whichever core the detecting thread was
-///     scheduled on, and its L2 may be shared rather than private (#432).
+/// That is not caution, it is a measurement. Detection was wired in by #426 on
+/// the assumption that real cache sizes must beat figures hardcoded to a
+/// Haswell-class core. Measured on an i7-12700K (Golden Cove, P-cores pinned,
+/// AVX2, fp64, 5 interleaved rounds, min of 5) it LOST on 9 of 10 points:
+///
+///     detected  kc=384 mc=213      default  kc=256 mc=64
+///
+///     shape            T=1     T=8
+///     1024^3          0.965   0.551      <- 3 of 8 threads left idle
+///     2048^3          0.920   0.929
+///     4096^3          0.901   0.985
+///     852 x 8192      0.914   0.806      <- two 12.6 MB B panels in a 25 MB L3
+///     852 x 12288     0.906   0.675
+///     (ratio = detected / default throughput; < 1 is a loss)
+///
+/// Three distinct causes, and only the first is about cache sizing:
+///
+///   1. At T=1 the larger kc/mc are simply slower, everywhere, by ~9%. The
+///      analytical "half of L1, half of L2" sizing is beaten by the hand-tuned
+///      constants on this microarchitecture. No threading is involved.
+///   2. A larger mc means FEWER ic blocks, and gemm_blocked fixes
+///      ic_nt = min(budget, nib) from nib BEFORE balanced_mc runs. At 1024^3,
+///      mc 64 -> 213 takes nib 16 -> 5, so five threads of eight do the work.
+///   3. A larger kc inflates the packed B panel (kc x nc), and once the jc loop
+///      splits into teams each team holds one: 2 x 12.6 MB against a 25 MB L3.
+///
+/// (2) and (3) are the #408 / #429 family -- a cache-derived parameter moving a
+/// BLOCK COUNT that the thread partition is sensitive to. They are real defects
+/// independent of detection, and detection is what exposed them.
+///
+/// So the machinery stays, tested and available, and the shipped blocking is
+/// byte-identical to pre-#426 until the model is shown to win on hardware.
+/// benchmarks/run_blocking_ab.sh is how that is decided; #430 is the experiment.
 inline const hw_traits& detected_hw_traits() {
-#if defined(MTL5_DISABLE_CACHE_DETECTION)
-    return default_hw_traits;   // constexpr object: static storage, safe to bind
-#else
+#if defined(MTL5_ENABLE_CACHE_DETECTION)
     static const hw_traits hw =
         with_detected_caches(default_hw_traits, util::cached_cache_info());
     return hw;
+#else
+    return default_hw_traits;   // constexpr object: static storage, safe to bind
 #endif
 }
 

--- a/include/mtl/simd/blocking.hpp
+++ b/include/mtl/simd/blocking.hpp
@@ -241,9 +241,10 @@ constexpr hw_traits with_detected_caches(hw_traits base, const util::cache_info&
 ///
 /// Three distinct causes, and only the first is about cache sizing:
 ///
-///   1. At T=1 the larger kc/mc are simply slower, everywhere, by ~9%. The
-///      analytical "half of L1, half of L2" sizing is beaten by the hand-tuned
-///      constants on this microarchitecture. No threading is involved.
+///   1. At T=1 the larger kc/mc are slower at every size -- 3.5% at 1024^3 and
+///      8-10% at the rest. The analytical "half of L1, half of L2" sizing is
+///      beaten by the hand-tuned constants on this microarchitecture. No
+///      threading is involved.
 ///   2. A larger mc means FEWER ic blocks, and gemm_blocked fixes
 ///      ic_nt = min(budget, nib) from nib BEFORE balanced_mc runs. At 1024^3,
 ///      mc 64 -> 213 takes nib 16 -> 5, so five threads of eight do the work.

--- a/tests/unit/util/test_cache_info.cpp
+++ b/tests/unit/util/test_cache_info.cpp
@@ -83,12 +83,24 @@ TEST_CASE("detected_hw_traits overrides only what was detected",
     // Stated as an if/else on each field so an undetectable platform (non-x86
     // Windows, or a container without sysfs) is asserted to behave exactly as it
     // did before detection existed.
+#if defined(MTL5_ENABLE_CACHE_DETECTION)
     if (c.l1d_bytes  != 0) REQUIRE(hw.l1_bytes   == c.l1d_bytes);
     else                   REQUIRE(hw.l1_bytes   == def.l1_bytes);
     if (c.l2_bytes   != 0) REQUIRE(hw.l2_bytes   == c.l2_bytes);
     else                   REQUIRE(hw.l2_bytes   == def.l2_bytes);
     if (c.line_bytes != 0) REQUIRE(hw.line_bytes == c.line_bytes);
     else                   REQUIRE(hw.line_bytes == def.line_bytes);
+#else
+    // Detection is opt-in and this build did not opt in, so the SHIPPED blocking
+    // must be the compile-time defaults on every machine, whatever was detected
+    // (#426 measured the detected figures losing by up to 45% on an i7-12700K).
+    // Deliberately unconditional: this is the assertion that fails first if the
+    // default is ever flipped back without the measurement to justify it.
+    REQUIRE(hw.l1_bytes   == def.l1_bytes);
+    REQUIRE(hw.l2_bytes   == def.l2_bytes);
+    REQUIRE(hw.line_bytes == def.line_bytes);
+    REQUIRE(hw.l1_assoc   == def.l1_assoc);
+#endif
 
     // L3 is detected but NOT applied, whatever the machine reports: it feeds only
     // nc, and nc sets the jc block count that the threaded nest partitions
@@ -138,6 +150,14 @@ TEMPLATE_TEST_CASE("runtime_blocking keeps the compiled register tile",
 
     // Two calls return the same cached object.
     REQUIRE(&simd::runtime_blocking<TestType>() == &rbp);
+
+#if !defined(MTL5_ENABLE_CACHE_DETECTION)
+    // Detection opt-out (the shipped default): every parameter, not just the
+    // register tile, must equal the compile-time derivation -- kc and mc
+    // included. This is what makes the shipped GEMM byte-identical to pre-#426.
+    REQUIRE(rbp.kc == dbp.kc);
+    REQUIRE(rbp.mc == dbp.mc);
+#endif
 }
 
 TEST_CASE("an undetected cache level keeps the compile-time default",


### PR DESCRIPTION
## Summary

#426 wired the detected cache hierarchy into `kc`/`mc` on the assumption that real cache sizes must beat figures hardcoded to a Haswell-class core. **This PR measures that assumption and finds it false**, so detection becomes opt-in and shipped blocking returns byte-identical to pre-#426.

## The measurement

i7-12700K, Golden Cove, P-cores pinned, AVX2, fp64, 5 interleaved rounds, min of 5. `detected kc=384 mc=213` against `default kc=256 mc=64`. Ratio is detected/default throughput, so below 1 is a loss:

| shape | T=1 | T=8 |
|---|---|---|
| 1024³ | 0.965 | **0.551** |
| 2048³ | 0.920 | 0.929 |
| 4096³ | 0.901 | 0.985 |
| 852 × 8192 × 1024 | 0.914 | 0.806 |
| 852 × 12288 × 1024 | 0.906 | 0.675 |

**Nine losses, one tie, no wins.**

## Three causes, only one of them about cache sizing

1. **At T=1 the larger blocks are just slower** — ~9% at every size, no threading involved. The analytical "half of L1, half of L2" sizing is beaten by the hand-tuned constants on this microarchitecture. This is the finding that matters most, and no amount of fixing the thread nest repairs it.
2. **A larger `mc` starves the thread partition.** `gemm_blocked` fixes `ic_nt = min(budget, nib)` from the *unbalanced* block count, before `balanced_mc` runs. At 1024³, `mc` 64 → 213 takes `nib` 16 → 5, so **five threads of eight** do the work — which is the 0.551.
3. **A larger `kc` inflates the packed B panel.** Once the jc loop splits into teams each holds one: 2 × 12.6 MB against a 25 MiB L3.

Causes 2 and 3 are the #408 / #429 family — a cache-derived parameter moving a *block count* that the thread partition is acutely sensitive to. Both are defects that predate this work; detection merely exposed them.

## What changes

- **`MTL5_ENABLE_CACHE_DETECTION`** — detection is opt-in. Without it, `detected_hw_traits()` returns the compile-time defaults, so shipped blocking is byte-identical to pre-#426 on every machine.
- Everything else **stays**: the detection code, its CPUID/sysfs/sysctl paths, the tests, the harness, the i7 readings. #429, #430 and #432 all build on them, and the question is now *decidable* rather than assumed.
- Tests assert **both** configurations — with the macro, detected values must be applied; without it, `runtime_blocking` must equal `default_blocking` down to `kc` and `mc`. That unconditional assertion is what fails first if the default is ever flipped back without a measurement.

## The harness that produced this

- `benchmarks/bench_blocking_ab.cpp` built twice from one source; the arms differ *only* by the macro.
- `benchmarks/run_blocking_ab.sh` pins (`BENCH_PCPUS`, as `run_scaling.sh` does), interleaves within a session, min-of-N. **Shapes are derived from the machine**, once, from the detected arm and passed to both — the jc-parallel regime needs `nib ≤ T/2` and `njb ≥ 2`, and both bounds contain that machine's own `mc`/`nc`. Every #426 measurement was square, which is exactly where `jc_nt` is structurally 1 and none of this can appear.
- `benchmarks/analyze_blocking_ab.py` refuses to call a point unless the arms differ structurally, ranges don't overlap, and the effect clears 2%.

Validated first on the Xeon, a **null machine** (its L1/L2 already equal the defaults, so both arms compile identically and the right answer is "no difference"). The analyzer failed that on its first version — with 2 rounds it called a 4.8% "win" between two byte-identical configurations — and now detects identical parameters and declines to call anything. Structural control, not a statistical one.

## Docs

`docs/benchmarks/systems.md` gains both pinned cache readings for the i7 (it reports **two** hierarchies depending on where the detecting thread lands, #432) and the full A/B table above.

## Test Results

| | gcc | clang |
|---|---|---|
| full unit suite (detection off, shipped) | 164/164 | 164/164 |
| unit suite compiled **with** `MTL5_ENABLE_CACHE_DETECTION` | 63 assertions, 7 cases, pass | — |
| both A/B arms build + run | OK | — |

## Breaking change

Builds relying on #426's automatic `kc`/`mc` sizing must now define `MTL5_ENABLE_CACHE_DETECTION`. It was the default for less than a day and measured slower; no released version shipped it as the default.

Relates to #426, #429, #430, #432
