### PR TITLE
fix(build): lower CMakePresets schema to v3 so CMake 3.22 can read it

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,5 +1,5 @@
 {
-    "version": 6,
+    "version": 3,
     "cmakeMinimumRequired": { "major": 3, "minor": 22, "patch": 0 },
     "configurePresets": [
         {


### PR DESCRIPTION
## Summary

`CMakePresets.json` declared `"version": 6`, which requires **CMake 3.25+**. The same file declares `cmakeMinimumRequired` **3.22**, and `CMakeLists.txt` declares `cmake_minimum_required(VERSION 3.22)` — so the project claimed to support 3.22 while shipping a presets file 3.22 cannot parse:

```
$ cmake --preset ci
CMake Error: Could not read presets from /home/branes/dev/stillwater/clones/mtl5: Unrecognized "version" field
```

Reported on a **Jetson running Ubuntu 22.04's stock CMake 3.22.1** while setting it up for the #430 experiment. It went unnoticed because every other machine here runs a much newer CMake (4.2.1 on the Xeon), so the presets always parsed.

## Why v3 and not something else

Nothing in the file needs v6. That schema level exists for `packagePresets` and `workflowPresets`; this file has only `configurePresets`, using `name`, `displayName`, `binaryDir` and `cacheVariables` — all **schema v1** fields.

| schema | needs CMake | adds |
|---|---|---|
| v1 | 3.19 | `configurePresets` — everything this file actually uses |
| v3 | 3.21 | `condition`, `toolchainFile`, `installDir` |
| v6 | 3.25 | `packagePresets`, `workflowPresets` — unused |

v3 rather than v1 because it is the highest level CMake 3.22 accepts, so the presets can later gain `condition`/`toolchainFile` without another compatibility break.

## Verification

- All four presets (`dev`, `release`, `ci`, `ci-regression`) resolve after the change.
- `.github/workflows/ci.yml:580` uses `cmake --preset ci-regression`; unaffected.

Nothing else changes — this is a one-character version bump downward.

Generated with [Claude Code](https://claude.com/claude-code)