### PR TITLE
bench(simd): PowerShell driver for the cache-blocking A/B, and the MSVC ISA trap

### DIFF
--- a/benchmarks/run_blocking_ab.ps1
+++ b/benchmarks/run_blocking_ab.ps1
@@ -1,0 +1,188 @@
+<#
+.SYNOPSIS
+    Windows/MSVC port of run_blocking_ab.sh: A/B the detected cache blocking
+    against the compile-time defaults (#426, #430, #432).
+
+.DESCRIPTION
+    Both arms are the same source. bench_blocking_ab_detected is built with
+    MTL5_ENABLE_CACHE_DETECTION; bench_blocking_ab_default is what MTL5 ships.
+    Nothing else differs, so a difference in throughput is a difference in kc/mc.
+    Both targets live in ONE build tree, so this configures and builds once.
+
+    Protocol matches the bash driver and the rest of docs/benchmarks/:
+      * PINNED -- a Windows affinity BITMASK (OR of one bit per physical core),
+        since there is no taskset. SMT siblings excluded.
+      * INTERLEAVED with the order alternating per round, so warm-up and thermal
+        drift do not accrue to one arm.
+      * MIN of N -- the binary reports the minimum of -Reps runs per point.
+      * SHAPES DERIVED ONCE from the detected arm and passed to both, so the arms
+        are never compared on different shapes.
+
+    TWO WINDOWS-SPECIFIC CAVEATS, both worth reading before trusting a result:
+
+    1. ISA SELECTION. MTL5_NATIVE_ARCH is `if(MTL5_NATIVE_ARCH AND NOT MSVC)` in
+       CMakeLists.txt -- a NO-OP under MSVC. MSVC x64 defaults to SSE2, so
+       without an explicit /arch: flag Highway selects a 128-bit target and the
+       run measures blocking for 2 doubles. On a Zen 4 or Golden Cove part, whose
+       interest is AVX-512 / AVX2, that answers the wrong question while looking
+       perfectly clean. -Arch therefore defaults to /arch:AVX512 and is echoed
+       into the log. Set -Arch "" only if you intend to measure the baseline.
+
+    2. DETECTION AND AFFINITY. On Linux, cache detection reads sysfs restricted
+       to the process's affinity mask, so it describes the pinned cores. Windows
+       has no such path and falls back to CPUID, which describes whichever core
+       the thread is on -- and .NET can only set ProcessorAffinity AFTER the
+       process starts, so detection may already have run on another core. That is
+       harmless on a HOMOGENEOUS part (every core reports the same), which covers
+       ryzen-9-8945hs. On a hybrid Windows machine the detected arm's figures
+       would not be reproducible; do not use this driver there without fixing
+       #432's Windows half first.
+
+.PARAMETER PCores
+    First-logical-processor id of each physical core, in the order to fill. The
+    default 0,2,4,... matches an SMT machine whose sibling threads are adjacent
+    (verify with topology_probe: physical core -> logical mask).
+
+.PARAMETER Threads
+    Thread counts to sweep (default "1,8"). Each must be <= the number of -PCores.
+
+.PARAMETER Arch
+    Compiler ISA flag. Default /arch:AVX512 -- see caveat 1.
+
+.EXAMPLE
+    pwsh benchmarks/run_blocking_ab.ps1 -OutDir "benchmarks\data\ryzen-9-8945hs"
+#>
+[CmdletBinding()]
+param(
+    # Comma strings, not [int[]]: passing "1,8" to an [int[]] param via
+    # `powershell -File` coerces it to the single integer 18 (commas read as
+    # digit-group separators). Parse the strings into int lists ourselves.
+    [string]$PCores  = "0,2,4,6,8,10,12,14",
+    [string]$Threads = "1,8",
+    [int]$Reps       = 5,
+    [int]$Rounds     = 5,
+    [string]$DType   = "double",
+    [string]$Shapes  = "",          # empty: derive from the machine (preferred)
+    [string]$Arch    = "/arch:AVX512",
+    [string]$OutDir  = "benchmarks\data",
+    [string]$BuildDir = "build-blocking-ab",
+    [int]$Jobs       = [Environment]::ProcessorCount
+)
+
+[int[]]$PCoreList  = $PCores  -split ',' | ForEach-Object { [int]$_ }
+[int[]]$ThreadList = $Threads -split ',' | ForEach-Object { [int]$_ }
+
+foreach ($T in $ThreadList) {
+    if ($T -lt 1) { throw "-Threads: '$T' is not a positive integer." }
+    if ($T -gt $PCoreList.Count) {
+        throw "-Threads $T exceeds the $($PCoreList.Count) physical core(s) in -PCores ($PCores). Set -PCores to one logical id per physical core on this machine."
+    }
+}
+if ($Reps -lt 1)   { throw "-Reps must be > 0." }
+if ($Rounds -lt 1) { throw "-Rounds must be > 0." }
+if ($DType -ne "double" -and $DType -ne "float") { throw "-DType must be double or float." }
+
+# See run_sweeps.ps1 for why $ErrorActionPreference is left at Continue.
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+$DataDir  = Join-Path $RepoRoot $OutDir
+$LogDir   = Join-Path $DataDir "logs"
+New-Item -ItemType Directory -Force -Path $DataDir, $LogDir | Out-Null
+
+# Affinity mask covering the first T physical cores (one logical id per core).
+function Mask-ForThreads {
+    param([int]$T)
+    $m = 0L
+    for ($i = 0; $i -lt $T; $i++) { $m = $m -bor (1L -shl $PCoreList[$i]) }
+    return $m
+}
+
+function Invoke-Native {
+    param([string]$Exe, [string[]]$NativeArgs, [string]$LogBase)
+    $p = Start-Process -FilePath $Exe -ArgumentList $NativeArgs -PassThru -NoNewWindow -Wait `
+                       -RedirectStandardOutput "$LogBase.out.log" -RedirectStandardError "$LogBase.err.log"
+    return $p.ExitCode
+}
+
+# --- build both arms from one tree ------------------------------------------
+$Full = Join-Path $RepoRoot $BuildDir
+$cfg  = @("-B", $Full,
+          "-DMTL5_BUILD_BENCHMARKS=ON", "-DMTL5_BUILD_TESTS=OFF", "-DMTL5_BUILD_EXAMPLES=OFF",
+          "-DCMAKE_BUILD_TYPE=Release", "-DMTL5_WITH_HIGHWAY=ON")
+if ($Arch -ne "") { $cfg += "-DCMAKE_CXX_FLAGS=$Arch" }
+
+Write-Host "=== configure ($BuildDir)"
+Write-Host ("    ISA flag: {0}" -f $(if ($Arch -ne "") { $Arch } else { "<none> -- measuring the MSVC default (SSE2)" }))
+if ((Invoke-Native "cmake" $cfg (Join-Path $LogDir "blocking_ab.configure")) -ne 0) {
+    throw "configure failed (see $LogDir\blocking_ab.configure.err.log)"
+}
+Write-Host "=== build"
+$targets = @("--build", $Full, "--config", "Release",
+             "--target", "bench_blocking_ab_detected", "bench_blocking_ab_default", "-j", "$Jobs")
+if ((Invoke-Native "cmake" $targets (Join-Path $LogDir "blocking_ab.build")) -ne 0) {
+    throw "build failed (see $LogDir\blocking_ab.build.err.log)"
+}
+
+$Det = Join-Path $Full "benchmarks\Release\bench_blocking_ab_detected.exe"
+$Def = Join-Path $Full "benchmarks\Release\bench_blocking_ab_default.exe"
+foreach ($exe in @($Det, $Def)) {
+    if (-not (Test-Path $exe)) { throw "missing $exe after build" }
+}
+
+# --- run one arm, pinned -----------------------------------------------------
+# Affinity is applied immediately after Start(); see caveat 2 in the header for
+# what that means for detection on a hybrid part.
+function Run-Arm {
+    param([string]$Exe, [string]$Label, [string]$Csv, [long]$Mask, [int]$T, [string]$ShapeSpec)
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName  = $Exe
+    $psi.Arguments = "--label $Label --dtype $DType --threads $T --reps $Reps --shapes `"$ShapeSpec`" --csv `"$Csv`""
+    $psi.UseShellExecute = $false          # stderr inherits the console: the
+    $psi.RedirectStandardOutput = $true    # per-arm blocking params stay visible
+    $env:MTL5_NUM_THREADS = "$T"
+    $p = [System.Diagnostics.Process]::Start($psi)
+    try { $p.ProcessorAffinity = [IntPtr]$Mask; $p.PriorityClass = 'High' } catch { Write-Warning $_ }
+    $p.StandardOutput.ReadToEnd() | Out-Null
+    $p.WaitForExit()
+    if ($p.ExitCode -ne 0) { throw "$Label arm failed (T=$T, exit $($p.ExitCode))" }
+}
+
+# --- shapes: derived ONCE, from the detected arm, at the largest thread count -
+$TMax = ($ThreadList | Measure-Object -Maximum).Maximum
+if ($Shapes -eq "") {
+    $maskMax = Mask-ForThreads $TMax
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName  = $Det
+    $psi.Arguments = "--suggest-shapes --threads $TMax --dtype $DType"
+    $psi.UseShellExecute = $false
+    $psi.RedirectStandardOutput = $true
+    $p = [System.Diagnostics.Process]::Start($psi)
+    try { $p.ProcessorAffinity = [IntPtr]$maskMax } catch { Write-Warning $_ }
+    $Shapes = ($p.StandardOutput.ReadToEnd()).Trim()
+    $p.WaitForExit()
+    if ($Shapes -eq "") { throw "could not derive shapes from $Det" }
+}
+Write-Host "shapes: $Shapes"
+
+$CsvDet = Join-Path $DataDir "blocking_ab_detected.csv"
+$CsvDef = Join-Path $DataDir "blocking_ab_default.csv"
+foreach ($f in @($CsvDet, $CsvDef, "$CsvDet.sysinfo", "$CsvDef.sysinfo")) {
+    if (Test-Path $f) { Remove-Item $f -Force }
+}
+
+for ($round = 1; $round -le $Rounds; $round++) {
+    foreach ($T in $ThreadList) {
+        $mask = Mask-ForThreads $T
+        Write-Host ("== round {0}, T={1}, affinity mask 0x{2:x}" -f $round, $T, $mask)
+        if ($round % 2 -eq 1) {
+            Run-Arm $Det "detected" $CsvDet $mask $T $Shapes
+            Run-Arm $Def "default"  $CsvDef $mask $T $Shapes
+        } else {
+            Run-Arm $Def "default"  $CsvDef $mask $T $Shapes
+            Run-Arm $Det "detected" $CsvDet $mask $T $Shapes
+        }
+    }
+}
+
+Write-Host ""
+Write-Host "wrote $CsvDet and $CsvDef (+ .sysinfo sidecars)"
+Write-Host "compare with: python benchmarks/analyze_blocking_ab.py `"$CsvDet`" `"$CsvDef`""

--- a/docs/benchmarks/systems.md
+++ b/docs/benchmarks/systems.md
@@ -374,6 +374,8 @@ question untested here. Any conclusion about L3 or `nc` waits on the
 `balanced_nc` work in #429; until then, treat detected-L3 results as
 experimental and out of scope for this runbook.
 
+**Linux (GCC/Clang):**
+
 ```bash
 cmake --preset release -DMTL5_WITH_HIGHWAY=ON -DMTL5_NATIVE_ARCH=ON
 cmake --build build-release --target bench_blocking_ab_detected bench_blocking_ab_default -j4
@@ -388,12 +390,39 @@ BENCH_PCPUS=0,2,4,6,8,10,12,14 THREADS="1 8" ROUNDS=5 \
 ./benchmarks/analyze_blocking_ab.py benchmarks/data/blocking_ab_{detected,default}.csv
 ```
 
+**Windows (MSVC)** — there is no `taskset`, so pinning is an affinity bitmask and
+the driver is PowerShell, following `run_scaling.ps1`:
+
+```powershell
+pwsh benchmarks/run_blocking_ab.ps1 `
+     -PCores "0,2,4,6,8,10,12,14" -Threads "1,8" -Rounds 5 `
+     -Arch "/arch:AVX512" -OutDir "benchmarks\data\ryzen-9-8945hs"
+
+python benchmarks/analyze_blocking_ab.py `
+     benchmarks\data\ryzen-9-8945hs\blocking_ab_detected.csv `
+     benchmarks\data\ryzen-9-8945hs\blocking_ab_default.csv
+```
+
+One caveat that is specific to Windows and does not apply on Linux: cache
+detection there falls back to CPUID, which describes whichever core the thread is
+running on, and .NET can only set `ProcessorAffinity` *after* the process starts —
+so detection may run before the pin takes effect. That is harmless on a
+**homogeneous** part, where every core reports the same hierarchy (which covers
+`ryzen-9-8945hs`), and it is why the Linux path reads sysfs under the affinity
+mask instead. Do not use the PowerShell driver on a hybrid Windows machine
+without closing that gap first — the detected arm's figures would not be
+reproducible.
+
 Four things decide whether the result means anything:
 
-- **`-DMTL5_NATIVE_ARCH=ON` is not optional.** Without it Highway compiles for the
+- **An explicit ISA flag is not optional.** Without one Highway compiles for the
   baseline 128-bit target rather than the machine's real ISA, and since `kc`, `mc`
   and `nc` all divide by the SIMD width, you would be measuring blocking for a
-  vector length the production build never uses.
+  vector length the production build never uses. On GCC/Clang that is
+  `-DMTL5_NATIVE_ARCH=ON`. **On MSVC that option does nothing** — it is guarded
+  `if(MTL5_NATIVE_ARCH AND NOT MSVC)`, and MSVC x64 defaults to SSE2 — so pass
+  the ISA directly, e.g. `-DCMAKE_CXX_FLAGS="/arch:AVX512"`. This is easy to miss
+  because the run completes and produces a clean table either way.
 - **`BENCH_PCPUS` must list one logical id per *physical* core**, in the order to
   use — the example above is the i7's and must be replaced for any other machine.
   On a hybrid CPU it does more than control noise: it fixes *which cache hierarchy


### PR DESCRIPTION
## Summary

The Zen 4 machine (`ryzen-9-8945hs`) is **Windows 11 / MSVC**, so `run_blocking_ab.sh` cannot run there at all — there is no `taskset`, and pinning is a Windows affinity bitmask. This is the port, plus the ISA trap that would have silently invalidated the run.

## `benchmarks/run_blocking_ab.ps1`

Follows `run_scaling.ps1`'s conventions exactly:

- `-PCores` as one logical id per **physical** core; an OR'd bitmask applied through `ProcessorAffinity`, `PriorityClass = 'High'`
- comma-strings parsed by hand — an `[int[]]` param would read `"1,8"` as the integer **18**, which that script documents having been bitten by
- logs under the data dir, `--config Release`, binaries from `benchmarks\Release\`

One simplification over `run_scaling.ps1`: both arms are targets in a **single** build tree, so it configures and builds once rather than per variant.

Protocol is identical to the bash driver — pinned, interleaved with the order alternating per round, min-of-N, and shapes derived **once** from the detected arm then passed to both.

## The trap this exists to prevent

```cmake
if(MTL5_NATIVE_ARCH AND NOT MSVC)
```

`MTL5_NATIVE_ARCH` is a **no-op under MSVC**, and MSVC x64 defaults to SSE2. So passing `-DMTL5_NATIVE_ARCH=ON` on Windows — which the runbook told you to do, and which **`run_scaling.ps1` already does** — silently measures a 128-bit target. On a Zen 4 part, whose entire interest here is AVX-512 (8 doubles → `nr=16`, and `kc`/`mc` divide completely differently), that answers the wrong question while producing a perfectly clean table.

`-Arch` defaults to `/arch:AVX512` and is echoed into the log so the ISA is on the record. `systems.md` now gives the GCC/Clang and MSVC spellings separately, and says why the difference is easy to miss.

*(Worth a separate look: the existing `native-fast` numbers on the ryzen results page were produced by `run_scaling.ps1` with that same no-op flag, so they are presumably baseline-ISA figures. Not touched here.)*

## A limitation I chose to document rather than paper over

On Windows, detection falls back to CPUID — which reads whichever core the thread is on — and .NET can only set `ProcessorAffinity` *after* the process starts. So the pin may land after detection has already run.

That is harmless on a **homogeneous** part, where every core reports the same hierarchy, which covers this machine. It is also exactly why the Linux path reads sysfs under the affinity mask instead (#432). The script header and `systems.md` both say not to use this driver on a hybrid Windows machine until that gap is closed, because the detected arm's figures would not be reproducible there.

## Validation — and its limit

**Not validated on Windows.** There is no PowerShell on any machine I can reach, so I could not parse it, let alone run it. What I did check here:

- brace / paren / bracket balance, and quote balance (no odd unescaped `"`)
- an idiom-by-idiom diff against `run_scaling.ps1`: `-bor`/`-shl` mask construction, `[IntPtr]` cast, `Measure-Object -Maximum`, `Join-Path`, and `UseShellExecute = $false` with **only stdout** redirected — stderr inherits the console, so the per-arm blocking parameters stay visible and there is no second pipe to deadlock on
- GCC 164/164 on the repo as a whole (the script is not in any build)

The first run on the Zen 4 box is the real test. If it fails, it will most likely be in argument quoting or the `Release\` path, both of which are one-line fixes.

Relates to #430

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Windows PowerShell workflow for comparing detected and default cache-blocking performance.
  * Supports configurable cores, threads, repetitions, rounds, data types, shapes, architectures, build options, and output locations.
  * Records benchmark results and system information, with validation and failure handling.

* **Documentation**
  * Added Windows/MSVC benchmarking instructions, including processor affinity and ISA configuration guidance.
  * Clarified Linux-specific instructions and Windows cache-detection limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->