### PR TITLE
fix(bench): harden the PowerShell A/B driver (review follow-up to #437)

### DIFF
--- a/benchmarks/run_blocking_ab.ps1
+++ b/benchmarks/run_blocking_ab.ps1
@@ -72,6 +72,22 @@ param(
 [int[]]$PCoreList  = $PCores  -split ',' | ForEach-Object { [int]$_ }
 [int[]]$ThreadList = $Threads -split ',' | ForEach-Object { [int]$_ }
 
+# Validate -PCores BEFORE -Threads, because -Threads is checked against its
+# count. "0,0" would otherwise pass a two-thread run whose mask is 0x1: two
+# nominal threads sharing one logical processor, producing scaling data that is
+# wrong rather than merely noisy. A 64-bit process affinity mask addresses ids
+# 0-63, so anything outside that cannot be pinned at all.
+$seen = @{}
+foreach ($c in $PCoreList) {
+    if ($c -lt 0 -or $c -gt 63) {
+        throw "-PCores: id $c is outside the 0-63 range a process affinity mask can address."
+    }
+    if ($seen.ContainsKey($c)) {
+        throw "-PCores: id $c appears more than once. Give one logical id per PHYSICAL core; duplicates silently shrink the affinity mask."
+    }
+    $seen[$c] = $true
+}
+
 foreach ($T in $ThreadList) {
     if ($T -lt 1) { throw "-Threads: '$T' is not a positive integer." }
     if ($T -gt $PCoreList.Count) {
@@ -96,9 +112,19 @@ function Mask-ForThreads {
     return $m
 }
 
+# -ArgumentList joins an array with spaces, so an element that CONTAINS a space
+# would be split into two arguments. Windows repo paths routinely sit under
+# "C:\Users\First Last\...", which would otherwise break `-B <builddir>` in a way
+# that surfaces as a confusing CMake error rather than a quoting error.
+function Quote-Arg {
+    param([string]$a)
+    if ($a -match '\s') { return '"' + $a + '"' } else { return $a }
+}
+
 function Invoke-Native {
     param([string]$Exe, [string[]]$NativeArgs, [string]$LogBase)
-    $p = Start-Process -FilePath $Exe -ArgumentList $NativeArgs -PassThru -NoNewWindow -Wait `
+    $quoted = @($NativeArgs | ForEach-Object { Quote-Arg $_ })
+    $p = Start-Process -FilePath $Exe -ArgumentList $quoted -PassThru -NoNewWindow -Wait `
                        -RedirectStandardOutput "$LogBase.out.log" -RedirectStandardError "$LogBase.err.log"
     return $p.ExitCode
 }
@@ -107,8 +133,14 @@ function Invoke-Native {
 $Full = Join-Path $RepoRoot $BuildDir
 $cfg  = @("-B", $Full,
           "-DMTL5_BUILD_BENCHMARKS=ON", "-DMTL5_BUILD_TESTS=OFF", "-DMTL5_BUILD_EXAMPLES=OFF",
-          "-DCMAKE_BUILD_TYPE=Release", "-DMTL5_WITH_HIGHWAY=ON")
-if ($Arch -ne "") { $cfg += "-DCMAKE_CXX_FLAGS=$Arch" }
+          "-DCMAKE_BUILD_TYPE=Release", "-DMTL5_WITH_HIGHWAY=ON",
+          # ALWAYS set it, empty included. Omitting it for -Arch "" would leave a
+          # previous /arch:AVX512 sitting in this build tree's CMake cache while
+          # the log below announced an SSE2 baseline -- the build would be AVX-512
+          # and the record would say otherwise. That is precisely the failure this
+          # script exists to prevent, so it must not be reintroduced by the escape
+          # hatch.
+          "-DCMAKE_CXX_FLAGS=$Arch")
 
 Write-Host "=== configure ($BuildDir)"
 Write-Host ("    ISA flag: {0}" -f $(if ($Arch -ne "") { $Arch } else { "<none> -- measuring the MSVC default (SSE2)" }))
@@ -140,7 +172,16 @@ function Run-Arm {
     $psi.RedirectStandardOutput = $true    # per-arm blocking params stay visible
     $env:MTL5_NUM_THREADS = "$T"
     $p = [System.Diagnostics.Process]::Start($psi)
-    try { $p.ProcessorAffinity = [IntPtr]$Mask; $p.PriorityClass = 'High' } catch { Write-Warning $_ }
+    # Pinning is FATAL, not advisory. Warning and continuing would append samples
+    # to a CSV whose whole claim is that they were taken on N pinned physical
+    # cores -- unpinned numbers filed as pinned ones are worse than no numbers.
+    try { $p.ProcessorAffinity = [IntPtr]$Mask }
+    catch {
+        try { $p.Kill() } catch { }
+        throw "could not pin $Label to mask 0x$('{0:x}' -f $Mask): $_"
+    }
+    # Priority is a nice-to-have and stays advisory.
+    try { $p.PriorityClass = 'High' } catch { Write-Warning "priority class: $_" }
     $p.StandardOutput.ReadToEnd() | Out-Null
     $p.WaitForExit()
     if ($p.ExitCode -ne 0) { throw "$Label arm failed (T=$T, exit $($p.ExitCode))" }
@@ -156,9 +197,17 @@ if ($Shapes -eq "") {
     $psi.UseShellExecute = $false
     $psi.RedirectStandardOutput = $true
     $p = [System.Diagnostics.Process]::Start($psi)
-    try { $p.ProcessorAffinity = [IntPtr]$maskMax } catch { Write-Warning $_ }
+    try { $p.ProcessorAffinity = [IntPtr]$maskMax }
+    catch {
+        try { $p.Kill() } catch { }
+        throw "could not pin shape discovery to mask 0x$('{0:x}' -f $maskMax): $_"
+    }
     $Shapes = ($p.StandardOutput.ReadToEnd()).Trim()
     $p.WaitForExit()
+    # Exit code first: a failing --suggest-shapes that still wrote something to
+    # stdout would otherwise feed a garbage shape list to BOTH arms, and the run
+    # would complete and compare them happily.
+    if ($p.ExitCode -ne 0) { throw "shape discovery failed (exit $($p.ExitCode)) from $Det" }
     if ($Shapes -eq "") { throw "could not derive shapes from $Det" }
 }
 Write-Host "shapes: $Shapes"


### PR DESCRIPTION
## Summary

Five CodeRabbit findings on #437, which merged before they could be addressed. All five are valid; **two are the exact failure class the script was written to prevent** — a run that completes, writes a plausible CSV, and quietly violates the protocol it claims.

## The two that produce wrong data rather than an error

**`-Arch ""` left a stale ISA in the CMake cache.** The flag was only passed when non-empty, so a build tree previously configured with `/arch:AVX512` kept it — while the log printed `<none> -- measuring the MSVC default (SSE2)`. The binary would be AVX-512 and the record would say baseline. Given this script exists *because* MSVC silently ignores `MTL5_NATIVE_ARCH`, reintroducing the same trap through the escape hatch is not a detail. `-DCMAKE_CXX_FLAGS` is now always passed, empty included.

**Affinity failure warned and continued.** The CSV's whole claim is "N pinned physical cores"; appending unpinned samples to it is worse than failing. Pinning is now fatal in both the arm and shape-discovery paths, killing the process first. `PriorityClass` stays advisory — it is a nice-to-have, not part of the claim.

## The other three

- **`-PCores` accepted duplicates and out-of-range ids.** `"0,0"` passed a two-thread run whose mask is `0x1` — two nominal threads on one logical processor, which is *wrong* data, not noisy data. Ids must now be unique and within the 0–63 an affinity mask can address, validated **before** `-Threads`, since `-Threads` is checked against their count.
- **`Start-Process -ArgumentList` splits array elements containing spaces.** Windows repos routinely live under `C:\Users\First Last\...`, where that broke `-B <builddir>` and surfaced as a confusing CMake error rather than a quoting one. Elements with whitespace are now quoted.
- **Shape discovery ignored the exit code.** A failing `--suggest-shapes` that still printed something would feed a garbage shape list to *both* arms, and the comparison would proceed happily.

## Validation, and its limit — unchanged from #437

Still **not executable here**: no PowerShell on any machine I can reach. Re-checked what is checkable — brace/paren/bracket balance, quote balance, `try`/`catch` pairing (5/5), and that each fix sits at the right site. The first run on the Zen 4 box remains the real test.

Worth noting the same `-ArgumentList` quoting issue exists in `run_scaling.ps1` and `run_sweeps.ps1`, which I have not touched here — it would bite identically on a path with a space, and is a candidate for a follow-up if those scripts are ever run from such a checkout.

Relates to #430, #437

Generated with [Claude Code](https://claude.com/claude-code)
