### PR TITLE
perf(simd): plan the GEMM thread grid instead of greedily filling it

### DIFF
--- a/include/mtl/detail/gemm_blocked.hpp
+++ b/include/mtl/detail/gemm_blocked.hpp
@@ -102,6 +102,75 @@ inline std::size_t balanced_mc(std::size_t m, std::size_t mc_max, unsigned ic_nt
     return mc == 0 ? mc_max : mc;
 }
 
+/// The threaded nest's shape decision: the ic block size and the ic x jc thread
+/// grid. Pure, so it can be unit-tested and enumerated offline (#430) instead of
+/// being inferred from a throughput change.
+struct gemm_grid {
+    std::size_t mc;      ///< ic block size actually used (<= the cache bound)
+    std::size_t nib;     ///< ic blocks that mc produces
+    std::size_t njb;     ///< jc blocks
+    unsigned    ic_nt;   ///< threads across ic
+    unsigned    jc_nt;   ///< teams across jc
+};
+
+/// Choose mc and the grid for an m x n problem on `budget` threads.
+///
+/// Two defects this fixes, both found by measuring three machines (#430) and both
+/// costing whole cores rather than percentages:
+///
+/// 1. mc WAS THE CACHE BOUND ONLY, so `nib = ceil(m/mc)` could be smaller than
+///    the budget and cap ic_nt permanently -- with njb == 1 (square problems,
+///    where n <= nc) there is no jc parallelism to make up the difference and the
+///    machine simply idles. Measured: an i7-12700K at 1024^3 ran 5 of 8 threads
+///    (ratio 0.551 against the smaller-mc arm) and a Zen 4 ran 4 of 8 (0.590).
+///    mc is therefore also bounded by ceil(m/budget) -- enough blocks to hand
+///    every thread one -- floored at a single register tile. This only ever
+///    LOWERS mc, so the L2 bound is still respected, and it binds ONLY when the
+///    partition would otherwise starve: at the shipped mc = 64 with m = 1024 and
+///    8 threads the cap is 128 and nothing changes.
+///
+/// 2. THE FACTORIZATION WAS GREEDY: fill ic first, then give jc the integer
+///    quotient. That throws the remainder away -- at budget 6 with nib = 4 it
+///    picked 4 x 1 = 4 and left two cores idle, while 3 x 2 and 2 x 3 were both
+///    legal. Measured on a Jetson Orin Nano: 0.760 where the grid was the only
+///    difference. The search below is exhaustive over ic (a handful of values)
+///    and maximises ic_nt * jc_nt, preferring the larger ic_nt on ties because a
+///    wider ic team keeps the shared packed-B panel resident.
+constexpr gemm_grid plan_gemm_grid(std::size_t m, std::size_t n,
+                                   std::size_t mc_cache, std::size_t nc,
+                                   std::size_t mr, unsigned budget) {
+    if (budget < 1) budget = 1;
+    // mc is a divisor and a loop step, so it must never leave here as 0 even on
+    // a degenerate call -- a 0 step would not terminate. Everything else about a
+    // degenerate call is "nothing to do": no blocks, a 1x1 grid.
+    gemm_grid g{mc_cache < 1 ? 1 : mc_cache, 0, 0, 1, 1};
+    if (m == 0 || n == 0 || mc_cache == 0 || nc == 0) return g;
+
+    // (1) Enough ic blocks to fill the budget, if m allows. Never below one
+    // register tile -- a block shorter than mr would waste the micro-kernel.
+    const std::size_t want = (m + budget - 1) / budget;
+    if (want < g.mc) g.mc = (want < mr) ? (mr < mc_cache ? mr : mc_cache) : want;
+
+    g.nib = (m + g.mc - 1) / g.mc;
+    g.njb = (n + nc - 1) / nc;
+
+    // (2) Exhaustive search for the largest usable grid.
+    unsigned best_ic = 1, best_jc = 1, best_grid = 1;
+    const unsigned ic_max = static_cast<unsigned>(g.nib < budget ? g.nib : budget);
+    for (unsigned ic = 1; ic <= ic_max; ++ic) {
+        unsigned jc = budget / ic;
+        if (jc > g.njb) jc = static_cast<unsigned>(g.njb);
+        if (jc < 1) continue;
+        const unsigned cand = ic * jc;
+        if (cand > best_grid || (cand == best_grid && ic > best_ic)) {
+            best_grid = cand; best_ic = ic; best_jc = jc;
+        }
+    }
+    g.ic_nt = best_ic;
+    g.jc_nt = best_jc;
+    return g;
+}
+
 inline unsigned gemm_default_threads() {
     return thread_pool::instance().size();
 }
@@ -254,32 +323,30 @@ void gemm_blocked(std::size_t m, std::size_t n, std::size_t k,
 
     if (nthreads <= 1) { serial_nest(); return; }
 
-    // Block-start lists for the m (ic) and n (jc) dimensions.
+    // The thread budget is needed BEFORE the block lists, because it now bounds
+    // the ic block size -- see plan_gemm_grid. Never exceed the pool: pool.run()
+    // clamps its worker count to the pool size, so a grid sized past the pool
+    // would leave team members that never run, and their barrier would wait
+    // forever (deadlock).
+    thread_pool& pool = thread_pool::instance();
+    const unsigned budget = std::min(nthreads, pool.size());
+    if (budget <= 1) { serial_nest(); return; }
+
+    const gemm_grid plan = plan_gemm_grid(m, n, MC, NC, MR, budget);
+
+    // Block-start lists for the m (ic) and n (jc) dimensions. The m dimension
+    // steps by the PLANNED mc, which may be smaller than the cache bound MC when
+    // the cache bound alone would not produce enough blocks to fill the machine.
     std::vector<std::size_t> ic_starts, jc_starts;
-    for (std::size_t ic = 0; ic < m; ic += MC) ic_starts.push_back(ic);
+    for (std::size_t ic = 0; ic < m; ic += plan.mc) ic_starts.push_back(ic);
     for (std::size_t jc = 0; jc < n; jc += NC) jc_starts.push_back(jc);
     const std::size_t nib = ic_starts.size();
     const std::size_t njb = jc_starts.size();
 
     // Thread budget: never exceed the pool. pool.run() clamps its worker count to
-    // the pool size, so a grid sized past the pool would leave team members that
-    // never run -- and their barrier would wait forever (deadlock). Cap here.
-    thread_pool& pool = thread_pool::instance();
-    const unsigned budget = std::min(nthreads, pool.size());
-    if (budget <= 1) { serial_nest(); return; }
-
-    // 2D grid factorization (deterministic; affects performance, not results).
-    // Fill the ic loop first (keeps the shared B panel resident and maximizes its
-    // reuse), then hand any leftover threads to the jc loop. Re-expand ic with
-    // whatever remains so the grid uses as many threads as the shape allows.
-    // grid = ic_nt * jc_nt <= budget <= pool size (surplus threads stay idle).
-    unsigned ic_nt = static_cast<unsigned>(std::min<std::size_t>(budget, nib));
-    if (ic_nt < 1) ic_nt = 1;
-    unsigned jc_nt = static_cast<unsigned>(std::min<std::size_t>(budget / ic_nt, njb));
-    if (jc_nt < 1) jc_nt = 1;
-    ic_nt = static_cast<unsigned>(std::min<std::size_t>(budget / jc_nt, nib));
-    if (ic_nt < 1) ic_nt = 1;
-    const unsigned grid = ic_nt * jc_nt;
+    const unsigned ic_nt = plan.ic_nt;
+    const unsigned jc_nt = plan.jc_nt;
+    const unsigned grid  = ic_nt * jc_nt;
 
     if (grid <= 1) { serial_nest(); return; }
 
@@ -292,8 +359,8 @@ void gemm_blocked(std::size_t m, std::size_t n, std::size_t k,
     // This changes neither the result nor its bit-identity to the serial nest:
     // the FMA order for a given C element is fixed by the pc (k) loop, which is
     // untouched, and ic blocking only decides which rows are grouped together.
-    MC_eff = balanced_mc(m, MC, ic_nt, MR);
-    if (MC_eff != MC) {
+    MC_eff = balanced_mc(m, plan.mc, ic_nt, MR);
+    if (MC_eff != plan.mc) {
         ic_starts.clear();
         for (std::size_t ic = 0; ic < m; ic += MC_eff) ic_starts.push_back(ic);
     }

--- a/tests/unit/detail/test_gemm_grid.cpp
+++ b/tests/unit/detail/test_gemm_grid.cpp
@@ -14,6 +14,23 @@ using mtl::detail::plan_gemm_grid;
 namespace {
 // The default fp64 blocking on an AVX2 build, for the machines below.
 constexpr std::size_t NC = 4096, MR = 6;
+
+/// The factorization plan_gemm_grid REPLACED: fill ic, then hand jc the integer
+/// quotient. Kept here as a reference so a test can assert the planner is at
+/// least as good, and strictly better where it matters. Without this the search
+/// is easy to test vacuously -- most shapes are solved by the mc cap alone, and
+/// a greedy split reaches the same grid.
+unsigned greedy_grid(std::size_t nib, std::size_t njb, unsigned budget) {
+    unsigned ic = static_cast<unsigned>(nib < budget ? nib : budget);
+    if (ic < 1) ic = 1;
+    unsigned jc = budget / ic;
+    if (jc > njb) jc = static_cast<unsigned>(njb);
+    if (jc < 1) jc = 1;
+    ic = budget / jc;
+    if (ic > nib) ic = static_cast<unsigned>(nib);
+    if (ic < 1) ic = 1;
+    return ic * jc;
+}
 } // namespace
 
 TEST_CASE("a large mc no longer starves the ic partition", "[detail][gemm][grid]") {
@@ -42,11 +59,12 @@ TEST_CASE("the grid search finds factorizations the greedy split missed",
     // ic = min(6,4) = 4 then jc = 6/4 = 1 -> grid 4, two cores idle, measured
     // 0.760.
     //
-    // Note WHICH repair applies. The mc cap fires first -- ceil(64/6) = 11 is
-    // below the 16 cache bound -- giving nib = 6 and a 6x1 grid, so the search
-    // never needs the 3x2 that was missing before. Both defects pointed at this
-    // shape; the cap reaches it by the better route, since one wide ic team
-    // shares a single packed-B panel where 3x2 would hold two.
+    // Note WHICH repair applies: the mc cap, NOT the search. ceil(64/6) = 11 is
+    // below the 16 cache bound, giving nib = 6 and a 6x1 grid that a greedy split
+    // would also have found. Both defects pointed at this shape; the cap reaches
+    // it by the better route, since one wide ic team shares a single packed-B
+    // panel where 3x2 would hold two. The search is exercised separately below,
+    // because this case does not exercise it at all.
     const auto g = plan_gemm_grid(64, 6144, 16, 2048, MR, 6);
     REQUIRE(g.mc == 11);
     REQUIRE(g.nib == 6);
@@ -56,16 +74,43 @@ TEST_CASE("the grid search finds factorizations the greedy split missed",
     REQUIRE(g.jc_nt <= g.njb);
 }
 
-TEST_CASE("the search alone fixes a greedy miss when mc is already small",
+TEST_CASE("the exhaustive search is load-bearing, not decoration",
           "[detail][gemm][grid]") {
-    // Isolates defect (2) from defect (1): m is large enough that the mc cap does
-    // not bind (ceil(4096/6) = 683 > 16), so nib is unchanged and only the
-    // factorization can improve the grid. Greedy: ic = min(6,256) = 6, jc = 6/6
-    // = 1 -> 6. Here the budget is filled either way, so pick a case where it is
-    // not: nib = 4 with the cap inactive.
-    const auto g = plan_gemm_grid(400, 6144, 100, 2048, MR, 6);
-    REQUIRE(g.mc == 67);                     // ceil(400/6), cap active
-    REQUIRE(g.ic_nt * g.jc_nt == 6);
+    // This case exists because the obvious ones do NOT test the search. Where the
+    // mc cap can reach the budget it produces nib >= budget, and a greedy ic-first
+    // split then lands on the same grid -- true for both the Jetson case above
+    // and an earlier version of this test. Deleting the search would have left
+    // every one of them green.
+    //
+    // The register-tile floor is what forces the issue: at m = 24 the cap wants
+    // ceil(24/6) = 4, below mr, so mc stops at 6 and nib = 4 < budget. Greedy
+    // then takes ic = 4, jc = 6/4 = 1 -> 4, while 3 x 2 = 6 is legal.
+    const auto g = plan_gemm_grid(24, 6144, 100, 2048, MR, 6);
+    REQUIRE(g.mc == MR);                                  // floored, cannot shrink further
+    REQUIRE(g.nib == 4);
+    REQUIRE(g.njb == 3);
+    REQUIRE(greedy_grid(g.nib, g.njb, 6) == 4);           // what the old code did
+    REQUIRE(g.ic_nt * g.jc_nt == 6);                      // what the search finds
+    REQUIRE(g.ic_nt * g.jc_nt > greedy_grid(g.nib, g.njb, 6));
+}
+
+TEST_CASE("the planner is never worse than the greedy split it replaced",
+          "[detail][gemm][grid]") {
+    // Property form of the above, so the search cannot silently regress on shapes
+    // no one thought to enumerate.
+    for (std::size_t m : {std::size_t{16}, std::size_t{24}, std::size_t{64},
+                          std::size_t{96}, std::size_t{400}, std::size_t{1024},
+                          std::size_t{4096}})
+        for (std::size_t n : {std::size_t{2048}, std::size_t{6144}, std::size_t{16384}})
+            for (std::size_t mc : {std::size_t{16}, std::size_t{64}, std::size_t{100},
+                                   std::size_t{256}})
+                for (unsigned b : {2u, 6u, 8u, 12u}) {
+                    const auto g = plan_gemm_grid(m, n, mc, 2048, MR, b);
+                    INFO("m=" << m << " n=" << n << " mc=" << mc << " budget=" << b
+                         << " -> " << g.ic_nt << "x" << g.jc_nt
+                         << " vs greedy " << greedy_grid(g.nib, g.njb, b));
+                    REQUIRE(g.ic_nt * g.jc_nt >= greedy_grid(g.nib, g.njb, b));
+                }
 }
 
 TEST_CASE("the shipped default blocking is unchanged", "[detail][gemm][grid]") {

--- a/tests/unit/detail/test_gemm_grid.cpp
+++ b/tests/unit/detail/test_gemm_grid.cpp
@@ -1,0 +1,116 @@
+// plan_gemm_grid: the threaded nest's mc and ic x jc grid decision (#429).
+//
+// These are regression tests for measured losses, not invented cases. Each of
+// the three machines in #430 lost whole cores to this function, in two distinct
+// ways, and the numbers below are the ones those runs actually produced.
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstddef>
+
+#include <mtl/detail/gemm_blocked.hpp>
+
+using mtl::detail::plan_gemm_grid;
+
+namespace {
+// The default fp64 blocking on an AVX2 build, for the machines below.
+constexpr std::size_t NC = 4096, MR = 6;
+} // namespace
+
+TEST_CASE("a large mc no longer starves the ic partition", "[detail][gemm][grid]") {
+    // Square problems have njb == 1 (n <= nc), so there is NO jc parallelism to
+    // compensate: if mc yields fewer ic blocks than threads, the machine idles
+    // and no factorization can rescue it. Both cases measured as real losses.
+
+    SECTION("i7-12700K, 1024^3, detected mc=213 -> ran 5 of 8 threads (0.551)") {
+        const auto g = plan_gemm_grid(1024, 1024, 213, NC, MR, 8);
+        REQUIRE(g.njb == 1);                 // no jc parallelism available
+        REQUIRE(g.mc <= 213);                // cache bound still respected
+        REQUIRE(g.nib >= 8);                 // enough blocks for every thread
+        REQUIRE(g.ic_nt * g.jc_nt == 8);     // was 5
+    }
+
+    SECTION("Zen 4, 1024^3, detected mc=256 -> ran 4 of 8 threads (0.590)") {
+        const auto g = plan_gemm_grid(1024, 1024, 256, NC, MR, 8);
+        REQUIRE(g.mc <= 256);
+        REQUIRE(g.ic_nt * g.jc_nt == 8);     // was 4
+    }
+}
+
+TEST_CASE("the grid search finds factorizations the greedy split missed",
+          "[detail][gemm][grid]") {
+    // Jetson Orin Nano, 64 x 6144, mc=16, budget 6 (a 6-core part). Greedy took
+    // ic = min(6,4) = 4 then jc = 6/4 = 1 -> grid 4, two cores idle, measured
+    // 0.760.
+    //
+    // Note WHICH repair applies. The mc cap fires first -- ceil(64/6) = 11 is
+    // below the 16 cache bound -- giving nib = 6 and a 6x1 grid, so the search
+    // never needs the 3x2 that was missing before. Both defects pointed at this
+    // shape; the cap reaches it by the better route, since one wide ic team
+    // shares a single packed-B panel where 3x2 would hold two.
+    const auto g = plan_gemm_grid(64, 6144, 16, 2048, MR, 6);
+    REQUIRE(g.mc == 11);
+    REQUIRE(g.nib == 6);
+    REQUIRE(g.njb == 3);
+    REQUIRE(g.ic_nt * g.jc_nt == 6);         // was 4
+    REQUIRE(g.ic_nt <= g.nib);
+    REQUIRE(g.jc_nt <= g.njb);
+}
+
+TEST_CASE("the search alone fixes a greedy miss when mc is already small",
+          "[detail][gemm][grid]") {
+    // Isolates defect (2) from defect (1): m is large enough that the mc cap does
+    // not bind (ceil(4096/6) = 683 > 16), so nib is unchanged and only the
+    // factorization can improve the grid. Greedy: ic = min(6,256) = 6, jc = 6/6
+    // = 1 -> 6. Here the budget is filled either way, so pick a case where it is
+    // not: nib = 4 with the cap inactive.
+    const auto g = plan_gemm_grid(400, 6144, 100, 2048, MR, 6);
+    REQUIRE(g.mc == 67);                     // ceil(400/6), cap active
+    REQUIRE(g.ic_nt * g.jc_nt == 6);
+}
+
+TEST_CASE("the shipped default blocking is unchanged", "[detail][gemm][grid]") {
+    // The mc cap must bind ONLY when the partition would otherwise starve. At
+    // the shipped fp64 mc = 64 the cap is ceil(1024/8) = 128, which is larger,
+    // so nothing moves -- this is what keeps the change off the common path.
+    const auto g = plan_gemm_grid(1024, 1024, 64, NC, MR, 8);
+    REQUIRE(g.mc == 64);
+    REQUIRE(g.nib == 16);
+    REQUIRE(g.ic_nt * g.jc_nt == 8);
+}
+
+TEST_CASE("plan_gemm_grid respects its bounds everywhere", "[detail][gemm][grid]") {
+    for (std::size_t m : {std::size_t{1}, std::size_t{64}, std::size_t{1000},
+                          std::size_t{4096}, std::size_t{12288}})
+        for (std::size_t n : {std::size_t{64}, std::size_t{1024}, std::size_t{16384}})
+            for (std::size_t mc : {std::size_t{16}, std::size_t{64}, std::size_t{256}})
+                for (unsigned b : {1u, 2u, 6u, 8u, 20u}) {
+                    const auto g = plan_gemm_grid(m, n, mc, NC, MR, b);
+                    INFO("m=" << m << " n=" << n << " mc_cache=" << mc << " budget=" << b
+                         << " -> mc=" << g.mc << " nib=" << g.nib << " njb=" << g.njb
+                         << " grid=" << g.ic_nt << "x" << g.jc_nt);
+                    REQUIRE(g.mc >= 1);
+                    REQUIRE(g.mc <= mc);                       // never exceeds the cache bound
+                    REQUIRE(g.nib == (m + g.mc - 1) / g.mc);   // block count matches mc
+                    REQUIRE(g.ic_nt >= 1);
+                    REQUIRE(g.jc_nt >= 1);
+                    REQUIRE(g.ic_nt <= g.nib);                 // no thread without a block
+                    REQUIRE(g.jc_nt <= g.njb);
+                    REQUIRE(g.ic_nt * g.jc_nt <= b);           // never oversubscribe the pool
+                    // mc is only shrunk below the cache bound to reach the
+                    // budget; it must not drop under one register tile unless
+                    // the cache bound itself already was.
+                    if (g.mc < mc) REQUIRE(g.mc >= (mc < MR ? mc : MR));
+                }
+}
+
+TEST_CASE("plan_gemm_grid handles degenerate inputs", "[detail][gemm][grid][edge]") {
+    for (auto g : {plan_gemm_grid(0, 1024, 64, NC, MR, 8),
+                   plan_gemm_grid(1024, 0, 64, NC, MR, 8),
+                   plan_gemm_grid(1024, 1024, 0, NC, MR, 8),
+                   plan_gemm_grid(1024, 1024, 64, 0, MR, 8),
+                   plan_gemm_grid(1024, 1024, 64, NC, MR, 0)}) {
+        REQUIRE(g.ic_nt >= 1);
+        REQUIRE(g.jc_nt >= 1);
+        REQUIRE(g.mc >= 1);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the thread-grid half of #429. Two defects, both found by measuring three machines in #430, both costing **whole cores** rather than percentages. `plan_gemm_grid` is a **pure function**, so the decision is unit-testable and enumerable offline rather than inferred from a throughput change — which #430 also asked for.

## Defect 1 — `mc` was the cache bound only, so the partition could starve

`nib = ceil(m/mc)` could come out smaller than the thread budget, and `ic_nt = min(budget, nib)` then capped the grid permanently. On a **square** problem `njb == 1`, so no jc parallelism can make up the difference and the machine idles:

| machine | `mc` | `nib` | grid | measured |
|---|---|---|---|---|
| i7-12700K, 1024³ | 213 | 5 | **5 of 8** | 0.551 |
| Zen 4, 1024³ | 256 | 4 | **4 of 8** | 0.590 |

`mc` is now also bounded by `ceil(m/budget)` — enough blocks to give every thread one — floored at a register tile. It only ever *lowers* `mc`, so the L2 bound still holds, and it **binds only when the partition would starve**: at the shipped `mc = 64` with `m = 1024` on 8 threads the cap is 128 and nothing moves.

## Defect 2 — the factorization was greedy

Fill ic, then hand jc the integer quotient, discarding the remainder. At budget 6 with `nib = 4` it took `4 × 1` and left two cores idle while `3 × 2` and `2 × 3` were both legal (Jetson Orin Nano, 0.760). The search is now exhaustive over `ic` and maximises `ic_nt × jc_nt`, preferring the larger `ic_nt` on ties.

## The tie-break is not cosmetic — and it is what this host could measure

On the Xeon at `m=96 n=4096 k=1024`, 6 threads, the grid moves from `3 × 2` to `6 × 1` — **the same six threads** — but the live packed-B footprint halves:

```
before: mc=32 nib=3 grid=3x2=6   packed-B live = 2 x 8.4 MB = 16.8 MB   (L3 = 15.7 MB)
after : mc=16 nib=6 grid=6x1=6   packed-B live = 1 x 8.4 MB =  8.4 MB   (fits)
```

**20.97 → 30.64 GFLOP/s, 1.46×**, best of five interleaved runs. Shapes that were already balanced are unchanged — 1.00× at `m=192`, 1.03× at 1024³, both inside run-to-run spread.

Being precise about what this host proves: the **starvation** half cannot be demonstrated here. It needs `nib < budget` with `njb == 1`, and this machine's `mc = 32` at `m = 1024` gives `nib = 32` against 6 threads. Its evidence is the i7 and Zen 4 runs, and the unit tests encode those exact cases so they are pinned rather than remembered.

## Correctness

Results stay **bit-identical**: `mc` and the grid decide which rows are grouped and which thread owns a block, while the FMA order for a given C element is fixed by the untouched `pc` loop. Verified by identical checksums across the change and by the existing #297 determinism tests.

A degenerate-input sweep in the new tests caught a real contract violation on the way — `plan_gemm_grid` returned `mc = 0` for `mc_cache = 0`, and `mc` is a loop step.

## Test Results

| | gcc | clang |
|---|---|---|
| full unit suite | **165/165** | **165/165** |
| `detail_test_gemm_grid` (new) | 1928 assertions, 6 cases | — |
| `op_test_gemm_mt` (bit-identity) | pass | pass |

## What this does not do

It does not touch `nc` or apply the detected L3 — that is the rest of #429, and it is now clearly downstream: with the grid no longer wasting cores, the multi-thread losses that dominated the #430 data should shrink or vanish, and the cache model can finally be measured on its own. **Re-running the three machines after this lands is the natural next step**, and may well revisit #426's opt-in decision.

Relates to #429, #430

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved threaded matrix multiplication workload distribution for better CPU utilization.
  * Dynamically adapts block sizes and parallel partitioning to available processing capacity and matrix dimensions.
  * Reduces thread starvation, especially for smaller or unevenly sized workloads.

* **Bug Fixes**
  * Improved handling of edge cases and constrained workloads while preserving existing blocking behavior.
  * Added regression coverage for parallel partitioning limits and degenerate inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->