### PR TITLE
feat(bench): preflight gates and machine-state capture for every measurement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,12 +79,25 @@ configure_file(
 # content changes, so nothing rebuilds spuriously. Not part of the mtl5 INTERFACE
 # -- putting a per-commit define on every consumer would invalidate their objects
 # on each commit; benchmark targets depend on this target explicitly.
+#
+# CMAKE_CXX_FLAGS alone is usually EMPTY: the optimisation level lives in
+# CMAKE_CXX_FLAGS_<CONFIG> and MTL5_NATIVE_ARCH adds -march=native through
+# target_compile_options. A sidecar reading `cxx_flags=` on a -O3 -march=native
+# build records nothing while looking like it recorded something, so the
+# per-config flags are folded in here. The authoritative answer to "which ISA"
+# is build_isa in the sidecar, taken from the compiler's own predefined macros
+# (mtl/util/system_info.hpp) -- flags are the intent, that is the effect.
+set(MTL5_PROVENANCE_FLAGS "${CMAKE_CXX_FLAGS} $<$<CONFIG:Debug>:${CMAKE_CXX_FLAGS_DEBUG}>$<$<CONFIG:Release>:${CMAKE_CXX_FLAGS_RELEASE}>$<$<CONFIG:RelWithDebInfo>:${CMAKE_CXX_FLAGS_RELWITHDEBINFO}>$<$<CONFIG:MinSizeRel>:${CMAKE_CXX_FLAGS_MINSIZEREL}>")
+if(MTL5_NATIVE_ARCH)
+    set(MTL5_PROVENANCE_FLAGS "${MTL5_PROVENANCE_FLAGS} [MTL5_NATIVE_ARCH=ON]")
+endif()
+
 add_custom_target(mtl5_build_info ALL
     COMMAND ${CMAKE_COMMAND}
             -DSRC_DIR=${CMAKE_CURRENT_SOURCE_DIR}
             -DTEMPLATE=${CMAKE_CURRENT_SOURCE_DIR}/include/mtl/build_info.hpp.in
             -DOUTPUT=${CMAKE_CURRENT_BINARY_DIR}/include/mtl/build_info.hpp
-            -DCXX_FLAGS=${CMAKE_CXX_FLAGS}
+            "-DCXX_FLAGS=${MTL5_PROVENANCE_FLAGS}"
             -DCMAKE_TYPE=$<CONFIG>
             -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/GitInfo.cmake
     BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/include/mtl/build_info.hpp
@@ -92,12 +105,16 @@ add_custom_target(mtl5_build_info ALL
     VERBATIM)
 
 # Generate it once at configure time too, so a consumer that includes the header
-# without depending on the target still compiles.
+# without depending on the target still compiles. Genex do not expand here, so
+# the per-config flags are resolved directly; single-config generators know the
+# build type at this point and multi-config ones get the plain flags until the
+# build-time regeneration above corrects them.
+string(TOUPPER "${CMAKE_BUILD_TYPE}" _prov_cfg)
 execute_process(COMMAND ${CMAKE_COMMAND}
     -DSRC_DIR=${CMAKE_CURRENT_SOURCE_DIR}
     -DTEMPLATE=${CMAKE_CURRENT_SOURCE_DIR}/include/mtl/build_info.hpp.in
     -DOUTPUT=${CMAKE_CURRENT_BINARY_DIR}/include/mtl/build_info.hpp
-    -DCXX_FLAGS=${CMAKE_CXX_FLAGS}
+    "-DCXX_FLAGS=${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${_prov_cfg}}"
     -DCMAKE_TYPE=${CMAKE_BUILD_TYPE}
     -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/GitInfo.cmake)
 

--- a/benchmarks/preflight.ps1
+++ b/benchmarks/preflight.ps1
@@ -1,0 +1,218 @@
+<#
+.SYNOPSIS
+Preflight: gate a measurement on machine state, and record that state (#442).
+
+.DESCRIPTION
+The Windows half of benchmarks/preflight.sh; the contract is identical and the
+key names it emits are the same, so a Zen 4 sidecar and an i7 sidecar can be read
+side by side.
+
+Two jobs:
+  1. FAIL on conditions that make a measurement meaningless (dirty tree,
+     competing build, more threads than cpus). Not warn -- a warning scrolls past
+     and the CSV gets committed anyway.
+  2. EMIT key=value lines for the sidecar, so machine state is IN the data.
+
+WHAT WINDOWS CANNOT TELL US. Two of the probes are usually blank here, and both
+are recorded as `unavailable` rather than guessed:
+
+  * Temperature. MSAcpi_ThermalZoneTemperature is an ACPI optional feature that
+    most desktop firmware does not implement; on the Zen 4 machine it returns
+    nothing. The thermal gate therefore only FAILS where a sensor and a limit are
+    both readable -- refusing to run would make the machine unbenchmarkable, and
+    passing silently would hide the gap.
+  * Turbo state. Reachable only by parsing powercfg, and not on every SKU.
+
+.PARAMETER Phase
+'before' (default) runs every gate and emits the full record. 'after' emits
+thermal_after_c only; call it once the run finishes, since a session that ends
+hot and one that ran slow look identical in GFLOP/s alone.
+
+.PARAMETER Threads
+The largest thread count the run will ask for.
+
+.PARAMETER Repo
+Repository to check. Defaults to the parent of this script.
+
+.PARAMETER ReportOnly
+Probe and emit, never fail. For CI and for inspecting a machine; NOT for taking
+measurements.
+
+.NOTES
+Environment: ALLOW_DIRTY=1 permits a dirty tree (still recorded),
+MIN_THERMAL_HEADROOM_C (default 15) sets the required margin.
+Exit: 0 all gates pass, 1 a gate failed, 2 bad usage.
+#>
+param(
+    [ValidateSet('before', 'after')][string]$Phase = 'before',
+    [int]$Threads = 0,
+    [string]$Repo = '',
+    [switch]$ReportOnly
+)
+
+$ErrorActionPreference = 'Continue'
+
+if (-not $Repo) { $Repo = Split-Path -Parent $PSScriptRoot }
+$margin = if ($env:MIN_THERMAL_HEADROOM_C) { [double]$env:MIN_THERMAL_HEADROOM_C } else { 15.0 }
+
+$script:failures = 0
+function Emit($k, $v) { Write-Output "$k=$v" }
+function GateFailed($msg) {
+    Write-Error -Message "preflight: FAIL: $msg" -ErrorAction Continue
+    $script:failures++
+}
+function Warn($msg) { Write-Warning "preflight: $msg" }
+
+# -- thermal ----------------------------------------------------------------
+# Tenths of a Kelvin, per the ACPI spec. Absent on most desktop firmware.
+function Read-Thermal {
+    $r = [pscustomobject]@{ Temp = 'unavailable'; Limit = 'unavailable'; Sensor = 'unavailable' }
+    try {
+        $z = Get-CimInstance -Namespace 'root/wmi' -ClassName 'MSAcpi_ThermalZoneTemperature' -ErrorAction Stop |
+             Select-Object -First 1
+        if ($z) {
+            $r.Temp = '{0:F1}' -f (($z.CurrentTemperature / 10.0) - 273.15)
+            $r.Sensor = "acpi:$($z.InstanceName)"
+            # CriticalTripPoint is where the machine shuts down, not where it
+            # throttles. Gate on it anyway when it is all we have -- it is still
+            # a real limit -- but the headroom it yields is generous.
+            if ($z.CriticalTripPoint -gt 0) {
+                $r.Limit = '{0:F1}' -f (($z.CriticalTripPoint / 10.0) - 273.15)
+            }
+        }
+    } catch {
+        # Not implemented by this firmware; leave everything 'unavailable'.
+    }
+    return $r
+}
+
+$thermal = Read-Thermal
+
+if ($Phase -eq 'after') {
+    Emit 'thermal_after_c' $thermal.Temp
+    exit 0
+}
+
+Emit 'preflight_version' 1
+Emit 'preflight_host'    $env:COMPUTERNAME
+Emit 'preflight_kernel'  ([System.Environment]::OSVersion.VersionString -replace ' ', '_')
+
+# -- working tree -----------------------------------------------------------
+# The BINARY records the commit it was built from (mtl/build_info.hpp); this
+# records the commit the tree is on NOW. If they disagree the binary is stale
+# relative to the checkout.
+$treeCommit = 'unknown'
+$treeDirty = 'unknown'
+if (Get-Command git -ErrorAction SilentlyContinue) {
+    $sha = & git -C $Repo rev-parse --short=12 HEAD 2>$null
+    if ($LASTEXITCODE -eq 0 -and $sha) {
+        $treeCommit = $sha.Trim()
+        $status = & git -C $Repo status --porcelain --untracked-files=normal 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            if ([string]::IsNullOrWhiteSpace($status -join '')) {
+                $treeDirty = '0'
+            } else {
+                $treeDirty = '1'
+                if ($env:ALLOW_DIRTY -eq '1') {
+                    Warn "working tree is dirty; ALLOW_DIRTY=1, recording tree_git_dirty=1"
+                } else {
+                    GateFailed "working tree is dirty -- this result could not be reproduced. Commit, stash, or set ALLOW_DIRTY=1 to record it as dirty."
+                }
+            }
+        }
+    }
+}
+Emit 'tree_git_commit' $treeCommit
+Emit 'tree_git_dirty'  $treeDirty
+
+# -- competing load ---------------------------------------------------------
+# A competing compile does not make the run noisy, it makes it wrong: the arms
+# are interleaved, so a build finishing mid-session penalises whichever arm was
+# running then, and the difference is reported as a result.
+#
+# Matched on process NAME. Matching command lines caught the shell that had
+# merely typed the benchmark's path on the POSIX side, which failed every clean
+# run.
+$busyNames = @('make', 'ninja', 'cmake', 'MSBuild', 'cl', 'link', 'devenv', 'cc1plus')
+$busy = @()
+foreach ($n in $busyNames) {
+    Get-Process -Name $n -ErrorAction SilentlyContinue | ForEach-Object { $busy += "$($_.ProcessName)($($_.Id))" }
+}
+Get-Process -Name 'bench_*' -ErrorAction SilentlyContinue |
+    Where-Object { $_.Id -ne $PID } |
+    ForEach-Object { $busy += "$($_.ProcessName)($($_.Id))" }
+
+if ($busy.Count -gt 0) {
+    Emit 'competing_load' ($busy -join ',')
+    GateFailed "a build or benchmark is already running: $($busy -join ' ')"
+} else {
+    Emit 'competing_load' 'none'
+}
+
+# -- cores and thread budget ------------------------------------------------
+# ProcessorCount reflects the affinity this process actually has, which is the
+# number a thread budget must fit into; NumberOfLogicalProcessors is the machine.
+$affinity = [System.Environment]::ProcessorCount
+$online = $affinity
+try {
+    $cs = Get-CimInstance -ClassName Win32_ComputerSystem -ErrorAction Stop
+    if ($cs.NumberOfLogicalProcessors) { $online = $cs.NumberOfLogicalProcessors }
+} catch { }
+Emit 'cpu_online'   $online
+Emit 'cpu_affinity' $affinity
+if ($Threads -gt 0 -and $Threads -gt $affinity) {
+    GateFailed "$Threads threads requested but only $affinity cpu(s) available."
+}
+
+# -- frequency policy -------------------------------------------------------
+# Recorded and warned about, not failed: every machine in systems.md runs a
+# non-performance policy today, and failing here would block all of them. What
+# makes the data defensible is that the policy is IN the sidecar, so a balanced
+# run is never silently compared with a pinned one.
+$governor = 'unavailable'
+try {
+    $scheme = & powercfg /getactivescheme 2>$null
+    if ($LASTEXITCODE -eq 0 -and $scheme) {
+        if ($scheme -match '\(([^)]+)\)') { $governor = $Matches[1] -replace ' ', '_' }
+    }
+} catch { }
+Emit 'governor' $governor
+if ($governor -notmatch '[Pp]erformance' -and $governor -ne 'unavailable') {
+    Warn "power scheme is '$governor', not a performance plan -- clocks are not pinned"
+}
+
+$turbo = 'unavailable'
+try {
+    $boost = & powercfg /q SCHEME_CURRENT SUB_PROCESSOR PERFBOOSTMODE 2>$null
+    if ($LASTEXITCODE -eq 0 -and $boost) {
+        $ac = ($boost | Select-String -Pattern 'Current AC Power Setting Index:\s*(0x[0-9a-fA-F]+)')
+        if ($ac) { $turbo = if ([int]$ac.Matches[0].Groups[1].Value -eq 0) { 'disabled' } else { 'enabled' } }
+    }
+} catch { }
+Emit 'turbo' $turbo
+
+Emit 'power_mode' 'n/a'   # nvpmodel is a Jetson concept
+
+# -- thermal gate -----------------------------------------------------------
+Emit 'thermal_sensor'   $thermal.Sensor
+Emit 'thermal_before_c' $thermal.Temp
+Emit 'thermal_limit_c'  $thermal.Limit
+if ($thermal.Temp -ne 'unavailable' -and $thermal.Limit -ne 'unavailable') {
+    $headroom = [double]$thermal.Limit - [double]$thermal.Temp
+    Emit 'thermal_headroom_c' ('{0:F1}' -f $headroom)
+    if ($headroom -lt $margin) {
+        GateFailed ("only {0:F1}C below the {1}C limit (need {2}C). Let the machine cool -- throttled data is indistinguishable from a slow configuration." -f $headroom, $thermal.Limit, $margin)
+    }
+} else {
+    # Not a failure. See the note in the header.
+    Emit 'thermal_headroom_c' 'unavailable'
+}
+
+Emit 'preflight_gates' $(if ($ReportOnly) { 'report-only' } else { 'enforced' })
+
+if ($ReportOnly) {
+    if ($script:failures -gt 0) { Warn "$($script:failures) gate(s) would have failed; -ReportOnly, continuing" }
+    exit 0
+}
+if ($script:failures -gt 0) { exit 1 }
+exit 0

--- a/benchmarks/preflight.sh
+++ b/benchmarks/preflight.sh
@@ -50,11 +50,21 @@ REPORT_ONLY=0
 REPO=""
 MARGIN=${MIN_THERMAL_HEADROOM_C:-15}
 
+# A gate that cannot be reached is worse than no gate: a trailing `--threads`
+# with no value used to leave $1 unchanged (shift 2 fails on one argument), so
+# the loop spun forever, and a non-numeric value silently skipped the thread
+# budget check entirely. Demand the value up front.
+need_value() {            # flag, remaining-count
+    if [ "$2" -lt 2 ]; then
+        echo "preflight: $1 requires a value" >&2
+        exit 2
+    fi
+}
 while [ $# -gt 0 ]; do
     case "$1" in
-        --phase)       PHASE=${2:-}; shift 2 ;;
-        --threads)     THREADS_REQ=${2:-0}; shift 2 ;;
-        --repo)        REPO=${2:-}; shift 2 ;;
+        --phase)       need_value "$1" $#; PHASE=$2; shift 2 ;;
+        --threads)     need_value "$1" $#; THREADS_REQ=$2; shift 2 ;;
+        --repo)        need_value "$1" $#; REPO=$2; shift 2 ;;
         --report-only) REPORT_ONLY=1; shift ;;
         -h|--help)     sed -n '2,45p' "$0"; exit 0 ;;
         *) echo "preflight: unknown argument '$1'" >&2; exit 2 ;;
@@ -63,6 +73,11 @@ done
 case "$PHASE" in
     before|after) ;;
     *) echo "preflight: --phase must be 'before' or 'after'" >&2; exit 2 ;;
+esac
+case "$THREADS_REQ" in
+    ''|*[!0-9]*)
+        echo "preflight: --threads must be a non-negative integer, got '$THREADS_REQ'" >&2
+        exit 2 ;;
 esac
 if [ -z "$REPO" ]; then
     REPO=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
@@ -211,8 +226,12 @@ emit loadavg_1m "$LOAD1"
 # ── cores and thread budget ─────────────────────────────────────────────────
 # nproc honours the affinity mask, so under taskset this is the count the run can
 # actually use -- which is the number the thread budget must fit into.
-NPROC_AFFINITY=$(nproc 2>/dev/null || echo 0)
-NPROC_ONLINE=$(nproc --all 2>/dev/null || echo "$NPROC_AFFINITY")
+#
+# macOS ships no nproc (it is GNU coreutils), which made this 0 there and failed
+# EVERY run with "0 cpus available" -- a gate that blocks the machine outright is
+# not a stricter gate, it is a broken one. sysctl is the platform's own answer.
+NPROC_AFFINITY=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 0)
+NPROC_ONLINE=$(nproc --all 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo "$NPROC_AFFINITY")
 emit cpu_online "$NPROC_ONLINE"
 emit cpu_affinity "$NPROC_AFFINITY"
 if [ "$THREADS_REQ" -gt 0 ] 2>/dev/null && [ "$THREADS_REQ" -gt "$NPROC_AFFINITY" ]; then

--- a/benchmarks/preflight.sh
+++ b/benchmarks/preflight.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# Preflight: gate a measurement on machine state, and record that state (#442).
+#
+# Every guard in this repo's benchmark harnesses was added AFTER the matching
+# error had already produced a wrong result -- a Zen 4 run destroyed the i7's
+# committed CSVs, the analyzer called a 4.8% "win" between byte-identical arms,
+# the Jetson asked for 8 threads on a 6-core part. This script is the first one
+# written before the error rather than after it, and it exists because the
+# remaining gaps all have the same shape: the number lands in the CSV and the
+# reason it is wrong lands nowhere.
+#
+# Two jobs, deliberately in one place:
+#
+#   1. FAIL on conditions that make a measurement meaningless. Not warn -- a
+#      warning scrolls past and the CSV gets committed anyway.
+#   2. EMIT key=value lines for the sidecar, so the machine state is IN the data
+#      rather than in someone's memory of the session. The Jetson numbers on
+#      docs/benchmarks/systems.md are annotated "15 W, schedutil, clocks not
+#      pinned" only because someone thought to ask.
+#
+# Usage:
+#   preflight.sh [--phase before|after] [--threads N] [--repo DIR] [--report-only]
+#
+#   --phase before   (default) run every gate, emit the full record
+#   --phase after    emit thermal_after_c only -- call once the run finishes, so
+#                    a throttled session is visible in the data. A run that ends
+#                    hot and one that ran slow look identical in GFLOP/s alone.
+#   --threads N      the largest thread count the run will ask for
+#   --repo DIR       repository to check (default: the parent of this script)
+#   --report-only    probe and emit, never fail. For CI and for inspecting a
+#                    machine; NOT for taking measurements.
+#
+# Environment:
+#   ALLOW_DIRTY=1              permit a dirty working tree (still recorded)
+#   MIN_THERMAL_HEADROOM_C=15  required margin below the throttle limit
+#
+# Exit: 0 all gates pass, 1 a gate failed, 2 bad usage.
+#
+# Thermal policy: this FAILS only where a sensor and its limit are both
+# readable. On a machine that exposes neither (typically Windows, and macOS
+# without extra tooling) it records `thermal_before_c=unavailable` and proceeds
+# -- refusing to run there would make those machines unbenchmarkable, and
+# silently passing would hide the gap. Unavailable is recorded, never assumed
+# cool.
+set -uo pipefail
+
+PHASE=before
+THREADS_REQ=0
+REPORT_ONLY=0
+REPO=""
+MARGIN=${MIN_THERMAL_HEADROOM_C:-15}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --phase)       PHASE=${2:-}; shift 2 ;;
+        --threads)     THREADS_REQ=${2:-0}; shift 2 ;;
+        --repo)        REPO=${2:-}; shift 2 ;;
+        --report-only) REPORT_ONLY=1; shift ;;
+        -h|--help)     sed -n '2,45p' "$0"; exit 0 ;;
+        *) echo "preflight: unknown argument '$1'" >&2; exit 2 ;;
+    esac
+done
+case "$PHASE" in
+    before|after) ;;
+    *) echo "preflight: --phase must be 'before' or 'after'" >&2; exit 2 ;;
+esac
+if [ -z "$REPO" ]; then
+    REPO=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+fi
+
+FAILURES=0
+emit() { printf '%s=%s\n' "$1" "$2"; }
+gate_failed() {           # message...
+    echo "preflight: FAIL: $*" >&2
+    FAILURES=$((FAILURES + 1))
+}
+warn() { echo "preflight: warn: $*" >&2; }
+
+# ── thermal ─────────────────────────────────────────────────────────────────
+# Sets THERMAL_C, THERMAL_LIMIT_C, THERMAL_SENSOR; each may be "unavailable".
+#
+# Two sources, because the machines in docs/benchmarks/systems.md split between
+# them: x86 parts expose hwmon (coretemp/k10temp) with the throttle point in
+# temp*_max, while the Jetson exposes thermal zones named CPU-therm/soc*-therm.
+# Prefer hwmon: it names the package and carries a limit, where a zone's trip
+# points are often unpopulated (this Xeon reports -274000, i.e. absolute zero, on
+# both of its trip points).
+milli_to_c() { awk -v m="$1" 'BEGIN { printf "%.1f", m / 1000.0 }'; }
+
+read_thermal() {
+    THERMAL_C=unavailable
+    THERMAL_LIMIT_C=unavailable
+    THERMAL_SENSOR=unavailable
+
+    for h in /sys/class/hwmon/hwmon*; do
+        [ -r "$h/name" ] || continue
+        local name; name=$(cat "$h/name" 2>/dev/null) || continue
+        case "$name" in
+            coretemp|k10temp|zenpower|cpu_thermal|soc_thermal) ;;
+            *) continue ;;
+        esac
+        [ -r "$h/temp1_input" ] || continue
+        local label=$name
+        [ -r "$h/temp1_label" ] && label="$name:$(cat "$h/temp1_label")"
+        THERMAL_C=$(milli_to_c "$(cat "$h/temp1_input")")
+        THERMAL_SENSOR=$label
+        # temp*_max is the point the part throttles at; temp*_crit is where it
+        # shuts down. Gate on the first if it is present -- data taken while
+        # throttling is already invalid, long before anything is at risk.
+        for lim in "$h/temp1_max" "$h/temp1_crit"; do
+            if [ -r "$lim" ]; then
+                local v; v=$(cat "$lim")
+                if [ "$v" -gt 0 ] 2>/dev/null; then
+                    THERMAL_LIMIT_C=$(milli_to_c "$v")
+                    break
+                fi
+            fi
+        done
+        return
+    done
+
+    for z in /sys/class/thermal/thermal_zone*; do
+        [ -r "$z/type" ] && [ -r "$z/temp" ] || continue
+        local type; type=$(cat "$z/type" 2>/dev/null) || continue
+        case "$type" in
+            *cpu*|*CPU*|x86_pkg_temp|*soc*|*SOC*) ;;
+            *) continue ;;
+        esac
+        THERMAL_C=$(milli_to_c "$(cat "$z/temp")")
+        THERMAL_SENSOR="thermal_zone:$type"
+        local best=""
+        for t in "$z"/trip_point_*_temp; do
+            [ -r "$t" ] || continue
+            local v; v=$(cat "$t")
+            # Unpopulated trip points read as -274000. Ignore them rather than
+            # computing headroom against a temperature below absolute zero.
+            [ "$v" -gt 0 ] 2>/dev/null || continue
+            if [ -z "$best" ] || [ "$v" -lt "$best" ]; then best=$v; fi
+        done
+        [ -n "$best" ] && THERMAL_LIMIT_C=$(milli_to_c "$best")
+        return
+    done
+}
+
+read_thermal
+
+if [ "$PHASE" = after ]; then
+    emit thermal_after_c "$THERMAL_C"
+    exit 0
+fi
+
+emit preflight_version 1
+emit preflight_host "$(uname -n)"
+emit preflight_kernel "$(uname -sr)"
+
+# ── working tree ────────────────────────────────────────────────────────────
+# The BINARY records the commit it was built from (mtl/build_info.hpp). This
+# records the commit the tree is on NOW. They are different facts: if they
+# disagree, the binary is stale relative to the checkout, and the run measures
+# code that is no longer what the tree says it is.
+TREE_COMMIT=unknown
+TREE_DIRTY=unknown
+if command -v git >/dev/null 2>&1 && git -C "$REPO" rev-parse HEAD >/dev/null 2>&1; then
+    TREE_COMMIT=$(git -C "$REPO" rev-parse --short=12 HEAD)
+    if [ -z "$(git -C "$REPO" status --porcelain --untracked-files=normal)" ]; then
+        TREE_DIRTY=0
+    else
+        TREE_DIRTY=1
+        if [ "${ALLOW_DIRTY:-0}" = 1 ]; then
+            warn "working tree is dirty; ALLOW_DIRTY=1, recording tree_git_dirty=1"
+        else
+            gate_failed "working tree is dirty -- this result could not be reproduced." \
+                        "Commit, stash, or set ALLOW_DIRTY=1 to record it as dirty."
+        fi
+    fi
+fi
+emit tree_git_commit "$TREE_COMMIT"
+emit tree_git_dirty  "$TREE_DIRTY"
+
+# ── competing load ──────────────────────────────────────────────────────────
+# "Check pgrep -a make before building" has lived in CLAUDE.md and in habit. A
+# competing compile does not make the run noisy, it makes it wrong: the arms are
+# interleaved, so a build that finishes mid-session penalises whichever arm was
+# running at the time and the difference is reported as a result.
+BUSY=""
+if command -v pgrep >/dev/null 2>&1; then
+    # Record NAMES, not bare pids: a pid in a sidecar read weeks later says
+    # nothing, while "make(12345)" says the session raced a build.
+    while read -r pid name _rest; do
+        [ -n "${pid:-}" ] && BUSY="$BUSY $name($pid)"
+    done < <(pgrep -xl "make|ninja|cmake|cc1|cc1plus|lto1|ld|conftest" 2>/dev/null)
+    # Match the process NAME, never the command line: -f matched the shell that
+    # had merely typed the benchmark's path, so preflight reported the session
+    # it was running inside as competing load and failed every clean run.
+    while read -r pid name _rest; do
+        [ -n "${pid:-}" ] && [ "$pid" != "$$" ] && BUSY="$BUSY $name($pid)"
+    done < <(pgrep -xl "bench_[a-z0-9_]+" 2>/dev/null)
+fi
+BUSY=$(echo "$BUSY" | tr -s ' ' | sed 's/^ *//;s/ *$//')
+if [ -n "$BUSY" ]; then
+    emit competing_load "$(echo "$BUSY" | tr ' ' ',')"
+    gate_failed "a build or benchmark is already running: $BUSY"
+else
+    emit competing_load none
+fi
+
+LOAD1=unavailable
+[ -r /proc/loadavg ] && LOAD1=$(cut -d' ' -f1 /proc/loadavg)
+emit loadavg_1m "$LOAD1"
+
+# ── cores and thread budget ─────────────────────────────────────────────────
+# nproc honours the affinity mask, so under taskset this is the count the run can
+# actually use -- which is the number the thread budget must fit into.
+NPROC_AFFINITY=$(nproc 2>/dev/null || echo 0)
+NPROC_ONLINE=$(nproc --all 2>/dev/null || echo "$NPROC_AFFINITY")
+emit cpu_online "$NPROC_ONLINE"
+emit cpu_affinity "$NPROC_AFFINITY"
+if [ "$THREADS_REQ" -gt 0 ] 2>/dev/null && [ "$THREADS_REQ" -gt "$NPROC_AFFINITY" ]; then
+    gate_failed "$THREADS_REQ threads requested but only $NPROC_AFFINITY cpu(s) available."
+fi
+
+# ── frequency policy ────────────────────────────────────────────────────────
+# Recorded, and warned about, not failed: every machine in systems.md today runs
+# a non-performance governor (powersave on the i7, ondemand on the Xeon,
+# schedutil on the Jetson), and failing here would block all of them. What makes
+# the data defensible is that the governor is IN the sidecar, so a run taken
+# under schedutil is never silently compared with one taken pinned.
+GOVERNORS=$(cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor 2>/dev/null | sort -u | tr '\n' ',' | sed 's/,$//')
+[ -z "$GOVERNORS" ] && GOVERNORS=unavailable
+emit governor "$GOVERNORS"
+case "$GOVERNORS" in
+    performance) ;;
+    unavailable) ;;
+    *) warn "governor is '$GOVERNORS', not 'performance' -- clocks are not pinned" ;;
+esac
+
+TURBO=unavailable
+if [ -r /sys/devices/system/cpu/intel_pstate/no_turbo ]; then
+    if [ "$(cat /sys/devices/system/cpu/intel_pstate/no_turbo)" = 0 ]; then TURBO=enabled; else TURBO=disabled; fi
+elif [ -r /sys/devices/system/cpu/cpufreq/boost ]; then
+    if [ "$(cat /sys/devices/system/cpu/cpufreq/boost)" = 1 ]; then TURBO=enabled; else TURBO=disabled; fi
+fi
+emit turbo "$TURBO"
+
+# Jetson: the power mode caps clocks AND decides how many cores are online, and
+# it differs per module and per JetPack image. A Jetson CSV without it cannot be
+# compared with another Jetson CSV.
+POWER_MODE=n/a
+if command -v nvpmodel >/dev/null 2>&1; then
+    POWER_MODE=$(nvpmodel -q 2>/dev/null | tr '\n' ' ' | sed 's/  */ /g;s/ *$//')
+    [ -z "$POWER_MODE" ] && POWER_MODE=unknown
+fi
+emit power_mode "$POWER_MODE"
+
+# ── thermal gate ────────────────────────────────────────────────────────────
+emit thermal_sensor   "$THERMAL_SENSOR"
+emit thermal_before_c "$THERMAL_C"
+emit thermal_limit_c  "$THERMAL_LIMIT_C"
+if [ "$THERMAL_C" != unavailable ] && [ "$THERMAL_LIMIT_C" != unavailable ]; then
+    HEADROOM=$(awk -v t="$THERMAL_C" -v l="$THERMAL_LIMIT_C" 'BEGIN { printf "%.1f", l - t }')
+    emit thermal_headroom_c "$HEADROOM"
+    if awk -v h="$HEADROOM" -v m="$MARGIN" 'BEGIN { exit !(h < m) }'; then
+        gate_failed "only ${HEADROOM}C below the ${THERMAL_LIMIT_C}C limit (need ${MARGIN}C)." \
+                    "Let the machine cool -- throttled data is indistinguishable from a slow configuration."
+    fi
+else
+    # Not a failure. See the thermal policy note at the top.
+    emit thermal_headroom_c unavailable
+fi
+
+emit preflight_gates "$([ "$REPORT_ONLY" = 1 ] && echo report-only || echo enforced)"
+
+if [ "$REPORT_ONLY" = 1 ]; then
+    [ "$FAILURES" -gt 0 ] && warn "$FAILURES gate(s) would have failed; --report-only, continuing"
+    exit 0
+fi
+[ "$FAILURES" -gt 0 ] && exit 1
+exit 0

--- a/benchmarks/run_blocking_ab.ps1
+++ b/benchmarks/run_blocking_ab.ps1
@@ -258,7 +258,18 @@ for ($round = 1; $round -le $Rounds; $round++) {
 # a configuration that is simply slow give the same GFLOP/s, and only the pair of
 # temperatures separates them. Appended once at the end because each benchmark
 # invocation truncates its own sidecar.
+# If the postflight read fails the MEASUREMENTS are still good -- they are
+# already on disk, and discarding a completed session over a failed thermometer
+# read would destroy data to punish a missing probe. What must not happen is the
+# key going missing silently, so a failure is recorded as `unavailable` and said
+# out loud. `unavailable` is a fact; an absent key is a reader's guess. This
+# matters more on Windows than anywhere else, where the sensor is usually absent.
 $AfterKv = & $PreflightScript -Phase after
+if ($LASTEXITCODE -ne 0) {
+    Write-Warning "postflight thermal read failed; recording thermal_after_c=unavailable. The measurements themselves are unaffected."
+    $AfterKv = "thermal_after_c=unavailable"
+}
+if (-not ($AfterKv -match 'thermal_after_c=')) { $AfterKv = "thermal_after_c=unavailable" }
 
 # Did we measure the code the tree is on? The binary records the commit it was
 # BUILT from (mtl/build_info.hpp); preflight records where the tree is NOW. They

--- a/benchmarks/run_blocking_ab.ps1
+++ b/benchmarks/run_blocking_ab.ps1
@@ -196,8 +196,21 @@ function Run-Arm {
     if ($p.ExitCode -ne 0) { throw "$Label arm failed (T=$T, exit $($p.ExitCode))" }
 }
 
-# --- shapes: derived ONCE, from the detected arm, at the largest thread count -
+# --- preflight: gate the session before anything is measured (#442) ----------
+# A dirty tree, a competing build or a machine already hot invalidates the run,
+# and discovering it afterwards means the CSVs are already written. The key=value
+# output is appended to both sidecars below, so machine state travels with the
+# data rather than living in the operator's memory of the session.
 $TMax = ($ThreadList | Measure-Object -Maximum).Maximum
+$PreflightScript = Join-Path $PSScriptRoot "preflight.ps1"
+$PreflightKv = & $PreflightScript -Threads $TMax -Repo (Split-Path -Parent $PSScriptRoot)
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "preflight failed -- not measuring. Fix the above, or set ALLOW_DIRTY=1"
+    Write-Host "if you accept a dirty tree (it is then recorded as such in the sidecar)."
+    exit 1
+}
+
+# --- shapes: derived ONCE, from the detected arm, at the largest thread count -
 if ($Shapes -eq "") {
     $maskMax = Mask-ForThreads $TMax
     $psi = New-Object System.Diagnostics.ProcessStartInfo
@@ -238,6 +251,45 @@ for ($round = 1; $round -le $Rounds; $round++) {
             Run-Arm $Def "default"  $CsvDef $mask $T $Shapes
             Run-Arm $Det "detected" $CsvDet $mask $T $Shapes
         }
+    }
+}
+
+# Thermal AFTER the session, next to the before reading: a run that ended hot and
+# a configuration that is simply slow give the same GFLOP/s, and only the pair of
+# temperatures separates them. Appended once at the end because each benchmark
+# invocation truncates its own sidecar.
+$AfterKv = & $PreflightScript -Phase after
+
+# Did we measure the code the tree is on? The binary records the commit it was
+# BUILT from (mtl/build_info.hpp); preflight records where the tree is NOW. They
+# differ whenever someone edits, forgets to rebuild, and measures -- an easy
+# error that hides completely in the numbers.
+$TreeCommit  = ($PreflightKv | Select-String -Pattern '^tree_git_commit=(.+)$').Matches.Groups[1].Value
+$BuildCommit = ""
+if (Test-Path "$CsvDet.sysinfo") {
+    $m = Get-Content "$CsvDet.sysinfo" | Select-String -Pattern '^git_commit=(.+)$' | Select-Object -First 1
+    if ($m) { $BuildCommit = $m.Matches.Groups[1].Value }
+}
+$Stale = "unknown"
+if ($TreeCommit -and $BuildCommit -and $TreeCommit -ne "unknown" -and $BuildCommit -ne "unknown") {
+    if ($TreeCommit -eq $BuildCommit) {
+        $Stale = "0"
+    } else {
+        $Stale = "1"
+        Write-Warning "binary was built from $BuildCommit but the tree is on $TreeCommit."
+        Write-Warning "These numbers describe the BUILT code; rebuild if that is not what you meant."
+    }
+}
+
+foreach ($s in @("$CsvDet.sysinfo", "$CsvDef.sysinfo")) {
+    if (Test-Path $s) {
+        Add-Content -Path $s -Value $PreflightKv
+        Add-Content -Path $s -Value $AfterKv
+        Add-Content -Path $s -Value @(
+            "binary_stale=$Stale",
+            "harness=run_blocking_ab.ps1",
+            "harness_rounds=$Rounds",
+            "harness_reps=$Reps")
     }
 }
 

--- a/benchmarks/run_blocking_ab.sh
+++ b/benchmarks/run_blocking_ab.sh
@@ -97,6 +97,18 @@ for t in $THREADS; do
     [ "$t" -gt "$TMAX" ] && TMAX=$t
 done
 
+# Preflight BEFORE anything is measured (#442): a dirty tree, a competing build
+# or a machine that is already hot invalidates the whole session, and finding
+# that out afterwards means the CSVs are already written. Its key=value output is
+# appended to both sidecars below, so the machine state travels with the data
+# instead of living in the operator's memory of the session.
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+if ! PREFLIGHT_KV=$("$SCRIPT_DIR/preflight.sh" --threads "$TMAX" --repo "$SCRIPT_DIR/.."); then
+    echo "preflight failed -- not measuring. Fix the above, or set ALLOW_DIRTY=1 if" >&2
+    echo "you accept a dirty tree (it is then recorded as such in the sidecar)." >&2
+    exit 1
+fi
+
 # Shapes: derived ONCE, from the detected arm, at the largest thread count (the
 # wide/short shapes depend on the thread budget). Both arms then get this list.
 SHAPES=${SHAPES:-$(taskset -c "$(pin_for "$TMAX")" "$DET" --suggest-shapes --threads "$TMAX" --dtype "$DTYPE")}
@@ -127,6 +139,40 @@ for round in $(seq 1 "$ROUNDS"); do
             run_arm "$DET" detected "$CSV_DET" "$cpus" "$t"
         fi
     done
+done
+
+# Thermal AFTER the session, alongside the before reading: a run that ended hot
+# and a configuration that is simply slow produce the same GFLOP/s, and only the
+# pair of temperatures distinguishes them. Appended to the sidecars the binaries
+# wrote, which is why this happens once at the end rather than per run -- each
+# invocation truncates its own sidecar.
+AFTER_KV=$("$SCRIPT_DIR/preflight.sh" --phase after || true)
+
+# Did we measure the code the tree is on? The binary records the commit it was
+# BUILT from (mtl/build_info.hpp); preflight records where the tree is NOW. They
+# differ whenever someone edits, forgets to rebuild, and measures -- an easy
+# error, and one that hides completely in the numbers. It happened while writing
+# this very script: the first run recorded a binary two commits behind.
+TREE_COMMIT=$(printf '%s\n' "$PREFLIGHT_KV" | sed -n 's/^tree_git_commit=//p')
+BUILD_COMMIT=$(sed -n 's/^git_commit=//p' "$CSV_DET.sysinfo" 2>/dev/null | head -1)
+STALE=unknown
+if [ -n "$TREE_COMMIT" ] && [ -n "$BUILD_COMMIT" ] && \
+   [ "$TREE_COMMIT" != unknown ] && [ "$BUILD_COMMIT" != unknown ]; then
+    if [ "$TREE_COMMIT" = "$BUILD_COMMIT" ]; then
+        STALE=0
+    else
+        STALE=1
+        echo "WARNING: binary was built from $BUILD_COMMIT but the tree is on $TREE_COMMIT." >&2
+        echo "         These numbers describe the BUILT code; rebuild if that is not what you meant." >&2
+    fi
+fi
+
+for s in "$CSV_DET.sysinfo" "$CSV_DEF.sysinfo"; do
+    if [ -f "$s" ]; then
+        printf '%s\n%s\n' "$PREFLIGHT_KV" "$AFTER_KV" >> "$s"
+        printf 'binary_stale=%s\nharness=run_blocking_ab.sh\nharness_rounds=%s\nharness_reps=%s\n' \
+               "$STALE" "$ROUNDS" "$REPS" >> "$s"
+    fi
 done
 
 echo

--- a/benchmarks/run_blocking_ab.sh
+++ b/benchmarks/run_blocking_ab.sh
@@ -146,7 +146,23 @@ done
 # pair of temperatures distinguishes them. Appended to the sidecars the binaries
 # wrote, which is why this happens once at the end rather than per run -- each
 # invocation truncates its own sidecar.
-AFTER_KV=$("$SCRIPT_DIR/preflight.sh" --phase after || true)
+# If the postflight read fails, the MEASUREMENTS are still good -- they are
+# already on disk, and discarding a completed session over a failed thermometer
+# read would destroy data to punish a missing probe. What must not happen is the
+# key going missing silently, so the failure is written into the sidecar as
+# `unavailable` and said out loud. `unavailable` is a fact; an absent key is a
+# reader's guess.
+if ! AFTER_KV=$("$SCRIPT_DIR/preflight.sh" --phase after); then
+    echo "WARNING: postflight thermal read failed; recording thermal_after_c=unavailable." >&2
+    echo "         The measurements themselves are unaffected." >&2
+    AFTER_KV="thermal_after_c=unavailable"
+fi
+# Guard the same hole from the other side: a preflight that exits 0 while
+# printing nothing would leave the key absent just as effectively.
+case "$AFTER_KV" in
+    *thermal_after_c=*) ;;
+    *) AFTER_KV="thermal_after_c=unavailable" ;;
+esac
 
 # Did we measure the code the tree is on? The binary records the commit it was
 # BUILT from (mtl/build_info.hpp); preflight records where the tree is NOW. They

--- a/docs/benchmarks/systems.md
+++ b/docs/benchmarks/systems.md
@@ -399,11 +399,24 @@ rather than a slow result.
 
 ## The run contract
 
-Every harness in `benchmarks/` must satisfy this. It exists because each rule
+Every harness in `benchmarks/` **must** satisfy this. It exists because each rule
 below was written **after** the corresponding mistake had already produced a
 number someone believed: a Zen 4 run that deleted the i7's committed CSVs, an
 analyzer that called a 4.8% "win" between two byte-identical arms, a Jetson that
 asked for eight threads on a six-core part.
+
+**Not every harness satisfies it yet.** The requirement is stated first because
+it is the target; here is where each one actually stands, so nobody reads a
+`run_scaling` CSV as though it had been gated:
+
+| Harness | Preflight | Pins | Interleaves | `OUTDIR` required |
+|---|---|---|---|---|
+| `run_blocking_ab.sh` / `.ps1` | yes | yes | yes | yes |
+| `run_scaling.sh` / `.ps1` | **no** | yes | no | **no** |
+| `run_sweeps.sh` / `.ps1` | **no** | yes | no | **no** |
+
+`run_scaling` and `run_sweeps` produced the published i7 and Ryzen numbers, and
+bringing them up to this contract is tracked in #442.
 
 | Rule | Why |
 |---|---|

--- a/docs/benchmarks/systems.md
+++ b/docs/benchmarks/systems.md
@@ -397,6 +397,78 @@ Interleave A/B variants **within one session** as on every other machine, and
 treat any run whose end temperature crossed the throttle point as invalid data
 rather than a slow result.
 
+## The run contract
+
+Every harness in `benchmarks/` must satisfy this. It exists because each rule
+below was written **after** the corresponding mistake had already produced a
+number someone believed: a Zen 4 run that deleted the i7's committed CSVs, an
+analyzer that called a 4.8% "win" between two byte-identical arms, a Jetson that
+asked for eight threads on a six-core part.
+
+| Rule | Why |
+|---|---|
+| **Preflight, and stop on failure** — `benchmarks/preflight.sh` / `.ps1` | A dirty tree, a competing build or a hot machine invalidates the session. Finding out afterwards means the CSVs are already written |
+| **Pin** — one logical id per physical core | On a hybrid CPU pinning also decides *which* cache hierarchy is detected, so an unpinned run is ambiguous, not merely noisy |
+| **Interleave, alternating order per round** | Warm-up and thermal drift otherwise accrue to whichever arm runs first, in a fixed direction |
+| **Min of N**, not mean | The minimum is the least contaminated sample; a mean folds in every interruption |
+| **`OUTDIR` per machine, required with no default** | CSVs are named by arm, not by machine, and the runners clear them before writing |
+| **Sidecar** — every CSV carries a `.sysinfo` | A number without its machine and its build is not evidence |
+
+### What every sidecar records
+
+Provenance comes from three places, deliberately, because each can be wrong
+independently of the others:
+
+| Source | Keys | Answers |
+|---|---|---|
+| The **binary** (`mtl/build_info.hpp`, `mtl/util/system_info.hpp`) | `git_commit` `git_dirty` `cxx_flags` `cmake_type` `build_isa` `cpu_*` `os_*` `compiler*` | What was built, and for which ISA |
+| **Preflight** | `tree_git_commit` `tree_git_dirty` `competing_load` `loadavg_1m` `cpu_online` `cpu_affinity` `governor` `turbo` `power_mode` `thermal_before_c` `thermal_limit_c` `thermal_headroom_c` | What the machine was doing |
+| The **harness** | `binary_stale` `thermal_after_c` `harness` `harness_rounds` `harness_reps` | Whether the run was self-consistent |
+
+Two pairs are worth understanding, since each pair looks redundant and is not:
+
+- **`cxx_flags` vs `build_isa`.** Flags are the *intent*; `build_isa` is the
+  *effect*, taken from the compiler's own predefined macros. `MTL5_NATIVE_ARCH`
+  adds `-march=native` through `target_compile_options`, so it appears in no
+  `CMAKE_CXX_FLAGS` variable at all — a build can read `cxx_flags=-O3 -DNDEBUG`
+  and still be an AVX build. This is exactly the question the Zen 4 run could not
+  answer: `/arch:AVX512` intended, AVX2 measured, nothing in the CSV to say so.
+- **`git_commit` vs `tree_git_commit`.** The first is where the *binary* came
+  from, the second where the *tree* is now. They diverge when someone edits and
+  forgets to rebuild, and the harness records that as `binary_stale=1` and warns.
+
+### Gates, and where they are enforced
+
+Preflight **fails** — it does not warn — on conditions that make a result
+meaningless. A warning scrolls past and the CSV gets committed anyway.
+
+| Condition | Action | Override |
+|---|---|---|
+| Working tree dirty | fail | `ALLOW_DIRTY=1`, and it is recorded as `tree_git_dirty=1` |
+| A build or benchmark already running | fail | none — fix the machine |
+| Threads requested exceed available cpus | fail | none |
+| Thermal headroom below the margin | fail **only where a sensor and a limit are both readable** | `MIN_THERMAL_HEADROOM_C` (default 15) |
+| Governor not `performance` | warn, and record the value | — |
+
+The thermal rule is asymmetric on purpose. Windows desktop firmware usually does
+not implement `MSAcpi_ThermalZoneTemperature`, and failing there would make the
+Zen 4 machine unbenchmarkable; passing silently would hide the gap. Unavailable
+is written as `thermal_before_c=unavailable` — recorded, never assumed cool.
+
+Governor is recorded rather than enforced because **every** machine on this page
+currently runs a non-performance governor (`powersave` on the i7, `ondemand` on
+the Xeon, `schedutil` on the Jetson). Failing on it would block all of them; what
+makes the data defensible is that a `schedutil` run can never be silently
+compared against a pinned one.
+
+### Sidecars written before this contract
+
+The CSVs committed before `preflight` existed carry the `.sysinfo` of their day:
+CPU, OS, compiler and caches, and **no** provenance or machine state. They are
+not retrofittable — the information was never captured — so read any sidecar
+without a `preflight_version` key as pre-contract, and treat its build and
+machine state as unknown rather than as default.
+
 ## Methodology
 
 One executable per backend. MTL5 dispatches to BLAS/LAPACK **at compile time**,

--- a/include/mtl/build_info.hpp.in
+++ b/include/mtl/build_info.hpp.in
@@ -29,8 +29,14 @@ inline constexpr const char* build_git_commit = MTL5_BUILD_GIT_COMMIT;
 /// benchmark result from a dirty tree is not reproducible; record it rather than
 /// pretend otherwise -- and "unknown" is not "clean".
 inline constexpr const char* build_git_dirty = MTL5_BUILD_GIT_DIRTY;
-/// CMAKE_CXX_FLAGS as configured -- the ISA selection lives here (-march=native,
-/// /arch:AVX512), and it decides the SIMD width every blocking parameter divides by.
+/// CMAKE_CXX_FLAGS plus CMAKE_CXX_FLAGS_<CONFIG>, as configured.
+///
+/// Read this as the build's INTENT, not as the ISA. Flags reach the compiler by
+/// several routes -- MTL5_NATIVE_ARCH adds -march=native through
+/// target_compile_options and never appears in any CMAKE_CXX_FLAGS variable --
+/// so this string can omit the one flag that mattered. The sidecar's `build_isa`
+/// (mtl::util::build_isa_list) is the authoritative answer, because it asks the
+/// compiler which ISA macros it actually defined.
 inline constexpr const char* build_cxx_flags = MTL5_BUILD_CXX_FLAGS;
 inline constexpr const char* build_cmake_type = MTL5_BUILD_CMAKE_TYPE;
 

--- a/include/mtl/util/system_info.hpp
+++ b/include/mtl/util/system_info.hpp
@@ -338,6 +338,53 @@ inline std::string simd_feature_list(const cpu_info& c) {
     return s;
 }
 
+/// The ISA the BINARY WAS COMPILED FOR, read from the compiler's own predefined
+/// macros (empty if none apply).
+///
+/// `simd_feature_list` above says what the MACHINE can do; this says what the
+/// code is actually allowed to use, and the two differ exactly when an intended
+/// flag did not take effect. That is not hypothetical: the Zen 4 A/B in #430 was
+/// measured as an AVX2 build when AVX-512 was intended, and nothing in the CSV
+/// could say so -- the flags reached the compiler through target_compile_options
+/// and CMAKE_CXX_FLAGS_<CONFIG>, so recording CMAKE_CXX_FLAGS alone shows an
+/// empty string on a build that is anything but default.
+///
+/// Asking the compiler what it defined sidesteps every one of those paths: it is
+/// the effect, not the intent.
+inline std::string build_isa_list() {
+    std::string s;
+    auto add = [&](const char* name) {
+        if (!s.empty()) s += ' ';
+        s += name;
+    };
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
+    // x86-64 guarantees SSE2; 32-bit needs _M_IX86_FP >= 2 under MSVC.
+  #if defined(__SSE2__) || defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 2)
+    add("SSE2");
+  #endif
+  #if defined(__AVX__)
+    add("AVX");
+  #endif
+  #if defined(__AVX2__)
+    add("AVX2");
+  #endif
+  #if defined(__FMA__) || (defined(_MSC_VER) && defined(__AVX2__))
+    // MSVC has no __FMA__; /arch:AVX2 enables FMA, so infer it there.
+    add("FMA");
+  #endif
+  #if defined(__AVX512F__)
+    add("AVX512F");
+  #endif
+#elif defined(__aarch64__) || defined(_M_ARM64)
+    add("NEON");   // mandatory on AArch64
+  #if defined(__ARM_FEATURE_SVE)
+    add("SVE");
+  #endif
+#endif
+    if (s.empty()) s = "baseline";
+    return s;
+}
+
 /// Human-readable multi-line summary, suitable for a benchmark output header.
 inline std::string to_string(const system_info& si) {
     std::string feats = simd_feature_list(si.cpu);
@@ -365,6 +412,9 @@ inline std::string to_keyvals(const system_info& si) {
     s += "cpu_arch="    + si.cpu.arch    + "\n";
     s += "cpu_logical_cores=" + std::to_string(si.cpu.logical_cores) + "\n";
     s += "cpu_simd="    + simd_feature_list(si.cpu) + "\n";
+    // What the machine can do (above) and what this binary was built to use
+    // (below) are different facts, and only the second explains the numbers.
+    s += "build_isa="   + build_isa_list() + "\n";
     s += "os_name="     + si.os.name     + "\n";
     s += "os_version="  + si.os.version  + "\n";
     s += "compiler="    + si.compiler.name + "\n";

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,27 @@ include(Catch2Testing OPTIONAL)
 add_subdirectory(unit)
 add_subdirectory(integration)
 
+# -- benchmark preflight contract (#442) -------------------------------------
+# preflight.sh and preflight.ps1 are one contract with two implementations that
+# run on disjoint machines, so they drift silently unless each platform checks
+# its own half. Windows picks the .ps1, everything else the .sh; both are held to
+# the same key list in tools/cmake/test_preflight.cmake.
+if(WIN32)
+    find_program(MTL5_PREFLIGHT_INTERP NAMES pwsh powershell)
+    set(_preflight_script ${PROJECT_SOURCE_DIR}/benchmarks/preflight.ps1)
+else()
+    find_program(MTL5_PREFLIGHT_INTERP NAMES bash)
+    set(_preflight_script ${PROJECT_SOURCE_DIR}/benchmarks/preflight.sh)
+endif()
+if(MTL5_PREFLIGHT_INTERP)
+    add_test(NAME bench_preflight_contract
+             COMMAND ${CMAKE_COMMAND}
+                     -DINTERP=${MTL5_PREFLIGHT_INTERP}
+                     -DSCRIPT=${_preflight_script}
+                     -DREPO=${PROJECT_SOURCE_DIR}
+                     -P ${PROJECT_SOURCE_DIR}/tools/cmake/test_preflight.cmake)
+endif()
+
 if(MTL5_BUILD_REGRESSION_TESTS)
     add_subdirectory(regression)
 endif()

--- a/tests/unit/util/test_system_info.cpp
+++ b/tests/unit/util/test_system_info.cpp
@@ -88,6 +88,12 @@ TEST_CASE("build_isa names what this binary was compiled for", "[util][system_in
     //
     // This is what makes the key worth putting in a sidecar: it cannot quietly
     // claim more than the run actually used.
+    //
+    // The precondition is that the binary RUNS where it was built, which holds
+    // for a test suite (it is compiled and executed by the same job) and for the
+    // benchmark builds this key exists to describe. A cross-built binary carried
+    // to a weaker machine would trip this legitimately -- and should, because its
+    // build_isa would then be describing instructions that machine cannot run.
     const auto si  = mtl::util::identify();
     const auto isa = mtl::util::build_isa_list();
 

--- a/tests/unit/util/test_system_info.cpp
+++ b/tests/unit/util/test_system_info.cpp
@@ -77,3 +77,35 @@ TEST_CASE("string renderings are non-empty and consistent", "[util][system_info]
     if (feats.find("AVX2") != std::string::npos) REQUIRE(si.cpu.avx2);
     if (feats.find("FMA") != std::string::npos)  REQUIRE(si.cpu.fma);
 }
+
+TEST_CASE("build_isa names what this binary was compiled for", "[util][system_info]") {
+    // The check that is NOT a restatement of the implementation: every ISA the
+    // binary was compiled for must be one the CPU actually has. It could not be
+    // otherwise -- a binary using an instruction the CPU lacks would have died
+    // with SIGILL long before reaching this assertion -- so a mis-mapping (say,
+    // reporting AVX512F for an /arch:AVX2 build) fails here on every machine
+    // that lacks the feature, which is most of them.
+    //
+    // This is what makes the key worth putting in a sidecar: it cannot quietly
+    // claim more than the run actually used.
+    const auto si  = mtl::util::identify();
+    const auto isa = mtl::util::build_isa_list();
+
+    REQUIRE_FALSE(isa.empty());
+    REQUIRE(isa.find("  ") == std::string::npos);   // no empty slots
+    REQUIRE(isa.back() != ' ');
+
+    if (si.cpu.arch == "x86_64") {
+        if (isa.find("SSE2") != std::string::npos)    REQUIRE(si.cpu.sse2);
+        if (isa.find("AVX") != std::string::npos)     REQUIRE(si.cpu.avx);
+        if (isa.find("AVX2") != std::string::npos)    REQUIRE(si.cpu.avx2);
+        if (isa.find("FMA") != std::string::npos)     REQUIRE(si.cpu.fma);
+        if (isa.find("AVX512F") != std::string::npos) REQUIRE(si.cpu.avx512f);
+        // x86-64 guarantees SSE2, so a build ISA that names nothing at all on
+        // this arch means the macro mapping missed the baseline.
+        REQUIRE(isa != "baseline");
+    }
+
+    // It reaches the sidecar, which is the only reason it exists.
+    REQUIRE(to_keyvals(si).find("build_isa=" + isa) != std::string::npos);
+}

--- a/tools/cmake/test_preflight.cmake
+++ b/tools/cmake/test_preflight.cmake
@@ -1,0 +1,79 @@
+# Contract test for benchmarks/preflight.{sh,ps1} (#442).
+#
+# There are two implementations of one contract, and they run on disjoint sets of
+# machines -- nobody executes the PowerShell one on Linux, so the two drift
+# silently and a Zen 4 sidecar quietly stops being comparable with an i7 one.
+# This runs whichever applies to THIS platform and holds it to the SAME key list,
+# so each CI platform proves its own half. That is the only place the drift can
+# be caught before a measurement depends on it.
+#
+# It also catches the plain failure the last PowerShell harness shipped with: a
+# syntax or parameter error nobody sees until someone tries to take a
+# measurement on the one machine that runs it (#437/#438).
+#
+# --report-only is deliberate: ctest runs *during* a build, so the competing-load
+# gate would fire, and CI checkouts of a PR branch are not always clean. The
+# gates themselves are exercised on real machines; what this asserts is that the
+# script RUNS and emits a complete record.
+#
+# Expects: INTERP, SCRIPT, REPO
+
+# Every key both implementations must emit. Adding one here without adding it to
+# both scripts fails on the platform that is missing it.
+set(REQUIRED_KEYS
+    preflight_version preflight_host preflight_kernel
+    tree_git_commit tree_git_dirty
+    competing_load
+    cpu_online cpu_affinity
+    governor turbo power_mode
+    thermal_sensor thermal_before_c thermal_limit_c thermal_headroom_c
+    preflight_gates)
+
+if(INTERP MATCHES "pwsh|powershell")
+    set(_before ${INTERP} -NoProfile -NonInteractive -File ${SCRIPT} -ReportOnly -Threads 1 -Repo ${REPO})
+    set(_after  ${INTERP} -NoProfile -NonInteractive -File ${SCRIPT} -Phase after)
+else()
+    set(_before ${INTERP} ${SCRIPT} --report-only --threads 1 --repo ${REPO})
+    set(_after  ${INTERP} ${SCRIPT} --phase after)
+endif()
+
+execute_process(COMMAND ${_before}
+                RESULT_VARIABLE _rc OUTPUT_VARIABLE _out ERROR_VARIABLE _err)
+if(NOT _rc EQUAL 0)
+    message(FATAL_ERROR "--report-only must never fail, got ${_rc}:\n${_err}\n--- stdout ---\n${_out}")
+endif()
+
+string(REPLACE "\n" ";" _lines "${_out}")
+foreach(key ${REQUIRED_KEYS})
+    # Match the VALUE too. An empty value is the failure mode that matters here:
+    # a probe that silently found nothing writes `governor=` into the sidecar,
+    # which reads as a recorded fact and is not one. Probes that cannot answer
+    # are required to say `unavailable` out loud.
+    set(_found "")
+    foreach(line ${_lines})
+        string(STRIP "${line}" line)
+        if(line MATCHES "^${key}=(.+)$")
+            set(_found "${CMAKE_MATCH_1}")
+        endif()
+    endforeach()
+    if(_found STREQUAL "")
+        message(FATAL_ERROR
+            "preflight emitted no value for '${key}'.\n"
+            "Both preflight.sh and preflight.ps1 must emit every key in "
+            "REQUIRED_KEYS, and must write 'unavailable' rather than nothing "
+            "when the platform cannot answer.\n--- stdout ---\n${_out}")
+    endif()
+endforeach()
+
+# The after phase is what makes a throttled session visible, and it is the phase
+# nobody runs by hand.
+execute_process(COMMAND ${_after}
+                RESULT_VARIABLE _rc2 OUTPUT_VARIABLE _out2 ERROR_VARIABLE _err2)
+if(NOT _rc2 EQUAL 0)
+    message(FATAL_ERROR "--phase after failed (${_rc2}):\n${_err2}")
+endif()
+if(NOT _out2 MATCHES "thermal_after_c=[^ \t\r\n]+")
+    message(FATAL_ERROR "--phase after must emit thermal_after_c, got:\n${_out2}")
+endif()
+
+message(STATUS "preflight contract: all keys present (${SCRIPT})")


### PR DESCRIPTION
## Summary

The first guard in this repo's benchmark harnesses written **before** the error rather than after it. `benchmarks/preflight.{sh,ps1}` runs ahead of any measurement, **fails** on conditions that invalidate a result, and emits `key=value` machine state into the sidecar either way.

Closes the first two acceptance items of #442; `run_scaling` / `run_sweeps` parity and the pre-contract labelling follow next.

## What it gates

| Condition | Action | Override |
|---|---|---|
| Working tree dirty | fail | `ALLOW_DIRTY=1`, recorded as `tree_git_dirty=1` |
| A build or benchmark already running | fail | none |
| Threads requested > available cpus | fail | none |
| Thermal headroom below margin | fail **only where a sensor and a limit are both readable** | `MIN_THERMAL_HEADROOM_C` (15) |
| Governor not `performance` | warn, record | — |

The thermal rule is asymmetric deliberately. Windows desktop firmware usually does not implement `MSAcpi_ThermalZoneTemperature`; failing there would make the Zen 4 machine unbenchmarkable, and passing silently would hide the gap. It records `unavailable` out loud. Governor is recorded rather than enforced because **all three** machines run a non-performance governor today — a hard gate would block every one of them.

## `build_isa` — the gap this work exposed

The stated purpose of the provenance epic was that *nothing distinguished a `/arch:AVX512` build from an AVX2 one*. Testing the pipeline end to end showed `cxx_flags` does **not** answer that:

- `MTL5_NATIVE_ARCH` adds `-march=native` via `target_compile_options` — it appears in no `CMAKE_CXX_FLAGS` variable
- the optimisation level lives in `CMAKE_CXX_FLAGS_<CONFIG>`

so a `-O3 -march=native` build recorded `cxx_flags=`, empty — the exact "empty value reads as a recorded fact" failure. Fixed two ways: per-config flags folded in (and the argument **quoted** — unquoted, any flag string containing a space would have split into separate `cmake` arguments), and `mtl::util::build_isa_list()` reads the compiler's own predefined macros.

```
default build:      build_isa=SSE2       cpu_simd=SSE2 AVX
-march=native:      build_isa=SSE2 AVX   cpu_simd=SSE2 AVX
```

Flags are intent; that is effect.

## Stale binaries

The binary records the commit it was **built** from; preflight records where the tree **is**. The harness compares them and writes `binary_stale`. Not hypothetical — the first end-to-end run of this change measured a binary two commits behind, and nothing in the numbers showed it.

## Tests, and what each can actually catch

- **`bench_preflight_contract`** runs whichever preflight applies to the platform and holds it to a **shared key list**, so each CI platform proves its own half. Two implementations of one contract running on disjoint machines drift silently otherwise — and PowerShell bugs reached `main` twice (#437/#438) because nothing in CI ever executed that file. Verified negatively: dropping a key fails it, and so does emitting a key with an **empty** value.
- **`build_isa`** is checked against the **runtime** CPU features. That is not a restatement of the implementation: a binary cannot use an ISA its CPU lacks, so a mis-mapping fails on every machine missing the feature.

Gates verified individually on the Xeon — dirty tree, thread budget, affinity-aware count under `taskset`, thermal margin, and a real competing process. Each fires; a clean run passes. Matching on *command lines* caught the shell that had merely typed the benchmark's path, so it matches process **names**.

## Changes

| File | What |
|---|---|
| `benchmarks/preflight.sh` / `.ps1` | new — gates and machine-state capture |
| `benchmarks/run_blocking_ab.sh` / `.ps1` | call preflight, append state, detect stale binaries |
| `include/mtl/util/system_info.hpp` | `build_isa_list()`, emitted as `build_isa=` |
| `CMakeLists.txt` | fold in per-config flags; quote the argument |
| `include/mtl/build_info.hpp.in` | `cxx_flags` documented as intent, pointing at `build_isa` |
| `tools/cmake/test_preflight.cmake`, `tests/CMakeLists.txt` | the contract test |
| `tests/unit/util/test_system_info.cpp` | `build_isa` ⊆ runtime features |
| `docs/benchmarks/systems.md` | "The run contract", documented once |

## Test Results

| Suite | Result |
|---|---|
| GCC | 167/167 |
| Clang | 167/167 |
| Preflight gates (manual, Xeon) | all five fire; clean run passes |
| End-to-end A/B run | sidecar carries all three provenance sources |

## Test plan

- [ ] Tier 1 CI on 8 platforms — Windows exercises `preflight.ps1` for the first time
- [ ] Promote when green

Relates to #442

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Benchmark runs now capture system conditions, compiler-enabled ISA features, build provenance, thermal state, and repository status.
  * Added preflight checks for competing workloads, thread limits, thermal headroom, CPU availability, and power settings.
  * Benchmark reports warn when binaries may not match the current source revision.

* **Bug Fixes**
  * Build records now accurately reflect configuration-specific compiler options and enabled instruction sets.

* **Documentation**
  * Added guidance on benchmark run requirements, provenance data, thermal handling, and legacy reports.

* **Tests**
  * Added automated validation for preflight behavior and ISA reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->