### PR TITLE
feat(bench): bring run_scaling and run_sweeps up to the run contract

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -86,15 +86,24 @@ columns stay empty. See the per-backend builds below.
 
 ```bash
 # Builds native / native-fast / openblas / mkl, pins to a P-core, one CSV each.
-BENCH_CPU=4 benchmarks/run_sweeps.sh            # 4 = a P-core; see note below
-# custom sweep:        BENCH_CPU=4 benchmarks/run_sweeps.sh 16:2048:32
+# OUTDIR is REQUIRED and must be this machine's own directory: the CSVs are named
+# by backend, not by machine, so a shared one silently overwrites another
+# machine's committed results (#439).
+OUTDIR=benchmarks/data/i7-12700k BENCH_CPU=4 benchmarks/run_sweeps.sh
+# custom sweep:
+OUTDIR=benchmarks/data/i7-12700k BENCH_CPU=4 benchmarks/run_sweeps.sh 16:2048:32
 # BLAS-only (the #82 gate; native LAPACK at large N is slow):
-BENCH_CPU=4 BENCH_SUITES=blas benchmarks/run_sweeps.sh
+OUTDIR=benchmarks/data/i7-12700k BENCH_CPU=4 BENCH_SUITES=blas benchmarks/run_sweeps.sh
 ```
 
-`run_sweeps.sh` configures each variant in its own (clean) build dir, builds
-`bench_all`, and runs the suites named in `BENCH_SUITES` (default `blas lapack`)
-single-threaded. The MKL variant is skipped automatically if
+`run_sweeps.sh` runs `benchmarks/preflight.sh` first and refuses to measure on a
+dirty tree, against a competing build, or on a machine without thermal headroom
+(see the run contract in `docs/benchmarks/systems.md`); the machine state it
+captures is appended to every `.sysinfo` sidecar. It then configures each variant
+in its own (clean) build dir and builds `bench_all` for **all** variants before
+measuring any of them, so no backend is timed while the machine is still hot from
+compiling its own binary. The suites named in `BENCH_SUITES` (default
+`blas lapack`) then run single-threaded. The MKL variant is skipped automatically if
 `/opt/intel/oneapi/setvars.sh` is absent (override with `MKL_SETVARS=...`).
 
 **CPU pinning matters.** On hybrid CPUs (e.g. Intel P/E-core parts) an unpinned
@@ -206,11 +215,12 @@ ceiling for GEMV/L1. `analyze_gate.py` measures this from the CSVs:
 
 ```bash
 # Build the gate variants (BLAS suite only -- native LAPACK at large N is slow):
-BENCH_CPU=4 BENCH_SUITES=blas benchmarks/run_sweeps.sh 65:1025:80
+OUTDIR=benchmarks/data/i7-12700k BENCH_CPU=4 BENCH_SUITES=blas \
+    benchmarks/run_sweeps.sh 65:1025:80
 
 # % of OpenBLAS and % of FMA peak, per op and size (peak = 1 P-core fp64):
-benchmarks/analyze_gate.py benchmarks/data/blas_sweep_native-fast.csv \
-    benchmarks/data/blas_sweep_openblas.csv --peak-gflops 78
+benchmarks/analyze_gate.py benchmarks/data/i7-12700k/blas_sweep_native-fast.csv \
+    benchmarks/data/i7-12700k/blas_sweep_openblas.csv --peak-gflops 78
 
 # Pass/fail gate: median GEMM ratio >= 80% of OpenBLAS for N >= 256,
 # and no individual size below the 70% floor
@@ -270,10 +280,12 @@ thread counts for native-fast **and** threaded OpenBLAS/MKL (their own
 reports speedup + parallel efficiency and draws the scaling plot.
 
 ```bash
-# native-fast / openblas / mkl, T in {1,2,4,8}, pinned to P-cores:
-BENCH_PCPUS=0,2,4,6,8,10,12,14 benchmarks/run_scaling.sh
-benchmarks/analyze_scaling.py benchmarks/data/gemm_scaling_*.csv \
-    --plot benchmarks/data/gemm_scaling.png
+# native-fast / openblas / mkl, T in {1,2,4,8}, pinned to P-cores.
+# OUTDIR is REQUIRED -- one directory per machine (#439).
+OUTDIR=benchmarks/data/i7-12700k BENCH_PCPUS=0,2,4,6,8,10,12,14 \
+    benchmarks/run_scaling.sh
+benchmarks/analyze_scaling.py benchmarks/data/i7-12700k/gemm_scaling_*.csv \
+    --plot benchmarks/data/i7-12700k/gemm_scaling.png
 ```
 
 > **Set `BENCH_PCPUS` to your topology** — one logical id per physical core

--- a/benchmarks/run_scaling.ps1
+++ b/benchmarks/run_scaling.ps1
@@ -41,7 +41,11 @@ param(
     [string]$VcpkgToolchain = $(if ($env:VCPKG_ROOT) { Join-Path $env:VCPKG_ROOT "scripts\buildsystems\vcpkg.cmake" } else { "" }),
     [string]$MklRoot = "C:\Users\tomtz\dev\mkl-venv\Library",
     [string]$OpenBlasRoot = "C:\Users\tomtz\dev\openblas-win",
-    [string]$OutDir = "benchmarks\data",
+    # REQUIRED, one directory PER MACHINE (e.g. benchmarks\data\ryzen-9-8945hs).
+    # There is deliberately no default: the CSVs are named by backend, not by
+    # machine, so a shared default silently overwrites another machine's
+    # committed results -- which is exactly what happened once (#439).
+    [Parameter(Mandatory = $true)][string]$OutDir,
     [int]$Jobs = [Environment]::ProcessorCount
 )
 
@@ -68,7 +72,11 @@ function Mask-ForThreads {
 
 function Invoke-Native {
     param([string]$Exe, [string[]]$NativeArgs, [string]$LogBase)
-    $p = Start-Process -FilePath $Exe -ArgumentList $NativeArgs -PassThru -NoNewWindow -Wait `
+    # Quote arguments containing spaces: Start-Process joins -ArgumentList with
+    # spaces and quotes NOTHING, so a repo under "C:\Users\Some Name\..." reaches
+    # cmake as two broken arguments, with a path in the log that looks right (#438).
+    $quoted = $NativeArgs | ForEach-Object { if ($_ -match '\s') { '"' + $_ + '"' } else { $_ } }
+    $p = Start-Process -FilePath $Exe -ArgumentList $quoted -PassThru -NoNewWindow -Wait `
                        -RedirectStandardOutput "$LogBase.out.log" -RedirectStandardError "$LogBase.err.log"
     return $p.ExitCode
 }
@@ -88,11 +96,14 @@ function Build-Variant {
     return (Join-Path $full "benchmarks\Release\bench_all.exe")
 }
 
+$script:Sidecars = @()
+
 # Run the thread sweep for one backend, merging per-T CSVs into one file.
 function Run-Scaling {
     param([string]$Exe, [string]$Backend, [string]$ThreadVar)
     $out = Join-Path $DataDir "gemm_scaling_${Backend}.csv"
     if (Test-Path $out) { Remove-Item $out }
+    if (Test-Path "$out.sysinfo") { Remove-Item "$out.sysinfo" }
     $first = $true
     foreach ($T in $ThreadList) {
         $mask = Mask-ForThreads $T
@@ -113,42 +124,123 @@ function Run-Scaling {
         $p.WaitForExit()
         if ($p.ExitCode -ne 0) { throw "bench failed ($Backend T=$T); see $log.log" }
 
-        if ($first) { Get-Content $tmp | Set-Content $out; $first = $false }
-        else { Get-Content $tmp | Select-Object -Skip 1 | Add-Content $out }
+        if ($first) {
+            Get-Content $tmp | Set-Content $out
+            # bench_all writes <csv>.sysinfo beside the CSV it was given; the
+            # per-T runs merge into one file, so keep the first one.
+            if (Test-Path "$tmp.sysinfo") { Move-Item "$tmp.sysinfo" "$out.sysinfo" }
+            $first = $false
+        } else {
+            Get-Content $tmp | Select-Object -Skip 1 | Add-Content $out
+            if (Test-Path "$tmp.sysinfo") { Remove-Item "$tmp.sysinfo" -Force }
+        }
         Remove-Item $tmp -Force
     }
+    $script:Sidecars += "$out.sysinfo"
     Write-Host "  -> $out"
 }
 
+# --- preflight -------------------------------------------------------------
+# Gate the session, and record the state it ran in (#442). Called twice: once
+# BEFORE the builds so a dirty tree or competing compile fails in seconds rather
+# than after ten minutes of configuring, and once after them, because the builds
+# heat the machine and the temperature that matters is the one the MEASUREMENTS
+# start at. The second record goes in the sidecars.
+#
+# The thread budget is validated HERE rather than where the mask is built: the
+# old code discovered "T=16 exceeds 8 physical cores" inside the measurement
+# loop, after the builds and after the smaller thread counts had already been
+# measured and written.
+foreach ($T in $ThreadList) {
+    if ($T -lt 1) { throw "-Threads: '$T' is not a positive integer" }
+    if ($T -gt $PCoreList.Count) {
+        throw "T=$T exceeds the $($PCoreList.Count) physical core(s) in -PCores ($PCores); add cores or reduce -Threads."
+    }
+}
+$TMax = ($ThreadList | Measure-Object -Maximum).Maximum
+$PreflightScript = Join-Path $PSScriptRoot "preflight.ps1"
+function Invoke-Preflight {
+    $kv = & $PreflightScript -Threads $TMax -Repo $RepoRoot
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "preflight failed -- not measuring. Fix the above, or set ALLOW_DIRTY=1"
+        Write-Host "if you accept a dirty tree (it is then recorded as such)."
+        exit 1
+    }
+    return $kv
+}
+Invoke-Preflight | Out-Null
+
+# --- build phase -----------------------------------------------------------
+# Every variant is built BEFORE any is measured: building and measuring in turn
+# timed each backend on a machine still hot from compiling its own binary, a
+# per-arm bias in a comparison whose whole purpose is comparing arms.
+Write-Host "=== building all variants (nothing is measured yet) ===`n"
+$Built = @()
 foreach ($v in $Variants) {
     switch ($v) {
         "native-fast" {
             Write-Host "=== native-fast (MTL5_NUM_THREADS) ==="
-            $exe = Build-Variant "build-scaling-native-fast" @(
-                "-DMTL5_NATIVE_FAST_GEMM=ON", "-DMTL5_WITH_HIGHWAY=ON", "-DMTL5_NATIVE_ARCH=ON")
-            Run-Scaling $exe "native-fast" "MTL5_NUM_THREADS"
+            $Built += [pscustomobject]@{
+                Label = "native-fast"; ThreadVar = "MTL5_NUM_THREADS"
+                Exe = (Build-Variant "build-scaling-native-fast" @(
+                    "-DMTL5_NATIVE_FAST_GEMM=ON", "-DMTL5_WITH_HIGHWAY=ON", "-DMTL5_NATIVE_ARCH=ON")) }
         }
         "openblas" {
             $obLib = Join-Path $OpenBlasRoot "lib\libopenblas.lib"
             if (-not (Test-Path $obLib)) { Write-Host "=== openblas: SKIPPED (no $obLib) ==="; break }
             Write-Host "=== openblas (OPENBLAS_NUM_THREADS) ==="
             $env:PATH = "$(Join-Path $OpenBlasRoot 'bin');$env:PATH"
-            $exe = Build-Variant "build-scaling-openblas" @(
-                "-DMTL5_WITH_BLAS=ON", "-DMTL5_WITH_LAPACK=ON",
-                "-DBLAS_LIBRARIES=$obLib", "-DLAPACK_LIBRARIES=$obLib")
-            Run-Scaling $exe "openblas" "OPENBLAS_NUM_THREADS"
+            $Built += [pscustomobject]@{
+                Label = "openblas"; ThreadVar = "OPENBLAS_NUM_THREADS"
+                Exe = (Build-Variant "build-scaling-openblas" @(
+                    "-DMTL5_WITH_BLAS=ON", "-DMTL5_WITH_LAPACK=ON",
+                    "-DBLAS_LIBRARIES=$obLib", "-DLAPACK_LIBRARIES=$obLib")) }
         }
         "mkl" {
             $mklLib = Join-Path $MklRoot "lib\mkl_rt.lib"
             if (-not (Test-Path $mklLib)) { Write-Host "=== mkl: SKIPPED (no $mklLib) ==="; break }
             Write-Host "=== mkl (MKL_NUM_THREADS) ==="
             $env:PATH = "$(Join-Path $MklRoot 'bin');$env:PATH"
-            $exe = Build-Variant "build-scaling-mkl" @(
-                "-DMTL5_WITH_BLAS=ON", "-DMTL5_WITH_LAPACK=ON",
-                "-DBLAS_LIBRARIES=$mklLib", "-DLAPACK_LIBRARIES=$mklLib")
-            Run-Scaling $exe "mkl" "MKL_NUM_THREADS"
+            $Built += [pscustomobject]@{
+                Label = "mkl"; ThreadVar = "MKL_NUM_THREADS"
+                Exe = (Build-Variant "build-scaling-mkl" @(
+                    "-DMTL5_WITH_BLAS=ON", "-DMTL5_WITH_LAPACK=ON",
+                    "-DBLAS_LIBRARIES=$mklLib", "-DLAPACK_LIBRARIES=$mklLib")) }
         }
         default { Write-Warning "unknown variant '$v', skipping" }
+    }
+}
+
+# --- measurement phase -----------------------------------------------------
+# NOT interleaved, unlike run_blocking_ab: bench_all truncates its --csv on every
+# invocation and analyze_scaling.py keeps the LAST row for a (backend, op, size,
+# T) key rather than the best, so rounds would overwrite rather than accumulate.
+# Tracked in #442.
+$PreflightKv = Invoke-Preflight
+Write-Host "`n=== measuring ==="
+foreach ($b in $Built) {
+    Write-Host "=== $($b.Label) ==="
+    Run-Scaling $b.Exe $b.Label $b.ThreadVar
+}
+
+# --- record machine state in every sidecar ---------------------------------
+# A failed postflight read must not silently drop the key: `unavailable` is a
+# fact, an absent key is a reader's guess.
+$AfterKv = & $PreflightScript -Phase after
+if ($LASTEXITCODE -ne 0) {
+    Write-Warning "postflight thermal read failed; recording thermal_after_c=unavailable."
+    $AfterKv = "thermal_after_c=unavailable"
+}
+if (-not ($AfterKv -match 'thermal_after_c=')) { $AfterKv = "thermal_after_c=unavailable" }
+
+foreach ($s in $script:Sidecars) {
+    if (Test-Path $s) {
+        Add-Content -Path $s -Value $PreflightKv
+        Add-Content -Path $s -Value $AfterKv
+        Add-Content -Path $s -Value @(
+            "harness=run_scaling.ps1",
+            "harness_pinned_cores=$PCores",
+            "harness_interleaved=0")
     }
 }
 

--- a/benchmarks/run_scaling.sh
+++ b/benchmarks/run_scaling.sh
@@ -13,7 +13,18 @@
 # Writes one CSV per backend (gemm_scaling_<backend>.csv) whose `backend` column
 # is labelled "<backend>-t<T>", so analyze_scaling.py can recover (backend, T).
 #
+# This harness follows the run contract in docs/benchmarks/systems.md: preflight
+# gates, pinning, a per-machine OUTDIR, and machine state in every sidecar. It
+# does NOT interleave -- see the note above the measurement phase for why that
+# needs bench_all to grow append support first.
+#
 # Environment:
+#   OUTDIR       REQUIRED. Where the CSVs land, one directory PER MACHINE, e.g.
+#                benchmarks/data/i7-12700k. There is deliberately no default:
+#                the CSVs are named by backend, not by machine, and this script
+#                deletes them before writing -- a shared default silently
+#                destroys another machine's committed results, which is exactly
+#                what happened once (#439).
 #   BENCH_PCPUS  comma list of physical-core logical ids to pin to, longest
 #                first-T prefix is used. Default for an i7-12700K: one sibling
 #                per P-core (0,2,4,6,8,10,12,14). Set to match YOUR topology
@@ -22,8 +33,11 @@
 #   SCALE_SIZES  GEMM sizes (default "1024,2048").
 #   MKL_SETVARS  oneAPI setvars.sh (default /opt/intel/oneapi/setvars.sh); mkl
 #                skipped if absent.
+#   ALLOW_DIRTY=1  permit a dirty working tree (recorded as tree_git_dirty=1).
 #
-# Example:  BENCH_PCPUS=0,2,4,6,8,10,12,14 benchmarks/run_scaling.sh
+# Example:
+#   OUTDIR=benchmarks/data/i7-12700k BENCH_PCPUS=0,2,4,6,8,10,12,14 \
+#       benchmarks/run_scaling.sh
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -33,11 +47,88 @@ cd "$ROOT"
 PCPUS="${BENCH_PCPUS:-0,2,4,6,8,10,12,14}"
 THREADS="${THREADS:-1 2 4 8}"
 SIZES="${SCALE_SIZES:-1024,2048}"
-DATA="benchmarks/data"
 MKL_SETVARS="${MKL_SETVARS:-/opt/intel/oneapi/setvars.sh}"
+
+if [ -z "${OUTDIR:-}" ]; then
+    echo "OUTDIR is required: give this machine its own directory, e.g." >&2
+    echo "  OUTDIR=benchmarks/data/<machine> $0" >&2
+    echo "Existing machine directories:" >&2
+    ls -d benchmarks/data/*/ 2>/dev/null | sed 's|^|  |' >&2
+    exit 2
+fi
+DATA="$OUTDIR"
 mkdir -p "$DATA"
 
 IFS=',' read -r -a PCPU_ARR <<< "$PCPUS"
+
+TMAX=0
+for T in $THREADS; do
+    if ! [ "$T" -ge 1 ] 2>/dev/null; then
+        echo "THREADS: '$T' is not a positive integer" >&2; exit 2
+    fi
+    if (( T > ${#PCPU_ARR[@]} )); then
+        echo "error: T=$T exceeds the ${#PCPU_ARR[@]} physical core(s) in BENCH_PCPUS ($PCPUS);" >&2
+        echo "       add more cores to BENCH_PCPUS or reduce THREADS." >&2
+        exit 2
+    fi
+    (( T > TMAX )) && TMAX=$T
+done
+
+# Gate the session, and record the state it ran in (#442). Called twice on
+# purpose: once BEFORE the builds, so a dirty tree or a competing compile fails
+# in seconds rather than after ten minutes of configuring, and once after them,
+# because the builds themselves heat the machine and the temperature that
+# matters is the one the MEASUREMENTS start at. The second record is the one
+# that goes in the sidecars.
+preflight_gate() {
+    local kv
+    if ! kv=$("$SCRIPT_DIR/preflight.sh" --threads "$TMAX" --repo "$ROOT"); then
+        echo "preflight failed -- not measuring. Fix the above, or set ALLOW_DIRTY=1" >&2
+        echo "if you accept a dirty tree (it is then recorded as such)." >&2
+        exit 1
+    fi
+    printf '%s\n' "$kv"
+}
+preflight_gate >/dev/null
+
+configure_build() {
+    local dir="$1"; shift
+    rm -rf "$dir"
+    cmake -B "$dir" -DMTL5_BUILD_BENCHMARKS=ON -DCMAKE_BUILD_TYPE=Release "$@" >/dev/null
+    cmake --build "$dir" --target bench_all -j"${JOBS:-4}" >/dev/null
+}
+
+# Every sidecar this session writes, so machine state can be appended to all of
+# them at the end.
+SIDECARS=()
+
+# run_scaling_for <build-dir> <backend> <thread-env-var>
+run_scaling_for() {
+    local bin="$1/benchmarks/bench_all" backend="$2" tvar="$3"
+    local out="$DATA/gemm_scaling_${backend}.csv"; rm -f "$out" "$out.sysinfo"
+    local first=1
+    for T in $THREADS; do
+        local pin; pin="$(pcpus_for "$T")"
+        local tmp; tmp="$(mktemp)"
+        echo "  $backend  T=$T  pinned to CPUs $pin"
+        env "$tvar=$T" OMP_NUM_THREADS="$T" \
+            taskset -c "$pin" "$bin" --suite gemm --sizes "$SIZES" \
+            --label "${backend}-t${T}" --csv "$tmp" >/dev/null
+        if [[ $first -eq 1 ]]; then
+            cat "$tmp" > "$out"
+            # bench_all writes <csv>.sysinfo next to the CSV it was given; the
+            # per-T runs are merged into one file, so keep the first one.
+            [[ -f "$tmp.sysinfo" ]] && mv "$tmp.sysinfo" "$out.sysinfo"
+            first=0
+        else
+            tail -n +2 "$tmp" >> "$out"
+            rm -f "$tmp.sysinfo"
+        fi
+        rm -f "$tmp"
+    done
+    SIDECARS+=("$out.sysinfo")
+    echo "  -> $out"
+}
 
 # pcpus_for <T>: comma list of the first T physical-core ids.
 pcpus_for() {
@@ -48,68 +139,96 @@ pcpus_for() {
     printf '%s' "$out"
 }
 
-configure_build() {
-    local dir="$1"; shift
-    rm -rf "$dir"
-    cmake -B "$dir" -DMTL5_BUILD_BENCHMARKS=ON -DCMAKE_BUILD_TYPE=Release "$@" >/dev/null
-    cmake --build "$dir" --target bench_all -j"${JOBS:-4}" >/dev/null
-}
+# ── build phase ─────────────────────────────────────────────────────────────
+# Every variant is built BEFORE any of them is measured. Building and measuring
+# in turn meant each backend was timed on a machine still hot from compiling its
+# own binary, while the next one compiled during the previous one's cooldown --
+# a per-arm bias in a comparison whose entire purpose is comparing arms.
+echo "=== building all variants (nothing is measured yet) ==="
+BACKENDS=()   # label
+BUILDDIRS=()  # build directory
+TVARS=()      # threading environment variable
+MKL_ARM=-1    # index of the mkl arm, which needs setvars sourced to RUN
 
-# run_scaling_for <build-dir> <backend> <thread-env-var>
-run_scaling_for() {
-    local bin="$1/benchmarks/bench_all" backend="$2" tvar="$3"
-    local out="$DATA/gemm_scaling_${backend}.csv"; rm -f "$out"
-    local first=1
-    for T in $THREADS; do
-        if (( T > ${#PCPU_ARR[@]} )); then
-            echo "error: T=$T exceeds the ${#PCPU_ARR[@]} physical core(s) in BENCH_PCPUS ($PCPUS);" >&2
-            echo "       add more cores to BENCH_PCPUS or reduce THREADS." >&2
-            exit 1
-        fi
-        local pin; pin="$(pcpus_for "$T")"
-        local tmp; tmp="$(mktemp)"
-        echo "  $backend  T=$T  pinned to CPUs $pin"
-        env "$tvar=$T" OMP_NUM_THREADS="$T" \
-            taskset -c "$pin" "$bin" --suite gemm --sizes "$SIZES" \
-            --label "${backend}-t${T}" --csv "$tmp" >/dev/null
-        if [[ $first -eq 1 ]]; then cat "$tmp" > "$out"; first=0; else tail -n +2 "$tmp" >> "$out"; fi
-        rm -f "$tmp"
-    done
-    echo "  -> $out"
-}
-
-echo "=== native-fast (Highway + -march=native, MTL5_NUM_THREADS) ==="
 configure_build build-scaling-native-fast \
     -DMTL5_NATIVE_FAST_GEMM=ON -DMTL5_WITH_HIGHWAY=ON -DMTL5_NATIVE_ARCH=ON
-run_scaling_for build-scaling-native-fast native-fast MTL5_NUM_THREADS
+BACKENDS+=(native-fast); BUILDDIRS+=(build-scaling-native-fast); TVARS+=(MTL5_NUM_THREADS)
 
-echo "=== openblas (OPENBLAS_NUM_THREADS) ==="
 configure_build build-scaling-openblas -DMTL5_WITH_BLAS=ON -DMTL5_WITH_LAPACK=ON
-run_scaling_for build-scaling-openblas openblas OPENBLAS_NUM_THREADS
+BACKENDS+=(openblas); BUILDDIRS+=(build-scaling-openblas); TVARS+=(OPENBLAS_NUM_THREADS)
 
 # BLIS (BLA_VENDOR=FLAME, BLIS_NUM_THREADS); skipped if not found at configure.
 if cmake -B build-scaling-blis-probe -DMTL5_BUILD_BENCHMARKS=ON -DCMAKE_BUILD_TYPE=Release \
         -DMTL5_WITH_BLAS=ON -DBLA_VENDOR=FLAME >/dev/null 2>&1; then
     rm -rf build-scaling-blis-probe
-    echo "=== blis (BLIS_NUM_THREADS) ==="
     configure_build build-scaling-blis -DMTL5_WITH_BLAS=ON -DBLA_VENDOR=FLAME
-    run_scaling_for build-scaling-blis blis BLIS_NUM_THREADS
+    BACKENDS+=(blis); BUILDDIRS+=(build-scaling-blis); TVARS+=(BLIS_NUM_THREADS)
 else
     rm -rf build-scaling-blis-probe
     echo "=== blis: SKIPPED (no FLAME/BLIS BLAS found) ==="
 fi
 
 if [[ -f "$MKL_SETVARS" ]]; then
-    echo "=== mkl (MKL_NUM_THREADS) ==="
-    set +u +e
-    # shellcheck disable=SC1090
-    source "$MKL_SETVARS" >/dev/null 2>&1 || true
-    set -u -e
-    configure_build build-scaling-mkl -DMTL5_WITH_BLAS=ON -DMTL5_WITH_LAPACK=ON -DBLA_VENDOR=Intel10_64lp
-    run_scaling_for build-scaling-mkl mkl MKL_NUM_THREADS
+    # setvars.sh is sourced in a SUBSHELL, here and at run time. Sourcing it into
+    # this shell would leave oneAPI's LD_LIBRARY_PATH ahead of every later run,
+    # so the openblas and blis binaries could resolve MKL's libraries and be
+    # labelled as themselves -- an arm measuring another arm.
+    ( set +u +e
+      # shellcheck disable=SC1090
+      source "$MKL_SETVARS" >/dev/null 2>&1 || true
+      set -u -e
+      configure_build build-scaling-mkl -DMTL5_WITH_BLAS=ON -DMTL5_WITH_LAPACK=ON \
+                      -DBLA_VENDOR=Intel10_64lp )
+    BACKENDS+=(mkl); BUILDDIRS+=(build-scaling-mkl); TVARS+=(MKL_NUM_THREADS)
+    MKL_ARM=$(( ${#BACKENDS[@]} - 1 ))
 else
     echo "=== mkl: SKIPPED (no $MKL_SETVARS) ==="
 fi
+
+# ── measurement phase ───────────────────────────────────────────────────────
+# Gate again now that the builds are done: this is the temperature and the load
+# the numbers are actually taken under, and it is what the sidecars record.
+#
+# NOT interleaved, unlike run_blocking_ab. Interleaving needs several rounds per
+# arm, and bench_all truncates its --csv on every invocation while
+# analyze_scaling.py keeps the LAST row for a (backend, op, size, T) key rather
+# than the best -- so rounds would silently overwrite instead of accumulating.
+# Doing it properly means append support in bench_all and min-of-rounds in the
+# analyzer; until then, building everything up front is what removes the largest
+# order effect. Tracked in #442.
+PREFLIGHT_KV=$(preflight_gate)
+echo "=== measuring ==="
+for i in "${!BACKENDS[@]}"; do
+    echo "=== ${BACKENDS[$i]} (${TVARS[$i]}) ==="
+    if [[ $i -eq $MKL_ARM ]]; then
+        ( set +u +e
+          # shellcheck disable=SC1090
+          source "$MKL_SETVARS" >/dev/null 2>&1 || true
+          set -u -e
+          run_scaling_for "${BUILDDIRS[$i]}" "${BACKENDS[$i]}" "${TVARS[$i]}" )
+        SIDECARS+=("$DATA/gemm_scaling_${BACKENDS[$i]}.csv.sysinfo")
+    else
+        run_scaling_for "${BUILDDIRS[$i]}" "${BACKENDS[$i]}" "${TVARS[$i]}"
+    fi
+done
+
+# ── record machine state in every sidecar ───────────────────────────────────
+# A failed postflight read must not silently drop the key: `unavailable` is a
+# fact, an absent key is a reader's guess.
+if ! AFTER_KV=$("$SCRIPT_DIR/preflight.sh" --phase after); then
+    echo "WARNING: postflight thermal read failed; recording thermal_after_c=unavailable." >&2
+    AFTER_KV="thermal_after_c=unavailable"
+fi
+case "$AFTER_KV" in
+    *thermal_after_c=*) ;;
+    *) AFTER_KV="thermal_after_c=unavailable" ;;
+esac
+
+for s in "${SIDECARS[@]}"; do
+    [[ -f "$s" ]] || continue
+    printf '%s\n%s\n' "$PREFLIGHT_KV" "$AFTER_KV" >> "$s"
+    printf 'harness=run_scaling.sh\nharness_pinned_cpus=%s\nharness_interleaved=0\n' "$PCPUS" >> "$s"
+done
 
 echo
 echo "Done. Analyze with:"

--- a/benchmarks/run_sweeps.ps1
+++ b/benchmarks/run_sweeps.ps1
@@ -56,10 +56,11 @@ param(
     # and BLAS-only, so it is not usable as a reference. Point this at the unzipped
     # OpenBLAS-<ver>-x64 dir (contains lib\libopenblas.lib and bin\libopenblas.dll).
     [string]$OpenBlasRoot = "C:\Users\tomtz\dev\openblas-win",
-    # Output directory for CSVs, relative to the repo root. Point per-machine
-    # runs at a subdir (e.g. data\ryzen-9-8945hs) so they never overwrite the
-    # committed reference CSVs that back an existing results page.
-    [string]$OutDir = "benchmarks\data",
+    # REQUIRED, one directory PER MACHINE (e.g. benchmarks\data\ryzen-9-8945hs).
+    # There is deliberately no default: the CSVs are named by backend, not by
+    # machine, so a shared default silently overwrites another machine's
+    # committed results -- which is exactly what happened once (#439).
+    [Parameter(Mandatory = $true)][string]$OutDir,
     [int]$Jobs = [Environment]::ProcessorCount
 )
 
@@ -120,9 +121,14 @@ function Invoke-Pinned {
 # wrapping native stderr in ErrorRecords.
 function Invoke-Native {
     param([string]$Exe, [string[]]$NativeArgs, [string]$LogBase)
+    # Quote arguments containing spaces, exactly as Invoke-Pinned does.
+    # Start-Process joins -ArgumentList with spaces and quotes NOTHING, so a repo
+    # under "C:\Users\Some Name\..." reaches cmake as two broken arguments and
+    # the configure fails with a path that looks correct in the log (#438).
+    $quoted = $NativeArgs | ForEach-Object { if ($_ -match '\s') { '"' + $_ + '"' } else { $_ } }
     # -Wait is required: without it, Start-Process -PassThru leaves ExitCode
     # empty in Windows PowerShell 5.1 (disposed process handle).
-    $p = Start-Process -FilePath $Exe -ArgumentList $NativeArgs -PassThru -NoNewWindow -Wait `
+    $p = Start-Process -FilePath $Exe -ArgumentList $quoted -PassThru -NoNewWindow -Wait `
                        -RedirectStandardOutput "$LogBase.out.log" `
                        -RedirectStandardError  "$LogBase.err.log"
     return $p.ExitCode
@@ -147,6 +153,8 @@ function Build-Variant {
     return (Join-Path $full "benchmarks\Release\bench_all.exe")
 }
 
+$script:Sidecars = @()
+
 function Run-Variant {
     param([string]$Exe, [string]$Label, [switch]$BlasOnly)
     foreach ($s in $SuiteList) {
@@ -159,26 +167,48 @@ function Run-Variant {
         Write-Host ">> ${Label}: $s sweep ($Sweep)"
         Invoke-Pinned -Exe $Exe -LogPath $log -BenchArgs @(
             "--suite", $s, $sweepFlag, $Sweep, "--label", $Label, "--csv", $csv)
+        $script:Sidecars += "$csv.sysinfo"
     }
 }
 
-# --- variants --------------------------------------------------------------
+# --- preflight -------------------------------------------------------------
+# Gate the session, and record the state it ran in (#442). Called twice on
+# purpose: once BEFORE the builds so a dirty tree or a competing compile fails in
+# seconds rather than after ten minutes of configuring, and once after them,
+# because the builds heat the machine and the temperature that matters is the one
+# the MEASUREMENTS start at. The second record goes in the sidecars.
+$PreflightScript = Join-Path $PSScriptRoot "preflight.ps1"
+function Invoke-Preflight {
+    $kv = & $PreflightScript -Threads 1 -Repo $RepoRoot
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "preflight failed -- not measuring. Fix the above, or set ALLOW_DIRTY=1"
+        Write-Host "if you accept a dirty tree (it is then recorded as such)."
+        exit 1
+    }
+    return $kv
+}
+Invoke-Preflight | Out-Null
 
+# --- build phase -----------------------------------------------------------
+# Every variant is built BEFORE any is measured. Building and measuring in turn
+# meant each backend was timed on a machine still hot from compiling its own
+# binary, while the next compiled during the previous one's cooldown -- a per-arm
+# bias in a comparison whose whole purpose is comparing arms.
 Write-Host "Pinning single-thread runs to affinity mask 0x$($PinMask.ToString('x'))"
-Write-Host "Data -> $DataDir`n"
+Write-Host "Data -> $DataDir"
+Write-Host "=== building all variants (nothing is measured yet) ===`n"
 
+$Built = @()
 foreach ($v in $Variants) {
     switch ($v) {
         "native" {
             Write-Host "=== native (generic-only) ==="
-            $exe = Build-Variant "build-native" @()
-            Run-Variant $exe "native"
+            $Built += [pscustomobject]@{ Label = "native"; Exe = (Build-Variant "build-native" @()) }
         }
         "native-fast" {
             Write-Host "=== native-fast (blocked GEMM / SIMD GEMV via Highway) ==="
-            $exe = Build-Variant "build-native-fast" @(
-                "-DMTL5_NATIVE_FAST_GEMM=ON", "-DMTL5_WITH_HIGHWAY=ON", "-DMTL5_NATIVE_ARCH=ON")
-            Run-Variant $exe "native-fast"
+            $Built += [pscustomobject]@{ Label = "native-fast"; Exe = (Build-Variant "build-native-fast" @(
+                "-DMTL5_NATIVE_FAST_GEMM=ON", "-DMTL5_WITH_HIGHWAY=ON", "-DMTL5_NATIVE_ARCH=ON")) }
         }
         "openblas" {
             $obLib = Join-Path $OpenBlasRoot "lib\libopenblas.lib"
@@ -190,10 +220,9 @@ foreach ($v in $Variants) {
             # The official mingw build bundles LAPACK, so libopenblas.lib resolves
             # both BLAS and the Fortran LAPACK symbols; put its DLL on PATH.
             $env:PATH = "$obBin;$env:PATH"
-            $exe = Build-Variant "build-openblas" @(
+            $Built += [pscustomobject]@{ Label = "openblas"; Exe = (Build-Variant "build-openblas" @(
                 "-DMTL5_WITH_BLAS=ON", "-DMTL5_WITH_LAPACK=ON",
-                "-DBLAS_LIBRARIES=$obLib", "-DLAPACK_LIBRARIES=$obLib")
-            Run-Variant $exe "openblas"
+                "-DBLAS_LIBRARIES=$obLib", "-DLAPACK_LIBRARIES=$obLib")) }
         }
         "mkl" {
             $mklLib = Join-Path $MklRoot "lib\mkl_rt.lib"
@@ -208,12 +237,44 @@ foreach ($v in $Variants) {
             # exports the Fortran BLAS/LAPACK symbols MTL5 needs), and put its
             # DLL dir on PATH so the benchmark resolves it at runtime.
             $env:PATH = "$mklBin;$env:PATH"
-            $exe = Build-Variant "build-mkl" @(
+            $Built += [pscustomobject]@{ Label = "mkl"; Exe = (Build-Variant "build-mkl" @(
                 "-DMTL5_WITH_BLAS=ON", "-DMTL5_WITH_LAPACK=ON",
-                "-DBLAS_LIBRARIES=$mklLib", "-DLAPACK_LIBRARIES=$mklLib")
-            Run-Variant $exe "mkl"
+                "-DBLAS_LIBRARIES=$mklLib", "-DLAPACK_LIBRARIES=$mklLib")) }
         }
         default { Write-Warning "unknown variant '$v', skipping" }
+    }
+}
+
+# --- measurement phase -----------------------------------------------------
+# NOT interleaved, unlike run_blocking_ab: bench_all truncates its --csv on every
+# invocation, so multiple rounds would overwrite rather than accumulate. Doing it
+# properly needs append support in bench_all and best-of-rounds in the analyzers.
+# Tracked in #442.
+$PreflightKv = Invoke-Preflight
+Write-Host "`n=== measuring ==="
+foreach ($b in $Built) {
+    Write-Host "=== $($b.Label) ==="
+    Run-Variant $b.Exe $b.Label
+}
+
+# --- record machine state in every sidecar ---------------------------------
+# A failed postflight read must not silently drop the key: `unavailable` is a
+# fact, an absent key is a reader's guess.
+$AfterKv = & $PreflightScript -Phase after
+if ($LASTEXITCODE -ne 0) {
+    Write-Warning "postflight thermal read failed; recording thermal_after_c=unavailable."
+    $AfterKv = "thermal_after_c=unavailable"
+}
+if (-not ($AfterKv -match 'thermal_after_c=')) { $AfterKv = "thermal_after_c=unavailable" }
+
+foreach ($s in $script:Sidecars) {
+    if (Test-Path $s) {
+        Add-Content -Path $s -Value $PreflightKv
+        Add-Content -Path $s -Value $AfterKv
+        Add-Content -Path $s -Value @(
+            "harness=run_sweeps.ps1",
+            "harness_pinned_mask=0x$($PinMask.ToString('x'))",
+            "harness_interleaved=0")
     }
 }
 

--- a/benchmarks/run_sweeps.sh
+++ b/benchmarks/run_sweeps.sh
@@ -1,14 +1,22 @@
 #!/usr/bin/env bash
 # Build one bench_all per backend and run the sweeps, writing one CSV per
-# backend into benchmarks/data/. This is the "one executable per backend"
-# methodology: each variant is compiled with the BLAS/LAPACK flags a dependent
-# application would set for the whole program, and the public mtl:: API
-# dispatches accordingly. Native is a generic-only build (no BLAS/LAPACK).
+# backend into OUTDIR. This is the "one executable per backend" methodology:
+# each variant is compiled with the BLAS/LAPACK flags a dependent application
+# would set for the whole program, and the public mtl:: API dispatches
+# accordingly. Native is a generic-only build (no BLAS/LAPACK).
+#
+# This harness follows the run contract in docs/benchmarks/systems.md: preflight
+# gates, pinning, a per-machine OUTDIR, and machine state in every sidecar. It
+# does NOT interleave -- see the note above the measurement phase.
 #
 # Usage:
-#   benchmarks/run_sweeps.sh [sweep-spec]
+#   OUTDIR=benchmarks/data/<machine> benchmarks/run_sweeps.sh [sweep-spec]
 #
 # Environment:
+#   OUTDIR       REQUIRED. Where the CSVs land, one directory PER MACHINE. There
+#                is deliberately no default: the CSVs are named by backend, not
+#                by machine, so a shared default silently overwrites another
+#                machine's committed results (#439).
 #   BENCH_CPU    CPU id to pin to via taskset (recommend a P-core on hybrid
 #                CPUs for stable single-thread numbers). Empty = no pinning.
 #   BENCH_SWEEP  sweep spec (default 65:1025:80, all-odd / non-power-of-2).
@@ -18,6 +26,7 @@
 #                GEMV/L1 acceptance gate (#93).
 #   MKL_SETVARS  path to oneAPI setvars.sh (default /opt/intel/oneapi/setvars.sh);
 #                the MKL variant is skipped if it is not found.
+#   ALLOW_DIRTY=1  permit a dirty working tree (recorded as tree_git_dirty=1).
 #
 # Variants: native (generic-only), native-fast (the blocked GEMM / SIMD GEMV
 # path: -DMTL5_NATIVE_FAST_GEMM + Highway + -march=native, no external BLAS),
@@ -25,7 +34,8 @@
 # is present).
 #
 # Example (P-core 4, GEMM/GEMV/L1 gate only):
-#   BENCH_CPU=4 BENCH_SUITES=blas benchmarks/run_sweeps.sh
+#   OUTDIR=benchmarks/data/i7-12700k BENCH_CPU=4 BENCH_SUITES=blas \
+#       benchmarks/run_sweeps.sh
 set -euo pipefail
 
 # Resolve repo root from this script's location (portable).
@@ -35,8 +45,16 @@ cd "$ROOT"
 
 SWEEP="${1:-${BENCH_SWEEP:-65:1025:80}}"
 SUITES="${BENCH_SUITES:-blas lapack}"
-DATA="benchmarks/data"
 MKL_SETVARS="${MKL_SETVARS:-/opt/intel/oneapi/setvars.sh}"
+
+if [ -z "${OUTDIR:-}" ]; then
+    echo "OUTDIR is required: give this machine its own directory, e.g." >&2
+    echo "  OUTDIR=benchmarks/data/<machine> $0" >&2
+    echo "Existing machine directories:" >&2
+    ls -d benchmarks/data/*/ 2>/dev/null | sed 's|^|  |' >&2
+    exit 2
+fi
+DATA="$OUTDIR"
 mkdir -p "$DATA"
 
 PIN=()
@@ -48,6 +66,25 @@ else
     echo "         CPUs the small L1 kernels may land on E-cores and skew results."
 fi
 
+# Gate the session, and record the state it ran in (#442). Called twice on
+# purpose: once BEFORE the builds, so a dirty tree or a competing compile fails
+# in seconds rather than after ten minutes of configuring, and once after them,
+# because the builds heat the machine and the temperature that matters is the
+# one the MEASUREMENTS start at. The second record goes in the sidecars.
+#
+# These are single-threaded runs (every vendor's thread count is forced to 1
+# below), so the thread budget asked of preflight is 1.
+preflight_gate() {
+    local kv
+    if ! kv=$("$SCRIPT_DIR/preflight.sh" --threads 1 --repo "$ROOT"); then
+        echo "preflight failed -- not measuring. Fix the above, or set ALLOW_DIRTY=1" >&2
+        echo "if you accept a dirty tree (it is then recorded as such)." >&2
+        exit 1
+    fi
+    printf '%s\n' "$kv"
+}
+preflight_gate >/dev/null
+
 # configure_build <build-dir> <extra-cmake-args...>
 # Starts from a clean build dir so a variant can never pick up a stale binary
 # from a previous run with different flags.
@@ -58,71 +95,128 @@ configure_build() {
     cmake --build "$dir" --target bench_all -j"${JOBS:-4}" >/dev/null
 }
 
+# Every sidecar this session writes, so machine state can be appended to all of
+# them at the end.
+SIDECARS=()
+
 # run_variant <build-dir> <label>
 # Runs the suites named in $SUITES (blas and/or lapack), one CSV each.
 run_variant() {
     local bin="$1/benchmarks/bench_all"; local label="$2"
-    local s
+    local s csv flag
     for s in $SUITES; do
         case "$s" in
-            blas)
-                echo ">> $label: BLAS L1/L2/L3 sweep"
-                OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 BLIS_NUM_THREADS=1 \
-                    "${PIN[@]}" "$bin" --suite blas --blas-sweep "$SWEEP" \
-                    --label "$label" --csv "$DATA/blas_sweep_${label}.csv" ;;
-            lapack)
-                echo ">> $label: LAPACK factorization sweep"
-                OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 BLIS_NUM_THREADS=1 \
-                    "${PIN[@]}" "$bin" --suite lapack --lapack-sweep "$SWEEP" \
-                    --label "$label" --csv "$DATA/lapack_sweep_${label}.csv" ;;
-            *) echo "  (unknown suite '$s' in BENCH_SUITES, skipping)" ;;
+            blas)   csv="$DATA/blas_sweep_${label}.csv";   flag=--blas-sweep ;;
+            lapack) csv="$DATA/lapack_sweep_${label}.csv"; flag=--lapack-sweep ;;
+            *) echo "  (unknown suite '$s' in BENCH_SUITES, skipping)"; continue ;;
         esac
+        echo ">> $label: $s sweep"
+        OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 BLIS_NUM_THREADS=1 \
+            "${PIN[@]}" "$bin" --suite "$s" "$flag" "$SWEEP" \
+            --label "$label" --csv "$csv"
+        SIDECARS+=("$csv.sysinfo")
     done
 }
 
-echo "=== native (generic-only) ==="
-configure_build build-native
-run_variant build-native native
+# ── build phase ─────────────────────────────────────────────────────────────
+# Every variant is built BEFORE any of them is measured. Building and measuring
+# in turn meant each backend was timed on a machine still hot from compiling its
+# own binary, while the next one compiled during the previous one's cooldown --
+# a per-arm bias in a comparison whose whole purpose is comparing arms.
+echo "=== building all variants (nothing is measured yet) ==="
+LABELS=(); DIRS=(); MKL_ARM=-1
 
-echo "=== native-fast (blocked GEMM / SIMD GEMV: Highway + -march=native) ==="
+configure_build build-native
+LABELS+=(native); DIRS+=(build-native)
+
 configure_build build-native-fast \
     -DMTL5_NATIVE_FAST_GEMM=ON -DMTL5_WITH_HIGHWAY=ON -DMTL5_NATIVE_ARCH=ON
-run_variant build-native-fast native-fast
+LABELS+=(native-fast); DIRS+=(build-native-fast)
 
-echo "=== openblas ==="
 configure_build build-openblas -DMTL5_WITH_BLAS=ON -DMTL5_WITH_LAPACK=ON
-run_variant build-openblas openblas
+LABELS+=(openblas); DIRS+=(build-openblas)
 
 # BLIS (BLAS-compatible; selected via CMake FindBLAS BLA_VENDOR=FLAME). BLIS is a
 # BLAS-only library (LAPACK would come from libflame, not wired here), so it is
 # configured with BLAS only -- the BLAS L1/L2/L3 suites are the point of the
-# comparison. Threads via BLIS_NUM_THREADS (pinned to 1 in run_variant's env).
-# Skipped if a FLAME/BLIS BLAS cannot be located at configure time.
-echo "=== blis ==="
+# comparison. Skipped if a FLAME/BLIS BLAS cannot be located at configure time.
 if cmake -B build-blis-probe -DMTL5_BUILD_BENCHMARKS=ON -DCMAKE_BUILD_TYPE=Release \
         -DMTL5_WITH_BLAS=ON -DBLA_VENDOR=FLAME >/dev/null 2>&1; then
     rm -rf build-blis-probe
     configure_build build-blis -DMTL5_WITH_BLAS=ON -DBLA_VENDOR=FLAME
-    run_variant build-blis blis
+    LABELS+=(blis); DIRS+=(build-blis)
 else
     rm -rf build-blis-probe
     echo "=== blis: SKIPPED (no FLAME/BLIS BLAS found; install libblis-dev or set BLA_VENDOR) ==="
 fi
 
 if [[ -f "$MKL_SETVARS" ]]; then
-    echo "=== mkl ==="
-    # oneAPI's setvars.sh references unset variables, which would trip our
-    # `set -u` (nounset) and silently abort the whole script mid-source -- and
-    # it may also return non-zero under `set -e`. Relax both just around it.
-    set +u +e
-    # shellcheck disable=SC1090
-    source "$MKL_SETVARS" >/dev/null 2>&1 || true
-    set -u -e
-    configure_build build-mkl -DMTL5_WITH_BLAS=ON -DMTL5_WITH_LAPACK=ON -DBLA_VENDOR=Intel10_64lp
-    run_variant build-mkl mkl
+    # oneAPI's setvars.sh references unset variables, which would trip `set -u`
+    # and abort mid-source, and it may return non-zero under `set -e`. It is also
+    # sourced in a SUBSHELL, here and at run time: sourcing it into this shell
+    # would leave oneAPI's LD_LIBRARY_PATH ahead of every later run, so the
+    # openblas and blis binaries could resolve MKL's libraries while still being
+    # labelled as themselves -- one arm measuring another.
+    ( set +u +e
+      # shellcheck disable=SC1090
+      source "$MKL_SETVARS" >/dev/null 2>&1 || true
+      set -u -e
+      configure_build build-mkl -DMTL5_WITH_BLAS=ON -DMTL5_WITH_LAPACK=ON \
+                      -DBLA_VENDOR=Intel10_64lp )
+    LABELS+=(mkl); DIRS+=(build-mkl)
+    MKL_ARM=$(( ${#LABELS[@]} - 1 ))
 else
     echo "=== mkl: SKIPPED (no $MKL_SETVARS) ==="
 fi
+
+# ── measurement phase ───────────────────────────────────────────────────────
+# Gate again now the builds are done: this is the temperature and the load the
+# numbers are actually taken under, and it is what the sidecars record.
+#
+# NOT interleaved, unlike run_blocking_ab. Interleaving needs several rounds per
+# arm, and bench_all truncates its --csv on every invocation, so rounds would
+# overwrite rather than accumulate. Doing it properly means append support in
+# bench_all and best-of-rounds in the analyzers; until then, building everything
+# up front removes the largest order effect. Tracked in #442.
+PREFLIGHT_KV=$(preflight_gate)
+echo "=== measuring ==="
+for i in "${!LABELS[@]}"; do
+    echo "=== ${LABELS[$i]} ==="
+    if [[ $i -eq $MKL_ARM ]]; then
+        ( set +u +e
+          # shellcheck disable=SC1090
+          source "$MKL_SETVARS" >/dev/null 2>&1 || true
+          set -u -e
+          run_variant "${DIRS[$i]}" "${LABELS[$i]}" )
+        for s in $SUITES; do
+            case "$s" in
+                blas)   SIDECARS+=("$DATA/blas_sweep_${LABELS[$i]}.csv.sysinfo") ;;
+                lapack) SIDECARS+=("$DATA/lapack_sweep_${LABELS[$i]}.csv.sysinfo") ;;
+            esac
+        done
+    else
+        run_variant "${DIRS[$i]}" "${LABELS[$i]}"
+    fi
+done
+
+# ── record machine state in every sidecar ───────────────────────────────────
+# A failed postflight read must not silently drop the key: `unavailable` is a
+# fact, an absent key is a reader's guess.
+if ! AFTER_KV=$("$SCRIPT_DIR/preflight.sh" --phase after); then
+    echo "WARNING: postflight thermal read failed; recording thermal_after_c=unavailable." >&2
+    AFTER_KV="thermal_after_c=unavailable"
+fi
+case "$AFTER_KV" in
+    *thermal_after_c=*) ;;
+    *) AFTER_KV="thermal_after_c=unavailable" ;;
+esac
+
+for s in "${SIDECARS[@]}"; do
+    [[ -f "$s" ]] || continue
+    printf '%s\n%s\n' "$PREFLIGHT_KV" "$AFTER_KV" >> "$s"
+    printf 'harness=run_sweeps.sh\nharness_pinned_cpus=%s\nharness_interleaved=0\n' \
+           "${BENCH_CPU:-none}" >> "$s"
+done
 
 echo
 echo "Done. CSVs in $DATA/. Plot with e.g.:"

--- a/docs/benchmarks/systems.md
+++ b/docs/benchmarks/systems.md
@@ -405,18 +405,30 @@ number someone believed: a Zen 4 run that deleted the i7's committed CSVs, an
 analyzer that called a 4.8% "win" between two byte-identical arms, a Jetson that
 asked for eight threads on a six-core part.
 
-**Not every harness satisfies it yet.** The requirement is stated first because
-it is the target; here is where each one actually stands, so nobody reads a
-`run_scaling` CSV as though it had been gated:
+Where each harness stands, so no CSV is read as more gated than it was:
 
-| Harness | Preflight | Pins | Interleaves | `OUTDIR` required |
-|---|---|---|---|---|
-| `run_blocking_ab.sh` / `.ps1` | yes | yes | yes | yes |
-| `run_scaling.sh` / `.ps1` | **no** | yes | no | **no** |
-| `run_sweeps.sh` / `.ps1` | **no** | yes | no | **no** |
+| Harness | Preflight | Pins | Per-machine `OUTDIR` | Sidecar state | Interleaves |
+|---|---|---|---|---|---|
+| `run_blocking_ab.sh` / `.ps1` | yes | yes | yes | yes | yes |
+| `run_scaling.sh` / `.ps1` | yes | yes | yes | yes | **no** |
+| `run_sweeps.sh` / `.ps1` | yes | yes | yes | yes | **no** |
+| `run_scaling_297.sh` / `.ps1` | **no** | yes | no | no | no |
 
-`run_scaling` and `run_sweeps` produced the published i7 and Ryzen numbers, and
-bringing them up to this contract is tracked in #442.
+**Why `run_scaling` and `run_sweeps` do not interleave.** Not an oversight, a
+dependency: `bench_all` truncates its `--csv` on every invocation, and
+`analyze_scaling.py` keeps the **last** row for a `(backend, op, size, T)` key
+rather than the best — so extra rounds would silently overwrite instead of
+accumulating, which is worse than not interleaving at all. It needs append
+support in `bench_all` and best-of-rounds in the analyzers first (#442).
+
+What they do instead is **build every variant before measuring any of them**.
+Previously each backend was built and then immediately measured, so every arm was
+timed on a machine still hot from compiling its own binary while the next arm
+compiled during the previous one's cooldown — a per-arm bias in a comparison
+whose entire purpose is comparing arms. That is the largest order effect
+available to remove without the round support above.
+
+`run_scaling_297.sh` is the remaining gap.
 
 | Rule | Why |
 |---|---|

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,22 @@ if(MTL5_PREFLIGHT_INTERP)
                      -P ${PROJECT_SOURCE_DIR}/tools/cmake/test_preflight.cmake)
 endif()
 
+# The PowerShell harnesses run on one machine each, by hand, ten minutes into a
+# session -- so a syntax error surfaces at the worst moment on the one machine
+# nobody else has. Parse them wherever a PowerShell is present, which on the
+# hosted runners includes Linux.
+find_program(MTL5_POWERSHELL NAMES pwsh powershell)
+if(MTL5_POWERSHELL)
+    file(GLOB MTL5_PS1_HARNESSES "${PROJECT_SOURCE_DIR}/benchmarks/*.ps1")
+    if(MTL5_PS1_HARNESSES)
+        add_test(NAME bench_powershell_parse
+                 COMMAND ${CMAKE_COMMAND}
+                         -DINTERP=${MTL5_POWERSHELL}
+                         "-DSCRIPTS=${MTL5_PS1_HARNESSES}"
+                         -P ${PROJECT_SOURCE_DIR}/tools/cmake/test_powershell_parse.cmake)
+    endif()
+endif()
+
 if(MTL5_BUILD_REGRESSION_TESTS)
     add_subdirectory(regression)
 endif()

--- a/tools/cmake/test_powershell_parse.cmake
+++ b/tools/cmake/test_powershell_parse.cmake
@@ -1,0 +1,30 @@
+# Syntax check for every PowerShell harness in benchmarks/ (#442).
+#
+# These scripts run on exactly one machine each, by hand, minutes into a session
+# that has already spent ten of them building. A syntax error therefore surfaces
+# at the worst possible moment and on the one machine nobody else has -- which is
+# not hypothetical: PowerShell defects reached main twice (#437/#438) because
+# nothing in CI ever loaded these files.
+#
+# Parsing is not running, and does not pretend to be: it catches syntax and
+# missing-brace errors, not logic. That is precisely the class that costs a whole
+# session, and it costs nothing to check.
+#
+# Expects: INTERP, SCRIPTS (a ;-list of .ps1 paths)
+
+foreach (script ${SCRIPTS})
+    if(NOT EXISTS "${script}")
+        message(FATAL_ERROR "no such PowerShell script: ${script}")
+    endif()
+    # ParseFile reports every error it finds, not just the first, so one run
+    # names the whole set.
+    execute_process(
+        COMMAND ${INTERP} -NoProfile -NonInteractive -Command
+                "$errors = $null; $null = [System.Management.Automation.Language.Parser]::ParseFile('${script}', [ref]$null, [ref]$errors); if ($errors) { $errors | ForEach-Object { Write-Output $_.ToString() }; exit 1 }; exit 0"
+        RESULT_VARIABLE _rc OUTPUT_VARIABLE _out ERROR_VARIABLE _err)
+    if(NOT _rc EQUAL 0)
+        message(FATAL_ERROR "${script} does not parse:\n${_out}${_err}")
+    endif()
+endforeach()
+
+message(STATUS "PowerShell harnesses parse cleanly")


### PR DESCRIPTION
## Summary

`run_scaling` and `run_sweeps` produced the **published i7 and Ryzen numbers** and had none of the guards `run_blocking_ab` collected the hard way. This brings both, in both shells, up to the run contract.

Completes the third acceptance item of #442.

## What changed

**Per-machine `OUTDIR`, required.** Both defaulted to the shared `benchmarks/data` *and* delete their CSVs before writing — the precise mechanism by which a Zen 4 run destroyed the i7's committed results (#439). No default now; the error lists the machine directories that already exist.

**Preflight, twice, on purpose.** Once *before* the builds, so a dirty tree or competing compile fails in seconds rather than after ten minutes of configuring; once *after* them, because the builds heat the machine and the temperature that matters is the one the measurements start at. The second record goes in every sidecar, with the postflight thermal read.

**Build everything before measuring anything.** Each variant used to be built and then immediately measured — so every arm was timed on a machine still hot from compiling its own binary, while the next arm compiled during the previous one's cooldown. A per-arm bias in a comparison whose entire purpose is comparing arms. Separating the phases removes it at no cost.

**MKL environment isolated.** `setvars.sh` is now sourced in a **subshell** for both configure and run. Sourced into the parent it leaves oneAPI's `LD_LIBRARY_PATH` ahead of every later run, so the openblas and blis binaries could resolve MKL's libraries while still being labelled as themselves — one arm measuring another. It was previously safe only because `mkl` happened to run last.

**Windows.** Both `.ps1` files gained the `Start-Process` quoting fix in `Invoke-Native` — `-ArgumentList` joins with spaces and quotes *nothing*, so a repo under `C:\Users\Some Name\...` reaches cmake as two broken arguments with a path that looks correct in the log (#438). `run_scaling.ps1` also validates the thread budget before the builds, instead of discovering "T=16 exceeds 8 cores" inside the measurement loop after the smaller counts were already written.

## A parse test for the PowerShell harnesses

These run on one machine each, by hand, ten minutes into a session — so a syntax error surfaces at the worst possible moment on the one machine nobody else has. That is how PowerShell defects reached `main` twice (#437/#438).

`bench_powershell_parse` runs `Parser::ParseFile` over every `benchmarks/*.ps1` wherever a PowerShell exists, which on the hosted runners includes Linux. Parsing is not running and does not pretend to be — it catches the class that costs a whole session, for free.

## Still not interleaved, and now the docs say why

Not an oversight, a dependency: `bench_all` truncates its `--csv` on every invocation, and `analyze_scaling.py` keeps the **last** row for a `(backend, op, size, T)` key rather than the best. Rounds would silently overwrite instead of accumulating — worse than not interleaving at all. It needs append support in `bench_all` and best-of-rounds in the analyzers first (#442).

## Test Results

Verified end to end with **stubbed builds** — a fake `cmake` and `bench_all` on `PATH`, so the orchestration is exercised without ten minutes of compiling:

| Check | Result |
|---|---|
| All variants built before any measurement | `building all variants` at line 3, `measuring` at line 6, first timing at line 8 |
| Every sidecar carries the state block | 4/4 for `run_scaling` (incl. the subshelled mkl), 10/10 for `run_sweeps` |
| Dirty-tree gate stops the session | rc=1, **0** builds started, **0** files written |
| Oversized thread count rejected up front | `T=8 exceeds the 2 physical core(s)` before any build |
| `OUTDIR` missing | rc=2 with the existing machine directories listed |
| PowerShell parse driver | passes on clean input, reports the file and the parser's message on bad input, and errors on a missing file |

| Suite | Result |
|---|---|
| GCC | 167/167 |
| Clang | 167/167 |

## Test plan

- [ ] Tier 1 CI on 8 platforms
- [ ] `bench_powershell_parse` executes on Windows (and on Linux if `pwsh` is present there)
- [ ] Promote when green

Relates to #442

Generated with [Claude Code](https://claude.com/claude-code)
