### PR TITLE
fix(bench): stop preflight failing on the harness's own output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,13 @@ examples/phase15_sparse_direct/data/
 benchmarks/data/klu/
 benchmarks/data/superlu/
 
+# Configure/build logs the PowerShell harnesses write beside their CSVs. These
+# are run artifacts, not results -- and while they were tracked, a harness that
+# builds before it measures made the tree dirty WITH ITS OWN OUTPUT, so preflight
+# then refused to measure. A gate that a normal run trips by existing is not a
+# gate, it is a wall.
+benchmarks/data/**/logs/
+
 # IDE
 .idea/
 .vscode/

--- a/benchmarks/preflight.ps1
+++ b/benchmarks/preflight.ps1
@@ -47,7 +47,23 @@ param(
     [ValidateSet('before', 'after')][string]$Phase = 'before',
     [int]$Threads = 0,
     [string]$Repo = '',
-    [switch]$ReportOnly
+    [switch]$ReportOnly,
+    # Permit a dirty working tree (still recorded as tree_git_dirty=1).
+    #
+    # A SWITCH, not just the ALLOW_DIRTY environment variable, because the
+    # obvious way to set that variable does not work here: `set ALLOW_DIRTY=1` is
+    # cmd.exe syntax, and in PowerShell `set` is an alias for Set-Variable, so it
+    # creates a shell variable (or errors) and the run fails again with the same
+    # message. The environment form is $env:ALLOW_DIRTY = "1"; this switch means
+    # nobody has to know that.
+    [switch]$AllowDirty,
+
+    # Exclude a directory from the dirty check -- a harness passes its own
+    # OutDir. A previous run's CSVs, and the cmake logs these harnesses write
+    # beside them, say NOTHING about whether the source that built the binary is
+    # reproducible; counting them would stamp tree_git_dirty=1 on a sidecar whose
+    # code was pristine, and a field that lies is worse than one that is missing.
+    [string]$IgnorePath = ''
 )
 
 $ErrorActionPreference = 'Continue'
@@ -101,22 +117,50 @@ Emit 'preflight_kernel'  ([System.Environment]::OSVersion.VersionString -replace
 # The BINARY records the commit it was built from (mtl/build_info.hpp); this
 # records the commit the tree is on NOW. If they disagree the binary is stale
 # relative to the checkout.
+$ignoreRel = ''
+if ($IgnorePath -and (Test-Path $IgnorePath)) {
+    $ig = (Resolve-Path $IgnorePath).Path
+    $rp = (Resolve-Path $Repo).Path
+    if ($ig.StartsWith($rp, [System.StringComparison]::OrdinalIgnoreCase)) {
+        $ignoreRel = ($ig.Substring($rp.Length).TrimStart('\', '/')) -replace '\\', '/'
+    }
+}
+
 $treeCommit = 'unknown'
 $treeDirty = 'unknown'
 if (Get-Command git -ErrorAction SilentlyContinue) {
     $sha = & git -C $Repo rev-parse --short=12 HEAD 2>$null
     if ($LASTEXITCODE -eq 0 -and $sha) {
         $treeCommit = $sha.Trim()
-        $status = & git -C $Repo status --porcelain --untracked-files=normal 2>$null
+        # --untracked-files=ALL, not `normal`: git collapses a wholly untracked
+        # directory into one entry ("?? benchmarks/"), which no prefix filter for
+        # benchmarks/data/<machine>/ can ever match.
+        $status = & git -C $Repo status --porcelain --untracked-files=all 2>$null
         if ($LASTEXITCODE -eq 0) {
-            if ([string]::IsNullOrWhiteSpace($status -join '')) {
+            $entries = @($status | Where-Object { $_ -and $_.Length -gt 3 })
+            if ($ignoreRel) {
+                Emit 'tree_dirty_excluded' $ignoreRel
+                $entries = @($entries | Where-Object { $_.Substring(3) -notlike "$ignoreRel/*" })
+            }
+            if ($entries.Count -eq 0) {
                 $treeDirty = '0'
             } else {
                 $treeDirty = '1'
-                if ($env:ALLOW_DIRTY -eq '1') {
-                    Warn "working tree is dirty; ALLOW_DIRTY=1, recording tree_git_dirty=1"
+                if ($AllowDirty -or $env:ALLOW_DIRTY -eq '1') {
+                    Warn "working tree is dirty; recording tree_git_dirty=1"
                 } else {
-                    GateFailed "working tree is dirty -- this result could not be reproduced. Commit, stash, or set ALLOW_DIRTY=1 to record it as dirty."
+                    # Show what is dirty. Without this the operator has to guess,
+                    # and the usual answer is that a harness or an editor dropped
+                    # a file nobody meant to keep.
+                    $names = ($entries | Select-Object -First 5) -join '; '
+                    # Single-quoted so $env: and the backtick-free cmd example
+                    # survive verbatim -- a hint that gets mangled by the shell
+                    # it is teaching is worse than no hint.
+                    $hint = 'Commit, stash or clean them, or pass -AllowDirty. ' +
+                            'The environment form is $env:ALLOW_DIRTY = "1"; ' +
+                            'set ALLOW_DIRTY=1 is cmd.exe syntax and does nothing in PowerShell.'
+                    GateFailed ("working tree is dirty -- this result could not be reproduced.`n" +
+                                $hint + "`n  " + $names)
                 }
             }
         }

--- a/benchmarks/preflight.ps1
+++ b/benchmarks/preflight.ps1
@@ -117,13 +117,30 @@ Emit 'preflight_kernel'  ([System.Environment]::OSVersion.VersionString -replace
 # The BINARY records the commit it was built from (mtl/build_info.hpp); this
 # records the commit the tree is on NOW. If they disagree the binary is stale
 # relative to the checkout.
+# CONTAINED to benchmarks/data/<something>. The exclusion is for GENERATED
+# output, and an unrestricted one is a hole straight through the gate: pass
+# -IgnorePath benchmarks and an edit to this very script stops counting, so
+# preflight reports a clean tree and the sidecar records tree_git_dirty=0 for a
+# build whose source had been modified. A recorded fact has to be true, so the
+# exclusion may only cover a directory that cannot hold source.
+#
+# In-repo paths outside that root are REFUSED, not silently narrowed: a run whose
+# OutDir sits somewhere unexpected should be blocked by the ordinary dirty gate
+# rather than quietly measured with a weaker one.
 $ignoreRel = ''
 if ($IgnorePath -and (Test-Path $IgnorePath)) {
-    $ig = (Resolve-Path $IgnorePath).Path
-    $rp = (Resolve-Path $Repo).Path
+    $ig = (Resolve-Path $IgnorePath).Path.TrimEnd('\', '/')
+    $rp = (Resolve-Path $Repo).Path.TrimEnd('\', '/')
     if ($ig.StartsWith($rp, [System.StringComparison]::OrdinalIgnoreCase)) {
-        $ignoreRel = ($ig.Substring($rp.Length).TrimStart('\', '/')) -replace '\\', '/'
+        $rel = ($ig.Substring($rp.Length).TrimStart('\', '/')) -replace '\\', '/'
+        if ($rel -match '^benchmarks/data/.+') {
+            $ignoreRel = $rel
+        } else {
+            Warn ("-IgnorePath '$IgnorePath' is inside the repository but not under " +
+                  "benchmarks/data/<machine>; it will NOT be excluded from the dirty check.")
+        }
     }
+    # Outside the repository entirely: git never reports it, nothing to exclude.
 }
 
 $treeCommit = 'unknown'

--- a/benchmarks/preflight.sh
+++ b/benchmarks/preflight.sh
@@ -188,13 +188,28 @@ emit preflight_kernel "$(uname -sr)"
 # code was pristine, and a field that lies is worse than one that is missing.
 # It is also what made the gate unusable in practice: the harness tripped over
 # its own output and the documented escape hatch was cmd.exe syntax.
+#
+# CONTAINED to benchmarks/data/<something>. The exclusion is for GENERATED
+# output, and an unrestricted one is a hole straight through the gate: pass
+# --ignore-path benchmarks and an edit to this very script stops counting, so
+# preflight reports a clean tree and the sidecar records tree_git_dirty=0 for a
+# build whose source had been modified. The whole point is that a recorded fact
+# is true, so the exclusion may only cover a directory that cannot hold source.
+#
+# Out-of-root paths are REFUSED, not silently narrowed: a run whose OUTDIR sits
+# somewhere unexpected should be blocked by the ordinary dirty gate rather than
+# quietly measured with a weaker one.
 IGNORE_REL=""
 if [ -n "${IGNORE_PATH:-}" ] && [ -d "$IGNORE_PATH" ]; then
     _ig_abs=$(cd "$IGNORE_PATH" && pwd)
     _repo_abs=$(cd "$REPO" && pwd)
     case "$_ig_abs/" in
-        "$_repo_abs"/*) IGNORE_REL=${_ig_abs#"$_repo_abs"/} ;;
-        *) ;;   # outside the repo: git never reports it anyway
+        "$_repo_abs"/benchmarks/data/?*/)
+            IGNORE_REL=${_ig_abs#"$_repo_abs"/} ;;
+        "$_repo_abs"/*)
+            warn "--ignore-path '$IGNORE_PATH' is inside the repository but not under" \
+                 "benchmarks/data/<machine>; it will NOT be excluded from the dirty check." ;;
+        *) ;;   # outside the repo entirely: git never reports it anyway
     esac
 fi
 

--- a/benchmarks/preflight.sh
+++ b/benchmarks/preflight.sh
@@ -19,7 +19,8 @@
 #      pinned" only because someone thought to ask.
 #
 # Usage:
-#   preflight.sh [--phase before|after] [--threads N] [--repo DIR] [--report-only]
+#   preflight.sh [--phase before|after] [--threads N] [--repo DIR]
+#                [--report-only] [--allow-dirty] [--ignore-path DIR]
 #
 #   --phase before   (default) run every gate, emit the full record
 #   --phase after    emit thermal_after_c only -- call once the run finishes, so
@@ -29,6 +30,10 @@
 #   --repo DIR       repository to check (default: the parent of this script)
 #   --report-only    probe and emit, never fail. For CI and for inspecting a
 #                    machine; NOT for taking measurements.
+#   --allow-dirty    same as ALLOW_DIRTY=1.
+#   --ignore-path DIR  exclude DIR from the dirty check -- a harness passes its
+#                    own OUTDIR, since a previous run's CSVs say nothing about
+#                    whether the source is reproducible.
 #
 # Environment:
 #   ALLOW_DIRTY=1              permit a dirty working tree (still recorded)
@@ -66,6 +71,8 @@ while [ $# -gt 0 ]; do
         --threads)     need_value "$1" $#; THREADS_REQ=$2; shift 2 ;;
         --repo)        need_value "$1" $#; REPO=$2; shift 2 ;;
         --report-only) REPORT_ONLY=1; shift ;;
+        --allow-dirty) ALLOW_DIRTY=1; shift ;;
+        --ignore-path) need_value "$1" $#; IGNORE_PATH=$2; shift 2 ;;
         -h|--help)     sed -n '2,45p' "$0"; exit 0 ;;
         *) echo "preflight: unknown argument '$1'" >&2; exit 2 ;;
     esac
@@ -173,19 +180,59 @@ emit preflight_kernel "$(uname -sr)"
 # records the commit the tree is on NOW. They are different facts: if they
 # disagree, the binary is stale relative to the checkout, and the run measures
 # code that is no longer what the tree says it is.
+#
+# --ignore-path excludes a directory from the dirtiness question -- the harness
+# passes its own OUTDIR. A previous run's CSVs, or the cmake logs a harness
+# writes beside them, say NOTHING about whether the source that built the binary
+# is reproducible. Counting them would stamp tree_git_dirty=1 on a sidecar whose
+# code was pristine, and a field that lies is worse than one that is missing.
+# It is also what made the gate unusable in practice: the harness tripped over
+# its own output and the documented escape hatch was cmd.exe syntax.
+IGNORE_REL=""
+if [ -n "${IGNORE_PATH:-}" ] && [ -d "$IGNORE_PATH" ]; then
+    _ig_abs=$(cd "$IGNORE_PATH" && pwd)
+    _repo_abs=$(cd "$REPO" && pwd)
+    case "$_ig_abs/" in
+        "$_repo_abs"/*) IGNORE_REL=${_ig_abs#"$_repo_abs"/} ;;
+        *) ;;   # outside the repo: git never reports it anyway
+    esac
+fi
+
+# Porcelain lines are "XY <path>", repo-relative.
+#
+# --untracked-files=ALL, not `normal`: git collapses a wholly untracked directory
+# into one entry ("?? benchmarks/"), and a prefix filter for
+# benchmarks/data/<machine>/ can never match that. The first version of this
+# filter silently did nothing for exactly that reason.
+dirty_entries() {
+    local out
+    out=$(git -C "$REPO" status --porcelain --untracked-files=all) || return 1
+    [ -z "$out" ] && return 0
+    if [ -n "$IGNORE_REL" ]; then
+        printf '%s\n' "$out" | awk -v p="$IGNORE_REL/" 'substr($0, 4, length(p)) != p'
+    else
+        printf '%s\n' "$out"
+    fi
+}
+
 TREE_COMMIT=unknown
 TREE_DIRTY=unknown
 if command -v git >/dev/null 2>&1 && git -C "$REPO" rev-parse HEAD >/dev/null 2>&1; then
     TREE_COMMIT=$(git -C "$REPO" rev-parse --short=12 HEAD)
-    if [ -z "$(git -C "$REPO" status --porcelain --untracked-files=normal)" ]; then
+    [ -n "$IGNORE_REL" ] && emit tree_dirty_excluded "$IGNORE_REL"
+    DIRTY_ENTRIES=$(dirty_entries)
+    if [ -z "${DIRTY_ENTRIES//[[:space:]]/}" ]; then
         TREE_DIRTY=0
     else
         TREE_DIRTY=1
         if [ "${ALLOW_DIRTY:-0}" = 1 ]; then
-            warn "working tree is dirty; ALLOW_DIRTY=1, recording tree_git_dirty=1"
+            warn "working tree is dirty; recording tree_git_dirty=1"
         else
+            # Name what is dirty. Without it the operator has to go looking, and
+            # the answer is usually a file a harness or an editor dropped.
             gate_failed "working tree is dirty -- this result could not be reproduced." \
-                        "Commit, stash, or set ALLOW_DIRTY=1 to record it as dirty."
+                        "Commit, stash or clean these, or pass --allow-dirty (ALLOW_DIRTY=1):"
+            printf '%s\n' "$DIRTY_ENTRIES" | head -5 | sed 's/^/  /' >&2
         fi
     fi
 fi

--- a/benchmarks/run_blocking_ab.ps1
+++ b/benchmarks/run_blocking_ab.ps1
@@ -67,7 +67,14 @@ param(
     [string]$OutDir  = "",          # REQUIRED -- one directory per machine
 
     [string]$BuildDir = "build-blocking-ab",
-    [int]$Jobs       = [Environment]::ProcessorCount
+    [int]$Jobs       = [Environment]::ProcessorCount,
+
+    # Permit a dirty working tree (still recorded as tree_git_dirty=1). A switch,
+    # not only the ALLOW_DIRTY environment variable, because the obvious way to
+    # set that variable does not work here: `set ALLOW_DIRTY=1` is cmd.exe syntax,
+    # and in PowerShell `set` aliases Set-Variable, so the run fails again with
+    # the same message and no clue why.
+    [switch]$AllowDirty
 )
 
 [int[]]$PCoreList  = $PCores  -split ',' | ForEach-Object { [int]$_ }
@@ -138,6 +145,25 @@ function Invoke-Native {
     return $p.ExitCode
 }
 
+# --- preflight, before the build ---------------------------------------------
+# Gate FIRST, not after the build: a dirty tree or a competing compile should
+# cost seconds, not a full configure-and-build. It is also the only order that
+# works -- this harness builds into the repo and writes its cmake logs beside the
+# CSVs, so gating afterwards meant the run tripped over ITS OWN output and failed
+# dirty every time (the logs are now gitignored as well).
+$TMax = ($ThreadList | Measure-Object -Maximum).Maximum
+$PreflightScript = Join-Path $PSScriptRoot "preflight.ps1"
+function Invoke-Preflight {
+    $kv = & $PreflightScript -Threads $TMax -Repo $RepoRoot -AllowDirty:$AllowDirty -IgnorePath $DataDir
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "preflight failed -- not measuring. Fix the above, or pass -AllowDirty"
+        Write-Host "if you accept a dirty tree (it is then recorded as such in the sidecar)."
+        exit 1
+    }
+    return $kv
+}
+Invoke-Preflight | Out-Null
+
 # --- build both arms from one tree ------------------------------------------
 $Full = Join-Path $RepoRoot $BuildDir
 $cfg  = @("-B", $Full,
@@ -196,19 +222,11 @@ function Run-Arm {
     if ($p.ExitCode -ne 0) { throw "$Label arm failed (T=$T, exit $($p.ExitCode))" }
 }
 
-# --- preflight: gate the session before anything is measured (#442) ----------
-# A dirty tree, a competing build or a machine already hot invalidates the run,
-# and discovering it afterwards means the CSVs are already written. The key=value
-# output is appended to both sidecars below, so machine state travels with the
-# data rather than living in the operator's memory of the session.
-$TMax = ($ThreadList | Measure-Object -Maximum).Maximum
-$PreflightScript = Join-Path $PSScriptRoot "preflight.ps1"
-$PreflightKv = & $PreflightScript -Threads $TMax -Repo (Split-Path -Parent $PSScriptRoot)
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "preflight failed -- not measuring. Fix the above, or set ALLOW_DIRTY=1"
-    Write-Host "if you accept a dirty tree (it is then recorded as such in the sidecar)."
-    exit 1
-}
+# --- preflight, again, now the build is done ---------------------------------
+# The builds heat the machine, so the temperature that belongs in the sidecar is
+# the one the MEASUREMENTS start at, not the one the session started at. This
+# record is what travels with the data.
+$PreflightKv = Invoke-Preflight
 
 # --- shapes: derived ONCE, from the detected arm, at the largest thread count -
 if ($Shapes -eq "") {

--- a/benchmarks/run_blocking_ab.sh
+++ b/benchmarks/run_blocking_ab.sh
@@ -103,7 +103,8 @@ done
 # appended to both sidecars below, so the machine state travels with the data
 # instead of living in the operator's memory of the session.
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-if ! PREFLIGHT_KV=$("$SCRIPT_DIR/preflight.sh" --threads "$TMAX" --repo "$SCRIPT_DIR/.."); then
+if ! PREFLIGHT_KV=$("$SCRIPT_DIR/preflight.sh" --threads "$TMAX" --repo "$SCRIPT_DIR/.." \
+                        --ignore-path "$OUTDIR"); then
     echo "preflight failed -- not measuring. Fix the above, or set ALLOW_DIRTY=1 if" >&2
     echo "you accept a dirty tree (it is then recorded as such in the sidecar)." >&2
     exit 1

--- a/benchmarks/run_scaling.ps1
+++ b/benchmarks/run_scaling.ps1
@@ -46,7 +46,13 @@ param(
     # machine, so a shared default silently overwrites another machine's
     # committed results -- which is exactly what happened once (#439).
     [Parameter(Mandatory = $true)][string]$OutDir,
-    [int]$Jobs = [Environment]::ProcessorCount
+    [int]$Jobs = [Environment]::ProcessorCount,
+
+    # Permit a dirty working tree (still recorded as tree_git_dirty=1). A switch,
+    # not only the ALLOW_DIRTY environment variable, because `set ALLOW_DIRTY=1`
+    # is cmd.exe syntax -- in PowerShell `set` aliases Set-Variable, so the run
+    # fails again with the same message and no clue why.
+    [switch]$AllowDirty
 )
 
 if ($Variants.Count -eq 1 -and $Variants[0] -match ',') { $Variants = $Variants[0] -split ',' }
@@ -160,9 +166,9 @@ foreach ($T in $ThreadList) {
 $TMax = ($ThreadList | Measure-Object -Maximum).Maximum
 $PreflightScript = Join-Path $PSScriptRoot "preflight.ps1"
 function Invoke-Preflight {
-    $kv = & $PreflightScript -Threads $TMax -Repo $RepoRoot
+    $kv = & $PreflightScript -Threads $TMax -Repo $RepoRoot -AllowDirty:$AllowDirty -IgnorePath $DataDir
     if ($LASTEXITCODE -ne 0) {
-        Write-Host "preflight failed -- not measuring. Fix the above, or set ALLOW_DIRTY=1"
+        Write-Host "preflight failed -- not measuring. Fix the above, or pass -AllowDirty"
         Write-Host "if you accept a dirty tree (it is then recorded as such)."
         exit 1
     }

--- a/benchmarks/run_scaling.sh
+++ b/benchmarks/run_scaling.sh
@@ -82,7 +82,8 @@ done
 # that goes in the sidecars.
 preflight_gate() {
     local kv
-    if ! kv=$("$SCRIPT_DIR/preflight.sh" --threads "$TMAX" --repo "$ROOT"); then
+    if ! kv=$("$SCRIPT_DIR/preflight.sh" --threads "$TMAX" --repo "$ROOT" \
+                  --ignore-path "$DATA"); then
         echo "preflight failed -- not measuring. Fix the above, or set ALLOW_DIRTY=1" >&2
         echo "if you accept a dirty tree (it is then recorded as such)." >&2
         exit 1

--- a/benchmarks/run_sweeps.ps1
+++ b/benchmarks/run_sweeps.ps1
@@ -61,7 +61,13 @@ param(
     # machine, so a shared default silently overwrites another machine's
     # committed results -- which is exactly what happened once (#439).
     [Parameter(Mandatory = $true)][string]$OutDir,
-    [int]$Jobs = [Environment]::ProcessorCount
+    [int]$Jobs = [Environment]::ProcessorCount,
+
+    # Permit a dirty working tree (still recorded as tree_git_dirty=1). A switch,
+    # not only the ALLOW_DIRTY environment variable, because `set ALLOW_DIRTY=1`
+    # is cmd.exe syntax -- in PowerShell `set` aliases Set-Variable, so the run
+    # fails again with the same message and no clue why.
+    [switch]$AllowDirty
 )
 
 # `powershell -File script.ps1 -Variants a,b,c` can arrive as a single-element
@@ -179,9 +185,9 @@ function Run-Variant {
 # the MEASUREMENTS start at. The second record goes in the sidecars.
 $PreflightScript = Join-Path $PSScriptRoot "preflight.ps1"
 function Invoke-Preflight {
-    $kv = & $PreflightScript -Threads 1 -Repo $RepoRoot
+    $kv = & $PreflightScript -Threads 1 -Repo $RepoRoot -AllowDirty:$AllowDirty -IgnorePath $DataDir
     if ($LASTEXITCODE -ne 0) {
-        Write-Host "preflight failed -- not measuring. Fix the above, or set ALLOW_DIRTY=1"
+        Write-Host "preflight failed -- not measuring. Fix the above, or pass -AllowDirty"
         Write-Host "if you accept a dirty tree (it is then recorded as such)."
         exit 1
     }

--- a/benchmarks/run_sweeps.sh
+++ b/benchmarks/run_sweeps.sh
@@ -76,7 +76,8 @@ fi
 # below), so the thread budget asked of preflight is 1.
 preflight_gate() {
     local kv
-    if ! kv=$("$SCRIPT_DIR/preflight.sh" --threads 1 --repo "$ROOT"); then
+    if ! kv=$("$SCRIPT_DIR/preflight.sh" --threads 1 --repo "$ROOT" \
+                  --ignore-path "$DATA"); then
         echo "preflight failed -- not measuring. Fix the above, or set ALLOW_DIRTY=1" >&2
         echo "if you accept a dirty tree (it is then recorded as such)." >&2
         exit 1

--- a/docs/benchmarks/systems.md
+++ b/docs/benchmarks/systems.md
@@ -469,11 +469,21 @@ meaningless. A warning scrolls past and the CSV gets committed anyway.
 
 | Condition | Action | Override |
 |---|---|---|
-| Working tree dirty | fail | `ALLOW_DIRTY=1`, and it is recorded as `tree_git_dirty=1` |
+| Working tree dirty | fail | `--allow-dirty` / `-AllowDirty` (or `ALLOW_DIRTY=1`), and it is recorded as `tree_git_dirty=1` |
 | A build or benchmark already running | fail | none — fix the machine |
 | Threads requested exceed available cpus | fail | none |
 | Thermal headroom below the margin | fail **only where a sensor and a limit are both readable** | `MIN_THERMAL_HEADROOM_C` (default 15) |
 | Governor not `performance` | warn, and record the value | — |
+
+**What "dirty" excludes.** The harness's own `OUTDIR` — the CSVs from a previous
+run, and the cmake logs the PowerShell drivers write beside them (now gitignored
+as well). None of that says anything about whether the source that built the
+binary is reproducible, and counting it stamped `tree_git_dirty=1` on sidecars
+whose code was pristine. It also made the gate unusable: the Windows driver
+builds before it measures, so the run tripped over its own logs, and the escape
+hatch the message suggested (`set ALLOW_DIRTY=1`) is cmd.exe syntax that does
+nothing in PowerShell. A gate a normal run trips by existing is not a gate. Use
+`-AllowDirty` there, or `$env:ALLOW_DIRTY = "1"`.
 
 The thermal rule is asymmetric on purpose. Windows desktop firmware usually does
 not implement `MSAcpi_ThermalZoneTemperature`, and failing there would make the

--- a/tools/cmake/test_preflight.cmake
+++ b/tools/cmake/test_preflight.cmake
@@ -65,6 +65,30 @@ foreach(key ${REQUIRED_KEYS})
     endif()
 endforeach()
 
+# The dirty-check exclusion must stay contained to generated output. An
+# unrestricted --ignore-path is a hole straight through the gate: point it at a
+# source directory and edits there stop counting, so preflight reports a clean
+# tree and the sidecar records tree_git_dirty=0 for a build whose source had
+# changed. Asking for `benchmarks` (source) must NOT produce an exclusion.
+if(INTERP MATCHES "pwsh|powershell")
+    set(_bad_ignore ${INTERP} -NoProfile -NonInteractive -File ${SCRIPT}
+                    -ReportOnly -Threads 1 -Repo ${REPO} -IgnorePath ${REPO}/benchmarks)
+else()
+    set(_bad_ignore ${INTERP} ${SCRIPT} --report-only --threads 1 --repo ${REPO}
+                    --ignore-path ${REPO}/benchmarks)
+endif()
+execute_process(COMMAND ${_bad_ignore}
+                RESULT_VARIABLE _rc3 OUTPUT_VARIABLE _out3 ERROR_VARIABLE _err3)
+if(NOT _rc3 EQUAL 0)
+    message(FATAL_ERROR "--report-only must never fail, got ${_rc3}:\n${_err3}")
+endif()
+if(_out3 MATCHES "tree_dirty_excluded=")
+    message(FATAL_ERROR
+        "preflight excluded a SOURCE directory from the dirty check.\n"
+        "Only benchmarks/data/<machine> may be excluded; anything else lets a "
+        "modified source tree be recorded as clean.\n--- stdout ---\n${_out3}")
+endif()
+
 # The after phase is what makes a throttled session visible, and it is the phase
 # nobody runs by hand.
 execute_process(COMMAND ${_after}


### PR DESCRIPTION
## The bug

Reported from a real Zen 4 session. The PowerShell driver **builds before it measures**, writes its cmake logs into `benchmarks\data\<machine>\logs`, and preflight then failed the run as a **dirty tree** — tripped by output the harness had just produced itself. The suggested escape hatch (`set ALLOW_DIRTY=1`) doesn't work in PowerShell either, so the run could not be started at all.

A gate a normal run trips by existing is not a gate, it's a wall.

## Four fixes

**1. The logs are run artifacts, not results.** `benchmarks/data/**/logs/` is gitignored, so a harness cannot make the tree dirty with its own diagnostics.

**2. Dirtiness excludes the output directory.** `preflight` gained `--ignore-path` / `-IgnorePath`, and every harness passes its own `OUTDIR`. A previous run's CSVs say *nothing* about whether the source that built the binary is reproducible — counting them stamped `tree_git_dirty=1` on a sidecar whose code was pristine. That's the exact failure this feature exists to prevent, and it would have hit anyone running twice before committing.

This needed `--untracked-files=ALL`: git collapses a wholly untracked directory into one entry (`?? benchmarks/`), which no prefix filter for `benchmarks/data/<machine>/` can match. The first version of the filter **silently did nothing** for that reason — the test below is what caught it.

**3. `set ALLOW_DIRTY=1` is cmd.exe syntax.** In PowerShell `set` aliases `Set-Variable`, so it creates a shell variable and the run fails again with the same message and no clue why. Every PowerShell harness now takes `-AllowDirty`, and the hint names `$env:ALLOW_DIRTY = "1"` and says plainly that the cmd form does nothing. Both shells now also **list what is dirty** — without it you have to go looking, and the answer is usually a file a harness or an editor dropped.

**4. `run_blocking_ab.ps1` gates before the build.** It was the only harness gating afterwards, which is both slower to fail and the reason it saw its own logs. It now gates first (seconds, not a full configure-and-build) and again after, since the builds heat the machine and the temperature that belongs in the sidecar is the one the measurements start at.

## Test Results

Verified against an isolated repo, in all three directions that matter:

| Scenario | Expected | Result |
|---|---|---|
| Previous run's CSVs present, source clean | pass, `tree_git_dirty=0` | rc=0, `tree_dirty_excluded=benchmarks/data/m1` |
| A real source edit | fail | rc=1, lists ` M src.c` |
| Untracked file outside `OUTDIR` | fail | rc=1, lists `?? stray.txt` |

The `-uall` fix is why row 1 passes: without it the filter matched nothing and row 1 reported dirty.

| Suite | Result |
|---|---|
| GCC | 167/167 |
| Clang | 167/167 |

`bench_powershell_parse` covers the four `.ps1` files on every CI platform that has a PowerShell.

## Test plan

- [ ] Tier 1 CI on 8 platforms
- [ ] Zen 4 re-run gets past preflight without `-AllowDirty`

Relates to #442

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added options to allow benchmark runs with uncommitted changes and exclude generated output paths from checks.
  - Added configurable parallel job counts for sweep runs.
  - Improved preflight validation with clearer reporting and remediation guidance.

- **Documentation**
  - Updated benchmark guidance for dirty-tree overrides, ignored output directories, and PowerShell environment-variable syntax.

- **Chores**
  - Excluded generated benchmark logs from version-control tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->