### PR TITLE
feat(bench): record the mc the nest actually steps by, not the configured bound

### DIFF
--- a/benchmarks/analyze_blocking_ab.py
+++ b/benchmarks/analyze_blocking_ab.py
@@ -51,6 +51,25 @@ def main(argv):
         print(f"blocking ({dt}):  detected mr,nr,kc,mc,nc = {det_p.get(dt)}"
               f"   default = {dfl_p.get(dt)}")
 
+    # The CONFIGURED mc above is not the one the loops step by: it is capped to
+    # fill the thread budget (plan_gemm_grid) and then rounded so the partition
+    # divides evenly (balanced_mc). Reading the configured value as the value
+    # under test is wrong for BOTH arms -- a default arm configured mc=32 runs at
+    # 30 serially and 29 on six threads -- and it varies with the SHAPE, so it
+    # belongs per point rather than in a summary line. Collected here, printed in
+    # the table below.
+    def plan_of(rows):
+        out = {}
+        for key, rs in rows.items():
+            for r in rs:
+                if r.get("mc_used"):
+                    out[key] = (r["mc_used"], f'{r.get("ic_nt","?")}x{r.get("jc_nt","?")}')
+        return out
+    det_plan, dfl_plan = plan_of(det), plan_of(dfl)
+    if not det_plan and not dfl_plan:
+        print("\nNOTE: this CSV predates the mc_used column, so the mc above is the"
+              "\n      CONFIGURED bound and not the step any loop used (#430).")
+
     # A request larger than the machine is silently clamped: thread_pool caps
     # MTL5_NUM_THREADS at hardware_concurrency. Every grid calculation depends on
     # the CLAMPED value, so say so loudly rather than leaving it to be inferred
@@ -95,7 +114,8 @@ def main(argv):
         print("Re-run both arms over the same shapes and rounds.", file=sys.stderr)
         return 2
 
-    hdr = f"{'shape':>22} {'T':>3} {'default':>10} {'detected':>10} {'ratio':>7}  verdict"
+    hdr = (f"{'shape':>22} {'T':>3} {'default':>10} {'detected':>10} {'ratio':>7}"
+           f" {'mc def/det':>11} {'grid':>6}  verdict")
     print(hdr)
     print("-" * len(hdr))
 
@@ -140,9 +160,15 @@ def main(argv):
             verdict = "noise (ranges overlap)"
             noise += 1
 
+        # mc as RUN, per arm, and the grid (identical for both arms by
+        # construction -- it depends on m, n and the budget, not on the blocking).
+        pa, pb = dfl_plan.get(key), det_plan.get(key)
+        mc_col = f"{pa[0] if pa else '?'}/{pb[0] if pb else '?'}"
+        grid_col = (pb or pa or ("", "?"))[1]
         print(f"{m}x{n}x{k:>6}".rjust(22)
               + f" {t:>3} {gflops(m, n, k, b_best):>10.2f}"
-              + f" {gflops(m, n, k, a_best):>10.2f} {ratio:>7.3f}  {verdict}")
+              + f" {gflops(m, n, k, a_best):>10.2f} {ratio:>7.3f}"
+              + f" {mc_col:>11} {grid_col:>6}  {verdict}")
 
     print()
     print(f"{wins} faster, {losses} slower, {noise} indistinguishable "

--- a/benchmarks/bench_blocking_ab.cpp
+++ b/benchmarks/bench_blocking_ab.cpp
@@ -225,7 +225,17 @@ int main(int argc, char** argv) {
                                                    : run_one<double>(sh, nt, reps, chk);
             const auto& bp = (dtype == "float") ? bpf : bpd;
             const double gf = 2.0 * double(sh.m) * double(sh.n) * double(sh.k) / secs / 1e9;
-            char buf[512];
+            // What the nest ACTUALLY did, not what was configured. mc travels
+            // through three stages before any loop steps by it -- the L2 bound
+            // here in bp.mc, the budget cap in plan_gemm_grid, and the round-off
+            // in balanced_mc -- and the first is the only one the earlier CSVs
+            // recorded. The i7 rows in benchmarks/data say mc=213 for runs that
+            // stepped 210 serially and 128 on eight threads, so the parameter
+            // under test could not be recovered from the data it produced (#430).
+            const auto plan = (dtype == "float")
+                ? mtl::detail::gemm_plan_for<float>(sh.m, sh.n, nt)
+                : mtl::detail::gemm_plan_for<double>(sh.m, sh.n, nt);
+            char buf[640];
             // `threads` is what was ASKED for; `pool` is what the process can
             // actually use. thread_pool clamps MTL5_NUM_THREADS to
             // hardware_concurrency, so on a machine with fewer cores than the
@@ -234,14 +244,20 @@ int main(int argc, char** argv) {
             // Jetson run, where 8 was asked for on a 6-core part and the shortfall
             // was visible only as a suspiciously low speedup.
             std::snprintf(buf, sizeof buf,
-                "%s,%s,%zu,%zu,%zu,%u,%u,%zu,%zu,%zu,%zu,%zu,%d,%.6f,%.3f,%.6f",
+                "%s,%s,%zu,%zu,%zu,%u,%u,%zu,%zu,%zu,%zu,%zu,"
+                "%zu,%zu,%zu,%u,%u,%d,%.6f,%.3f,%.6f",
                 label.c_str(), dtype.c_str(), sh.m, sh.n, sh.k, nt,
                 mtl::detail::thread_pool::instance().size(),
-                bp.mr, bp.nr, bp.kc, bp.mc, bp.nc, reps, secs, gf, chk);
+                bp.mr, bp.nr, bp.kc, bp.mc, bp.nc,
+                plan.mc, plan.nib, plan.njb, plan.ic_nt, plan.jc_nt,
+                reps, secs, gf, chk);
             rows.emplace_back(buf);
-            std::fprintf(stderr, "  m=%zu n=%zu k=%zu T=%u (pool %u)  %.4f s  %.2f GFLOP/s\n",
+            std::fprintf(stderr,
+                         "  m=%zu n=%zu k=%zu T=%u (pool %u)  mc %zu->%zu  grid %ux%u"
+                         "  %.4f s  %.2f GFLOP/s\n",
                          sh.m, sh.n, sh.k, nt,
-                         mtl::detail::thread_pool::instance().size(), secs, gf);
+                         mtl::detail::thread_pool::instance().size(),
+                         bp.mc, plan.mc, plan.ic_nt, plan.jc_nt, secs, gf);
         }
     }
 
@@ -253,7 +269,8 @@ int main(int argc, char** argv) {
     std::ofstream out(csv, std::ios::app);
     if (!out) { std::fprintf(stderr, "cannot write %s\n", csv.c_str()); return 1; }
     if (fresh)
-        out << "arm,dtype,m,n,k,threads,pool,mr,nr,kc,mc,nc,reps,min_s,gflops,checksum\n";
+        out << "arm,dtype,m,n,k,threads,pool,mr,nr,kc,mc,nc,"
+               "mc_used,nib,njb,ic_nt,jc_nt,reps,min_s,gflops,checksum\n";
     for (const auto& r : rows) out << r << "\n";
 
     // Sidecar, matching the convention bench_all uses, plus the cache figures --

--- a/docs/benchmarks/systems.md
+++ b/docs/benchmarks/systems.md
@@ -397,6 +397,81 @@ Interleave A/B variants **within one session** as on every other machine, and
 treat any run whose end temperature crossed the throttle point as invalid data
 rather than a slow result.
 
+## Cache-blocking A/B — the four-machine result (#430)
+
+All four machines re-run after the thread-grid fix (#441), 5 rounds x 5 reps per
+point, every binary verified to contain the fix. **Detection is neutral at best
+and harmful at worst: across the 30 informative points, 1 was faster, 8 were
+slower, and 21 were indistinguishable.** The single win is 2.7%, barely over the
+noise threshold. `MTL5_ENABLE_CACHE_DETECTION` stays opt-in.
+
+| machine | ISA measured | detected kc, mc | verdicts (faster / slower / same) |
+|---|---|---|---|
+| i7-12700K | AVX2 | 384, 213 | 1 / 7 / 2 |
+| Ryzen 9 8945HS | **AVX-512** | 256, 256 | 0 / 1 / 9 |
+| Jetson Orin Nano 15 W | NEON | 1024, 16 | 0 / 0 / 10 |
+| Xeon E5-2420 v2 | AVX | identical to defaults | null run |
+
+### What the grid fix bought
+
+| point | before #441 | after |
+|---|---|---|
+| i7 1024³, T=8 | 0.551 | 0.707 |
+| Zen 4 1024³, T=8 | 0.590 | 0.928 |
+| Jetson wide/short, T=6 | 0.760 | 0.938 |
+
+The catastrophic multi-thread losses are gone. The Zen 4 row is **not** a
+controlled comparison: that sidecar reads `build_isa=...AVX512F` where the
+earlier run was AVX2, so the ISA changed with the fix. This is the first Zen 4
+measurement taken with the intended ISA, and it supersedes rather than extends
+the old one — which is exactly what `build_isa` was added to make visible.
+
+### mc is harmless; kc is where the loss lives
+
+The three machines happen to form a controlled experiment, because detection
+moved different parameters on each:
+
+| machine | kc | mc | single-thread ratios |
+|---|---|---|---|
+| Ryzen 8945HS | 256 → 256 (**unchanged**) | 64 → 256 (4x) | 1.002 – 1.015 |
+| i7-12700K | 256 → 384 (+50%) | 64 → 213 | 0.931 – 0.952 |
+| Jetson Orin | 512 → 1024 (2x) | 32 → 16 | 0.978 – 0.983 |
+
+Ryzen isolates `mc`: quadrupling it costs **nothing** single-threaded. Both
+machines where `kc` moved lost throughput. The harm attaches to the L1-derived
+`kc`, not the L2-derived `mc` — the inverse of the working assumption, which had
+`mc` as the suspect.
+
+Two details support it. Every detected arm sizes its A block to exactly 50% of
+L2, so *footprint fraction* is not what decides the outcome. And on the Jetson
+both arms have an identical 128 KB A block — 16x1024 against 32x512 — so that
+pair varies only the shape, and the deeper, narrower one is the one that loses.
+
+### The anomaly worth chasing
+
+i7 1024³ at T=8 is 0.707, and it is not noise: detected 312–326 GFLOP/s across
+five rounds against 438–461, ranges nowhere near overlapping. What makes it
+interesting is that the pre-#441 explanation no longer applies — at m=1024, T=8,
+mc_cache=213, the planner caps mc to 128, giving nib=8 and a perfectly balanced
+8x1 grid. **The worst remaining point is the balanced one**, so thread starvation
+is ruled out and `kc` plus L2 residency is what is left.
+
+The experiment that would settle it is a **kc-only vs mc-only** A/B on the i7:
+detect L1 alone in one arm, L2 alone in the other. If `kc` is the sole cause, the
+product of this whole line of work is not "detection off" but "detect L2, ignore
+L1" — a *win* on every machine whose mc is currently pinned at the default 64.
+
+### What the older CSVs cannot tell you
+
+The `mc` column in any CSV written before `mc_used` existed is the **configured**
+bound, not the step any loop used. Three stages sit between them — the L2 bound,
+the budget cap in `plan_gemm_grid`, and the even-partition round-off in
+`balanced_mc` — so the i7 rows say `mc=213` for runs that stepped 210 serially
+and 128 on eight threads, and even a *default* arm configured at 32 steps 30 and
+29. Every harness now records `mc_used`, `nib`, `njb`, `ic_nt`, `jc_nt` per point,
+and `analyze_blocking_ab.py` prints them beside each verdict; older CSVs are
+labelled as not carrying them.
+
 ## The run contract
 
 Every harness in `benchmarks/` **must** satisfy this. It exists because each rule

--- a/include/mtl/detail/gemm_blocked.hpp
+++ b/include/mtl/detail/gemm_blocked.hpp
@@ -175,6 +175,52 @@ inline unsigned gemm_default_threads() {
     return thread_pool::instance().size();
 }
 
+/// Everything the threaded nest decides for one call: the ic step it will
+/// actually use, the block counts that follow, and the thread grid.
+///
+/// This exists so the decision has ONE implementation and can be RECORDED.
+/// Three stages separate the configured mc from the one the loops step by --
+/// the L2 bound in blocking_params, the budget cap in plan_gemm_grid, and the
+/// round-off in balanced_mc -- and a benchmark that writes the first of them
+/// writes a number no loop ever saw. The committed A/B data (#430) records
+/// mc=213 for i7 runs whose nest stepped 210 single-threaded and 128 on eight
+/// threads, which left the parameter under test unrecoverable from the record.
+struct gemm_plan {
+    std::size_t mc;      ///< ic step actually used (post-cap, post-balance)
+    std::size_t nib;     ///< ic blocks that mc produces
+    std::size_t njb;     ///< jc blocks
+    unsigned    ic_nt;   ///< ic threads (1 when the nest runs serially)
+    unsigned    jc_nt;   ///< jc teams  (1 when the nest runs serially)
+    unsigned    budget;  ///< threads the pool actually allowed
+};
+
+/// The plan `gemm_blocked<TC>` will follow for an m x n problem on `nthreads`.
+/// Reads its parameters from exactly the places the nest reads them, so a caller
+/// that records this records what ran.
+template <typename TC>
+inline gemm_plan gemm_plan_for(std::size_t m, std::size_t n, unsigned nthreads) {
+    constexpr simd::blocking_params bp = simd::default_blocking<TC>;
+    const simd::blocking_params& rbp = simd::runtime_blocking<TC>();
+    const std::size_t MC = rbp.mc, NC = bp.nc, MR = bp.mr;
+
+    const unsigned budget = (nthreads <= 1)
+        ? 1u : std::min(nthreads, thread_pool::instance().size());
+
+    auto finish = [&](std::size_t mc, unsigned ic_nt, unsigned jc_nt) {
+        gemm_plan p{mc, 0, 0, ic_nt, jc_nt, budget};
+        p.nib = mc ? (m + mc - 1) / mc : 0;
+        p.njb = NC ? (n + NC - 1) / NC : 0;
+        return p;
+    };
+    // Serial: balanced_mc with ic_nt = 1 rounds the bound down to whole mr
+    // panels, which is what serial_nest steps by.
+    if (budget <= 1) return finish(balanced_mc(m, MC, 1, MR), 1, 1);
+
+    const gemm_grid g = plan_gemm_grid(m, n, MC, NC, MR, budget);
+    if (g.ic_nt * g.jc_nt <= 1) return finish(balanced_mc(m, MC, 1, MR), 1, 1);
+    return finish(balanced_mc(m, g.mc, g.ic_nt, MR), g.ic_nt, g.jc_nt);
+}
+
 /// Reusable sense-reversing barrier for a fixed party count. Used to synchronize
 /// the ic-threads of one jc-team around their shared packed-B panel: the leader
 /// packs B, all wait (publish), the team computes, all wait again (so the leader
@@ -329,42 +375,32 @@ void gemm_blocked(std::size_t m, std::size_t n, std::size_t k,
     // would leave team members that never run, and their barrier would wait
     // forever (deadlock).
     thread_pool& pool = thread_pool::instance();
-    const unsigned budget = std::min(nthreads, pool.size());
-    if (budget <= 1) { serial_nest(); return; }
 
-    const gemm_grid plan = plan_gemm_grid(m, n, MC, NC, MR, budget);
-
-    // Block-start lists for the m (ic) and n (jc) dimensions. The m dimension
-    // steps by the PLANNED mc, which may be smaller than the cache bound MC when
-    // the cache bound alone would not produce enough blocks to fill the machine.
-    std::vector<std::size_t> ic_starts, jc_starts;
-    for (std::size_t ic = 0; ic < m; ic += plan.mc) ic_starts.push_back(ic);
-    for (std::size_t jc = 0; jc < n; jc += NC) jc_starts.push_back(jc);
-    const std::size_t nib = ic_starts.size();
-    const std::size_t njb = jc_starts.size();
-
-    // Thread budget: never exceed the pool. pool.run() clamps its worker count to
+    // One call decides everything: the budget (never past the pool -- pool.run()
+    // clamps its worker count, so a grid sized past it would leave team members
+    // that never run and a barrier that waits forever), the ic step, and the
+    // grid. gemm_plan_for is the single implementation, so what a benchmark
+    // records is what this nest runs.
+    const gemm_plan plan = gemm_plan_for<TC>(m, n, nthreads);
     const unsigned ic_nt = plan.ic_nt;
     const unsigned jc_nt = plan.jc_nt;
     const unsigned grid  = ic_nt * jc_nt;
-
     if (grid <= 1) { serial_nest(); return; }
 
-    // Now that ic_nt is fixed, re-block the m dimension so the round-robin
-    // partition divides evenly (#408). balanced_mc only ever LOWERS mc, so the
-    // new block count is >= nib >= ic_nt and the grid stays valid; the packed-A
-    // buffers sized from mc_max = min(MC, m) stay large enough for the same
-    // reason. Rebuilding ic_starts is the only state that depends on it.
+    // plan.mc is already re-blocked so the round-robin partition divides evenly
+    // (#408); balanced_mc only ever LOWERS the bound, so the block count is
+    // >= ic_nt and the grid stays valid, and the packed-A buffers sized from
+    // mc_max = min(MC, m) stay large enough for the same reason.
     //
     // This changes neither the result nor its bit-identity to the serial nest:
     // the FMA order for a given C element is fixed by the pc (k) loop, which is
     // untouched, and ic blocking only decides which rows are grouped together.
-    MC_eff = balanced_mc(m, plan.mc, ic_nt, MR);
-    if (MC_eff != plan.mc) {
-        ic_starts.clear();
-        for (std::size_t ic = 0; ic < m; ic += MC_eff) ic_starts.push_back(ic);
-    }
+    MC_eff = plan.mc;
+    std::vector<std::size_t> ic_starts, jc_starts;
+    for (std::size_t ic = 0; ic < m; ic += MC_eff) ic_starts.push_back(ic);
+    for (std::size_t jc = 0; jc < n; jc += NC) jc_starts.push_back(jc);
     const std::size_t nib_eff = ic_starts.size();
+    const std::size_t njb = jc_starts.size();
 
     // Pre-allocate ALL scratch outside the parallel region: one packed-B per
     // jc-team (shared within the team), one packed-A per grid thread, and one

--- a/tests/unit/detail/test_gemm_grid.cpp
+++ b/tests/unit/detail/test_gemm_grid.cpp
@@ -159,3 +159,59 @@ TEST_CASE("plan_gemm_grid handles degenerate inputs", "[detail][gemm][grid][edge
         REQUIRE(g.mc >= 1);
     }
 }
+
+// --- gemm_plan_for: what the nest RUNS, not what was configured -------------
+//
+// The blocking parameter under test travels through three stages before any
+// loop steps by it: the L2 bound in blocking_params, the budget cap in
+// plan_gemm_grid, and the round-off in balanced_mc. The A/B harness recorded
+// only the first, so the committed data reports mc=213 for i7 runs that stepped
+// 210 serially and 128 on eight threads (#430). gemm_plan_for is the single
+// implementation the nest and the benchmark now share; these tests pin the
+// properties that make it worth recording.
+#include <mtl/simd/blocking.hpp>
+#include <mtl/detail/thread_pool.hpp>
+
+TEST_CASE("gemm_plan_for reports a derived mc, not the configured one",
+          "[detail][gemm][grid][plan]") {
+    const auto& bp = mtl::simd::runtime_blocking<double>();
+
+    SECTION("serial: rounded down to whole register panels") {
+        const auto p = mtl::detail::gemm_plan_for<double>(1024, 1024, 1);
+        REQUIRE(p.ic_nt == 1);
+        REQUIRE(p.jc_nt == 1);
+        REQUIRE(p.mc >= 1);
+        REQUIRE(p.mc <= bp.mc);
+        // The property that makes the recorded number meaningful: it is a whole
+        // number of mr-row panels, which the configured bound need not be (the
+        // shipped fp64 mc=64 with mr=6 runs at 60).
+        if (bp.mc >= bp.mr) REQUIRE(p.mc % bp.mr == 0);
+        REQUIRE(p.nib == (1024 + p.mc - 1) / p.mc);
+    }
+
+    SECTION("threaded: never past the pool, never past the cache bound") {
+        const unsigned pool = mtl::detail::thread_pool::instance().size();
+        for (unsigned req : {2u, 6u, 8u, 64u}) {
+            const auto p = mtl::detail::gemm_plan_for<double>(1024, 1024, req);
+            INFO("requested " << req << " of a " << pool << "-thread pool -> "
+                 << p.ic_nt << "x" << p.jc_nt << " mc=" << p.mc);
+            REQUIRE(p.budget <= pool);
+            REQUIRE(p.budget <= req);
+            REQUIRE(p.ic_nt * p.jc_nt <= p.budget);
+            REQUIRE(p.mc >= 1);
+            REQUIRE(p.mc <= bp.mc);          // the L2 bound is never exceeded
+            REQUIRE(p.nib == (1024 + p.mc - 1) / p.mc);
+            REQUIRE(p.ic_nt <= p.nib);
+            REQUIRE(p.jc_nt <= p.njb);
+        }
+    }
+
+    SECTION("a tall problem on many threads shrinks mc rather than idling") {
+        // The i7 case from #430: with the cache bound alone, m/mc yields fewer
+        // blocks than threads. Whatever the pool, the plan must never report
+        // more ic threads than it has blocks for.
+        const auto p = mtl::detail::gemm_plan_for<double>(1024, 1024, 8);
+        REQUIRE(p.ic_nt <= p.nib);
+        if (p.budget >= 8) REQUIRE(p.nib >= p.ic_nt);
+    }
+}


### PR DESCRIPTION
## Summary

Analysing the four-machine A/B (#430) turned up a hole in its own data: the CSV records the **configured** `mc`, and no loop ever uses that number.

Three stages sit between them — the L2 bound in `blocking_params`, the budget cap in `plan_gemm_grid`, and the even-partition round-off in `balanced_mc`:

```
i7 detected:  configured 213  ->  210 serial  ->  128 on 8 threads
Xeon default: configured  32  ->   30 serial  ->   29 on 6 threads
```

The parameter under test was not in the record of the experiment testing it.

## One implementation, so the record cannot drift

`detail::gemm_plan_for<T>(m, n, nthreads)` returns the whole decision — `mc`, `nib`, `njb`, `ic_nt`, `jc_nt`, `budget` — reading MC/NC/MR from exactly the places the nest reads them. **`gemm_blocked` now uses it** instead of recomputing the same three steps inline, so a benchmark that records the plan records what ran *by construction*, not by inspection. The nest's behaviour is unchanged: same budget clamp, same cap, same `balanced_mc`, same serial fallbacks.

- `bench_blocking_ab` writes `mc_used,nib,njb,ic_nt,jc_nt` per point and prints `mc 32->29 grid 6x1` per run
- `analyze_blocking_ab.py` shows mc as-run per arm **beside each verdict** — per point, not as a summary line, because it depends on the shape as well as the thread count
- CSVs without the column are labelled as predating it, rather than silently showing the old, wrong number

## Also: the four-machine result, written up

`docs/benchmarks/systems.md` gains the #430 analysis:

- **Detection is neutral at best**: 1 faster, 8 slower, 21 indistinguishable across 30 informative points. The one win is 2.7%. Opt-in stands.
- **The grid fix worked**: i7 1024³ T=8 went 0.551 → 0.707, Jetson 0.760 → 0.938, Zen 4 0.590 → 0.928.
- **The Zen 4 run is the first with the intended ISA** (`build_isa=...AVX512F` vs AVX2 before), so it supersedes rather than extends the old one — exactly what that key was added to make visible.
- **mc is harmless; kc is where the loss lives.** Ryzen isolates it: `kc` unchanged, `mc` ×4, single-thread ratios 1.002–1.015. Both machines where `kc` moved lost throughput.
- **The anomaly**: i7 1024³ T=8 = 0.707, stable across all five rounds, and the *balanced* grid point — so thread starvation is ruled out and `kc` is what remains.

## Test Results

| Suite | Result |
|---|---|
| GCC | 167/167 |
| Clang | 167/167 |

The nest refactor had to leave the bit-identity mt suites untouched; `op_test_gemm_mt` and the threaded solve tests pass unchanged.

New tests pin the properties that make the recorded value worth having — never exceeds the cache bound, whole register panels when serial, agrees with `nib`, grid never exceeds the pool — rather than restating the arithmetic. They read the pool size instead of assuming it, so they hold on any machine.

## Test plan

- [ ] Tier 1 CI on 8 platforms
- [ ] Next A/B run carries `mc_used`

Relates to #430, #442

Generated with [Claude Code](https://claude.com/claude-code)
