### PR TITLE
feat(bench): kc-only and mc-only arms, to separate the two detected levels

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -43,16 +43,29 @@ set_target_properties(bench_sparse PROPERTIES FOLDER "Benchmarks")
 # in kc/mc. Driven by benchmarks/run_blocking_ab.sh, which pins and interleaves
 # them. The `-default` arm is what MTL5 ships; the `-detected` arm is the opt-in
 # under test, which measured a loss on the i7-12700K.
-foreach(_arm detected default)
+# FOUR arms, because the four-machine result (#430) says kc and mc do not behave
+# alike -- the Ryzen run varied mc alone and cost nothing, while both machines
+# whose kc moved lost throughput. `kconly` and `mconly` turn that inference into
+# a measurement: L1 feeds kc, L2 feeds mc, and each arm detects one of them.
+#
+# All four are the SAME source; only the macro differs, so any difference in
+# throughput is a difference in blocking.
+set(_ab_arms      default        detected                        kconly                             mconly)
+set(_ab_arm_defs  ""             MTL5_ENABLE_CACHE_DETECTION     MTL5_ENABLE_CACHE_DETECTION_L1     MTL5_ENABLE_CACHE_DETECTION_L2)
+foreach(_i RANGE 3)
+    list(GET _ab_arms     ${_i} _arm)
+    list(GET _ab_arm_defs ${_i} _def)
     add_executable(bench_blocking_ab_${_arm} bench_blocking_ab.cpp)
     target_link_libraries(bench_blocking_ab_${_arm} PRIVATE MTL5::mtl5)
     target_include_directories(bench_blocking_ab_${_arm} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
     set_target_properties(bench_blocking_ab_${_arm} PROPERTIES FOLDER "Benchmarks")
+    if(NOT _def STREQUAL "")
+        target_compile_definitions(bench_blocking_ab_${_arm} PRIVATE ${_def})
+    endif()
     # Provenance is regenerated per build, so the recorded commit follows the
     # working tree rather than the last configure (#442).
     add_dependencies(bench_blocking_ab_${_arm} mtl5_build_info)
 endforeach()
-target_compile_definitions(bench_blocking_ab_detected PRIVATE MTL5_ENABLE_CACHE_DETECTION)
 
 # Future: individual focused benchmarks can be added here
 # add_executable(bench_gemm bench_gemm.cpp)

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -51,6 +51,8 @@ benchmarks/
   bench_klu.cpp          sparse scoreboard: native KLU vs SuiteSparse KLU (#138)
   bench_superlu.cpp      sparse scoreboard: native LU vs SuperLU (#186)
   bench_sparse.cpp       level-scheduled sparse triangular-solve scaling (#297)
+  machines/              per-machine run profiles: the pin list, thread counts and ISA
+                         flag for each benchmark host, committed instead of retyped
   run_sweeps.sh          builds native/native-fast/openblas/blis/mkl variants and runs the sweeps
   run_scaling.sh         multi-core GEMM scaling across backends and thread counts (#108)
   run_scaling_297.sh     native 1->N scaling of every threaded kernel family (#297)

--- a/benchmarks/analyze_blocking_ab.py
+++ b/benchmarks/analyze_blocking_ab.py
@@ -30,26 +30,34 @@ MIN_ROUNDS = 3
 
 
 def load(path):
+    """rows, blocking params, and the ARM NAME the data carries.
+
+    The name comes from the file rather than from this script's assumptions:
+    the harness now runs four arms (default / detected / kconly / mconly) and
+    any pair of them can be compared, so a hardcoded "detected vs default"
+    heading would mislabel three comparisons out of four."""
     rows = defaultdict(list)          # (dtype,m,n,k,threads) -> [row, ...]
     params = {}
+    arm = None
     with open(path, newline="") as fh:
         for r in csv.DictReader(fh):
+            arm = arm or r.get("arm")
             key = (r["dtype"], int(r["m"]), int(r["n"]), int(r["k"]), int(r["threads"]))
             rows[key].append(r)
             params[r["dtype"]] = (r["mr"], r["nr"], r["kc"], r["mc"], r["nc"])
-    return rows, params
+    return rows, params, (arm or "test")
 
 
 def main(argv):
     if len(argv) != 3:
         print("usage: analyze_blocking_ab.py <detected.csv> <default.csv>", file=sys.stderr)
         return 2
-    det, det_p = load(argv[1])
-    dfl, dfl_p = load(argv[2])
+    det, det_p, det_name = load(argv[1])
+    dfl, dfl_p, dfl_name = load(argv[2])
 
     for dt in sorted(set(det_p) | set(dfl_p)):
-        print(f"blocking ({dt}):  detected mr,nr,kc,mc,nc = {det_p.get(dt)}"
-              f"   default = {dfl_p.get(dt)}")
+        print(f"blocking ({dt}):  {det_name} mr,nr,kc,mc,nc = {det_p.get(dt)}"
+              f"   {dfl_name} = {dfl_p.get(dt)}")
 
     # The CONFIGURED mc above is not the one the loops step by: it is capped to
     # fill the thread budget (plan_gemm_grid) and then rounded so the partition
@@ -90,9 +98,9 @@ def main(argv):
     null_run = all(det_p.get(dt) == dfl_p.get(dt) for dt in set(det_p) | set(dfl_p))
     if null_run:
         print("\n*** NULL RUN: both arms compiled to identical blocking parameters.")
-        print("*** Detection changes nothing on this machine (its L1/L2 already match")
-        print("*** the compile-time defaults), so every difference below is noise and")
-        print("*** no point is called. This is a useful harness self-test, not a result.")
+        print(f"*** {det_name} and {dfl_name} derive the same kc/mc on this machine")
+        print("*** (its caches already match the compile-time model), so every difference")
+        print("*** below is noise and no point is called. A useful harness self-test.")
     print()
 
     # Integrity gate. An A/B is only an A/B if both arms measured the same points
@@ -114,8 +122,8 @@ def main(argv):
         print("Re-run both arms over the same shapes and rounds.", file=sys.stderr)
         return 2
 
-    hdr = (f"{'shape':>22} {'T':>3} {'default':>10} {'detected':>10} {'ratio':>7}"
-           f" {'mc def/det':>11} {'grid':>6}  verdict")
+    hdr = (f"{'shape':>22} {'T':>3} {dfl_name:>10} {det_name:>10} {'ratio':>7}"
+           f" {'mc base/test':>13} {'grid':>6}  verdict")
     print(hdr)
     print("-" * len(hdr))
 
@@ -151,10 +159,10 @@ def main(argv):
             verdict = f"unresolved (only {rounds} rounds)"
             noise += 1
         elif a_s[-1] < b_s[0]:
-            verdict = "detected faster"
+            verdict = f"{det_name} faster"
             wins += 1
         elif b_s[-1] < a_s[0]:
-            verdict = "DEFAULT faster"
+            verdict = f"{dfl_name.upper()} faster"
             losses += 1
         else:
             verdict = "noise (ranges overlap)"
@@ -168,7 +176,7 @@ def main(argv):
         print(f"{m}x{n}x{k:>6}".rjust(22)
               + f" {t:>3} {gflops(m, n, k, b_best):>10.2f}"
               + f" {gflops(m, n, k, a_best):>10.2f} {ratio:>7.3f}"
-              + f" {mc_col:>11} {grid_col:>6}  {verdict}")
+              + f" {mc_col:>13} {grid_col:>6}  {verdict}")
 
     print()
     print(f"{wins} faster, {losses} slower, {noise} indistinguishable "

--- a/benchmarks/bench_blocking_ab.cpp
+++ b/benchmarks/bench_blocking_ab.cpp
@@ -207,11 +207,19 @@ int main(int argc, char** argv) {
     std::fprintf(stderr, "arm=%s dtype=%s\n", label.c_str(), dtype.c_str());
     std::fprintf(stderr, "  detected l1d=%zu l2=%zu l3=%zu line=%zu\n",
                  ci.l1d_bytes, ci.l2_bytes, ci.l3_bytes, ci.line_bytes);
-#if defined(MTL5_ENABLE_CACHE_DETECTION)
-    std::fprintf(stderr, "  MTL5_ENABLE_CACHE_DETECTION is ON -- blocking follows the detected caches\n");
-#else
-    std::fprintf(stderr, "  detection not enabled -- blocking uses the compile-time defaults (shipped)\n");
-#endif
+    // Report the LEVELS this arm compiled with, not just whether the original
+    // both-levels macro was set: a kc-only arm announcing "detection not
+    // enabled" would put a false statement at the top of its own record.
+    {
+        using mtl::simd::detect_levels;
+        constexpr auto lv = mtl::simd::configured_detect_levels();
+        const char* what =
+            lv == detect_levels::none ? "none -- compile-time defaults (what MTL5 ships)"
+          : lv == detect_levels::both ? "L1+L2 -- both kc and mc follow the detected caches"
+          : mtl::simd::has_level(lv, detect_levels::l1) ? "L1 only -- kc detected, mc from the default model"
+          :                                              "L2 only -- mc detected, kc from the default model";
+        std::fprintf(stderr, "  cache detection: %s\n", what);
+    }
     std::fprintf(stderr, "  fp64 mr=%zu nr=%zu kc=%zu mc=%zu nc=%zu\n",
                  bpd.mr, bpd.nr, bpd.kc, bpd.mc, bpd.nc);
     std::fprintf(stderr, "  fp32 mr=%zu nr=%zu kc=%zu mc=%zu nc=%zu\n",

--- a/benchmarks/machines/i7-12700k.sh
+++ b/benchmarks/machines/i7-12700k.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Cache-blocking A/B on the i7-12700K (Alder Lake, hybrid).
+#
+# This file IS the invocation. The pin list below is not a preference, it is the
+# machine's topology, and getting it wrong on this part does more than add noise:
+# the P-cores and E-cores have DIFFERENT cache hierarchies (48 KB vs 32 KB L1d,
+# 1.25 MB private vs 2 MB shared L2), so an unpinned or wrongly pinned run
+# detects whichever hierarchy the thread happened to land on and the `detected`
+# arm becomes unreproducible (#432). Keeping it in a committed script rather than
+# in shell history is the difference between a result and an anecdote.
+#
+# Topology (lscpu -e=CPU,CORE): 8 P-cores with SMT on CPUs 0..15 (siblings
+# adjacent, so one id per core is 0,2,4,...,14) and 4 E-cores on 16..19, which
+# are EXCLUDED -- mixing core classes would measure the slower one.
+#
+# Usage:  benchmarks/machines/i7-12700k.sh            # the four-arm kc/mc split
+#         ARMS="detected default" benchmarks/machines/i7-12700k.sh
+#         ROUNDS=3 benchmarks/machines/i7-12700k.sh   # anything is overridable
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+cd "$ROOT"
+
+# Refuse to write another machine's numbers into this machine's directory. The
+# CSVs are named by arm and the runner clears them before writing, so a profile
+# executed on the wrong host silently replaces committed evidence with data from
+# somewhere else -- the #439 failure with a friendlier face. FORCE=1 overrides,
+# for a genuinely equivalent part.
+EXPECT="i7-12700K"
+ACTUAL=$(sed -n 's/^model name[[:space:]]*: //p' /proc/cpuinfo | head -1)
+if ! printf '%s' "$ACTUAL" | grep -q "$EXPECT"; then
+    echo "This profile is for a $EXPECT; this machine reports:" >&2
+    echo "  $ACTUAL" >&2
+    echo "Refusing to write $EXPECT data. Set FORCE=1 if this really is one." >&2
+    [ "${FORCE:-0}" = 1 ] || exit 2
+fi
+
+export BENCH_PROFILE=i7-12700k
+export OUTDIR=${OUTDIR:-benchmarks/data/i7-12700k}
+export BUILD_DIR=${BUILD_DIR:-build-release}
+DEFAULT_PCPUS=0,2,4,6,8,10,12,14                        # P-cores, one id per core
+export BENCH_PCPUS=${BENCH_PCPUS:-$DEFAULT_PCPUS}
+export THREADS=${THREADS:-"1 8"}                        # 1 and all eight P-cores
+export ROUNDS=${ROUNDS:-5}
+export REPS=${REPS:-5}
+export DTYPE=${DTYPE:-double}
+# All four arms in ONE session: this is the machine that decides the kc/mc
+# question (#430) -- its L1d is 48 KB, so kc moves 256 -> 384 here, and it owns
+# the unexplained 1024^3 T=8 loss.
+export ARMS=${ARMS:-"default detected kconly mconly"}
+
+echo "profile: $BENCH_PROFILE"
+echo "  build:   cmake --preset release -DMTL5_WITH_HIGHWAY=ON -DMTL5_NATIVE_ARCH=ON"
+if [ "$BENCH_PCPUS" = "$DEFAULT_PCPUS" ]; then
+    echo "  pinning: $BENCH_PCPUS (P-cores only; E-cores 16-19 excluded)"
+else
+    # Do not annotate a list this profile did not choose: claiming "P-cores only"
+    # about an overridden list is the kind of confident wrong label the sidecar
+    # work exists to remove.
+    echo "  pinning: $BENCH_PCPUS (OVERRIDDEN; profile default is $DEFAULT_PCPUS)"
+fi
+echo "  arms:    $ARMS"
+echo "  outdir:  $OUTDIR"
+echo
+
+# -march=native matters here: without an ISA flag Highway compiles for the
+# 128-bit baseline, and kc/mc/nc all divide by the SIMD width -- the blocking
+# under test would be for a vector length the production build never uses.
+if [ ! -x "$BUILD_DIR/benchmarks/bench_blocking_ab_default" ]; then
+    echo "== configuring and building $BUILD_DIR"
+    cmake --preset release -DMTL5_WITH_HIGHWAY=ON -DMTL5_NATIVE_ARCH=ON >/dev/null
+    targets=""
+    for a in $ARMS; do targets="$targets bench_blocking_ab_$a"; done
+    # shellcheck disable=SC2086
+    cmake --build "$BUILD_DIR" --target $targets -j4 >/dev/null
+fi
+
+exec "$ROOT/benchmarks/run_blocking_ab.sh"

--- a/benchmarks/machines/jetson-orin-nano.sh
+++ b/benchmarks/machines/jetson-orin-nano.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Cache-blocking A/B on the Jetson Orin Nano (Tegra234, 6x Cortex-A78AE).
+#
+# This file IS the invocation, and on a Jetson it has to carry more than the pin
+# list, because the numbers are only meaningful relative to a POWER MODE. The
+# mode selects clock caps (and on other modules, which cores are online), it
+# differs per module and per JetPack image, and an unpinned, unconfigured run
+# measures the cooling solution rather than the code.
+#
+# So the output directory FOLLOWS the mode: a 15 W run and a MAXN run land in
+# different directories and can never be silently averaged together. The
+# committed 15 W data was taken under `schedutil` with clocks unpinned, which is
+# why it is labelled that way in docs/benchmarks/systems.md.
+#
+# Topology: six A78AE cores, no SMT, all online -- six is the module's PHYSICAL
+# core count, not a power-mode reduction (nvpmodel.conf defines CPU_A78_0..5 and
+# nothing else). Two asymmetric clusters (4-core + 2-core), 64 KB L1d and 256 KB
+# L2 per core, 2 MB L3 per cluster, 4 MB system cache shared.
+#
+# Usage:  benchmarks/machines/jetson-orin-nano.sh
+#         sudo nvpmodel -m 0 && sudo jetson_clocks   # MAXN, DVFS pinned
+#         benchmarks/machines/jetson-orin-nano.sh    # -> data/jetson-orin-nano-MAXN
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+cd "$ROOT"
+
+# Refuse to write Jetson numbers on something that is not one (see the i7
+# profile for why this guard exists).
+if [ -r /proc/device-tree/model ]; then
+    MODEL=$(tr -d '\0' < /proc/device-tree/model)
+else
+    MODEL=unknown
+fi
+case "$MODEL" in
+    *Orin*) ;;
+    *) echo "This profile is for a Jetson Orin; this machine reports: $MODEL" >&2
+       echo "Refusing to write Orin data. Set FORCE=1 if this really is one." >&2
+       [ "${FORCE:-0}" = 1 ] || exit 2 ;;
+esac
+
+# The power mode decides the clocks, so it decides what the numbers mean. Read it
+# rather than asking the operator to remember: `nvpmodel -q` prints
+#   NV Power Mode: 15W
+#   0
+MODE="unknown"
+if command -v nvpmodel >/dev/null 2>&1; then
+    MODE=$(nvpmodel -q 2>/dev/null | sed -n 's/^NV Power Mode:[[:space:]]*//p' | head -1)
+    [ -n "$MODE" ] || MODE="unknown"
+fi
+if [ "$MODE" = unknown ]; then
+    echo "WARNING: could not read the power mode (nvpmodel missing, or it needs root)." >&2
+    echo "         The mode decides the clock caps, so a run without it cannot be" >&2
+    echo "         compared with one that has it. Set JETSON_MODE=<name> to record" >&2
+    echo "         it by hand, or run: sudo nvpmodel -q" >&2
+    MODE=${JETSON_MODE:-unknown}
+fi
+MODE=$(printf '%s' "$MODE" | tr -d ' /')
+
+# Clocks: `jetson_clocks` pins DVFS. Without it the early reps run at a lower
+# clock than the late ones, which reads as a warm-up effect and is not one.
+#
+# Asked of sysfs rather than of jetson_clocks --show, which needs root on some
+# images: scaling_min_freq == scaling_max_freq is exactly what pinning produces,
+# and it is world-readable.
+CLOCKS=unpinned
+CPUFREQ=/sys/devices/system/cpu/cpu0/cpufreq
+if [ -r "$CPUFREQ/scaling_min_freq" ] && [ -r "$CPUFREQ/scaling_max_freq" ]; then
+    if [ "$(cat "$CPUFREQ/scaling_min_freq")" = "$(cat "$CPUFREQ/scaling_max_freq")" ]; then
+        CLOCKS="pinned at $(( $(cat "$CPUFREQ/scaling_max_freq") / 1000 )) MHz"
+    else
+        CLOCKS="unpinned ($(( $(cat "$CPUFREQ/scaling_min_freq") / 1000 ))-$(( $(cat "$CPUFREQ/scaling_max_freq") / 1000 )) MHz)"
+    fi
+fi
+if [ "${CLOCKS#unpinned}" != "$CLOCKS" ]; then
+    echo "NOTE: CPU clocks are $CLOCKS. Run 'sudo jetson_clocks' first if you want" >&2
+    echo "      this session comparable with a pinned one -- DVFS ramping otherwise" >&2
+    echo "      makes the first reps of every arm slower than the last." >&2
+fi
+
+export BENCH_PROFILE="jetson-orin-nano-${MODE}"
+export OUTDIR=${OUTDIR:-benchmarks/data/jetson-orin-nano-${MODE}}
+export BUILD_DIR=${BUILD_DIR:-build-release}
+export BENCH_PCPUS=${BENCH_PCPUS:-0,1,2,3,4,5}   # six physical cores, no SMT
+export THREADS=${THREADS:-"1 6"}                 # 6, NOT the 8 that was asked once
+export ROUNDS=${ROUNDS:-5}
+export REPS=${REPS:-5}
+export DTYPE=${DTYPE:-double}
+export ARMS=${ARMS:-"default detected kconly mconly"}
+
+echo "profile: $BENCH_PROFILE"
+echo "  model:      $MODEL"
+echo "  power mode: $MODE   (clocks: $CLOCKS)"
+echo "  pinning:    $BENCH_PCPUS"
+echo "  arms:       $ARMS"
+echo "  outdir:     $OUTDIR"
+echo
+echo "  thermal now: $(cat /sys/devices/virtual/thermal/thermal_zone*/temp 2>/dev/null | \
+                       awk '{printf "%.1fC ", $1/1000}')"
+echo
+
+if [ ! -x "$BUILD_DIR/benchmarks/bench_blocking_ab_default" ]; then
+    echo "== configuring and building $BUILD_DIR"
+    cmake --preset release -DMTL5_WITH_HIGHWAY=ON -DMTL5_NATIVE_ARCH=ON >/dev/null
+    targets=""
+    for a in $ARMS; do targets="$targets bench_blocking_ab_$a"; done
+    # shellcheck disable=SC2086
+    cmake --build "$BUILD_DIR" --target $targets -j4 >/dev/null
+fi
+
+exec "$ROOT/benchmarks/run_blocking_ab.sh"

--- a/benchmarks/machines/ryzen-9-8945hs.ps1
+++ b/benchmarks/machines/ryzen-9-8945hs.ps1
@@ -1,0 +1,70 @@
+<#
+.SYNOPSIS
+    Cache-blocking A/B on the Ryzen 9 8945HS (Zen 4 / Hawk Point, Windows/MSVC).
+
+.DESCRIPTION
+    This file IS the invocation. Two of its settings are not preferences:
+
+    * -Arch "/arch:AVX512". MTL5_NATIVE_ARCH is a NO-OP under MSVC (it is guarded
+      `if(MTL5_NATIVE_ARCH AND NOT MSVC)`) and MSVC x64 defaults to SSE2, so
+      without this flag the run silently measures an SSE2 build -- and completes,
+      and prints a clean table. That is not hypothetical: the first Zen 4 A/B was
+      an AVX2 run when AVX-512 was intended, and nothing in the CSV could say so
+      until `build_isa` was added. Check it in the sidecar afterwards.
+
+    * -PCores "0,2,4,...,14". One logical id per physical core; the SMT siblings
+      are odd. Eight Zen 4 cores, homogeneous -- unlike the i7 there is no
+      P/E split here, which is why the Windows CPUID detection caveat (detection
+      may run before the affinity mask takes effect) is harmless on this machine
+      and not on a hybrid one.
+
+    All four arms run in ONE session: this machine is the AVX-512 half of the
+    kc/mc question (#430). Its L1d is 32 KB, so `kc` does NOT move here -- which
+    is exactly what makes it the control for the i7.
+
+.EXAMPLE
+    pwsh benchmarks/machines/ryzen-9-8945hs.ps1
+    pwsh benchmarks/machines/ryzen-9-8945hs.ps1 -Arms "detected,default" -Rounds 3
+#>
+[CmdletBinding()]
+param(
+    [string]$Arms    = "default,detected,kconly,mconly",
+    [string]$PCores  = "0,2,4,6,8,10,12,14",
+    [string]$Threads = "1,8",
+    [int]$Rounds     = 5,
+    [int]$Reps       = 5,
+    [string]$Arch    = "/arch:AVX512",
+    [string]$OutDir  = "benchmarks\data\ryzen-9-8945hs",
+    [switch]$Force
+)
+
+$RepoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+
+# Refuse to write this machine's numbers on a different machine: the CSVs are
+# named by arm and the runner clears them before writing, so a profile run on the
+# wrong host replaces committed evidence with data from somewhere else.
+$expect = "8945HS"
+$actual = (Get-CimInstance -ClassName Win32_Processor | Select-Object -First 1).Name
+if ($actual -notmatch $expect) {
+    Write-Host "This profile is for a Ryzen 9 $expect; this machine reports:"
+    Write-Host "  $actual"
+    if (-not $Force) {
+        Write-Host "Refusing to write $expect data. Pass -Force if this really is one."
+        exit 2
+    }
+}
+
+$env:BENCH_PROFILE = "ryzen-9-8945hs"
+
+Write-Host "profile: $($env:BENCH_PROFILE)"
+Write-Host "  cpu:     $actual"
+Write-Host "  isa:     $Arch   (MTL5_NATIVE_ARCH is a no-op under MSVC)"
+Write-Host "  pinning: $PCores (one logical id per physical core)"
+Write-Host "  arms:    $Arms"
+Write-Host "  outdir:  $OutDir"
+Write-Host ""
+
+& (Join-Path $RepoRoot "benchmarks\run_blocking_ab.ps1") `
+    -Arms $Arms -PCores $PCores -Threads $Threads `
+    -Rounds $Rounds -Reps $Reps -Arch $Arch -OutDir $OutDir
+exit $LASTEXITCODE

--- a/benchmarks/run_blocking_ab.ps1
+++ b/benchmarks/run_blocking_ab.ps1
@@ -335,11 +335,20 @@ foreach ($s in ($ArmList | ForEach-Object { "$(Arm-Csv $_).sysinfo" })) {
     if (Test-Path $s) {
         Add-Content -Path $s -Value $PreflightKv
         Add-Content -Path $s -Value $AfterKv
+        # The INVOCATION, not just the harness name. Which cpus were pinned,
+        # which arms ran, which ISA flag and which machine profile chose them are
+        # what make a committed CSV re-runnable.
         Add-Content -Path $s -Value @(
             "binary_stale=$Stale",
             "harness=run_blocking_ab.ps1",
+            "harness_profile=$(if ($env:BENCH_PROFILE) { $env:BENCH_PROFILE } else { 'none' })",
             "harness_rounds=$Rounds",
-            "harness_reps=$Reps")
+            "harness_reps=$Reps",
+            "harness_arms=$($ArmList -join ',')",
+            "harness_pcores=$PCores",
+            "harness_threads=$Threads",
+            "harness_arch=$(if ($Arch -ne '') { $Arch } else { 'none' })",
+            "harness_dtype=$DType")
     }
 }
 

--- a/benchmarks/run_blocking_ab.ps1
+++ b/benchmarks/run_blocking_ab.ps1
@@ -64,6 +64,16 @@ param(
     [string]$DType   = "double",
     [string]$Shapes  = "",          # empty: derive from the machine (preferred)
     [string]$Arch    = "/arch:AVX512",
+    # Arms to run, in the order they lead the first round. All are the same
+    # source and differ only in which detected cache levels feed the blocking:
+    #   default  none   -- the compile-time model MTL5 ships
+    #   detected L1+L2  -- kc from L1, mc from L2
+    #   kconly   L1     -- kc detected, mc from the default model
+    #   mconly   L2     -- mc detected, kc from the default model
+    # kconly/mconly exist because #430 implicated kc and exonerated mc without
+    # ever varying them separately. Run all four in ONE session to settle it:
+    #   -Arms "default,detected,kconly,mconly"
+    [string]$Arms    = "detected,default",
     [string]$OutDir  = "",          # REQUIRED -- one directory per machine
 
     [string]$BuildDir = "build-blocking-ab",
@@ -183,17 +193,27 @@ if ((Invoke-Native "cmake" $cfg (Join-Path $LogDir "blocking_ab.configure")) -ne
     throw "configure failed (see $LogDir\blocking_ab.configure.err.log)"
 }
 Write-Host "=== build"
-$targets = @("--build", $Full, "--config", "Release",
-             "--target", "bench_blocking_ab_detected", "bench_blocking_ab_default", "-j", "$Jobs")
+[string[]]$ArmList = $Arms -split '[,\s]+' | Where-Object { $_ }
+if ($ArmList.Count -lt 2) { throw "-Arms needs at least two arms to compare, got '$Arms'" }
+$known = @("default", "detected", "kconly", "mconly")
+foreach ($a in $ArmList) {
+    if ($known -notcontains $a) { throw "unknown arm '$a'; known arms: $($known -join ', ')" }
+}
+$targets = @("--build", $Full, "--config", "Release", "--target") +
+           ($ArmList | ForEach-Object { "bench_blocking_ab_$_" }) + @("-j", "$Jobs")
 if ((Invoke-Native "cmake" $targets (Join-Path $LogDir "blocking_ab.build")) -ne 0) {
     throw "build failed (see $LogDir\blocking_ab.build.err.log)"
 }
 
-$Det = Join-Path $Full "benchmarks\Release\bench_blocking_ab_detected.exe"
-$Def = Join-Path $Full "benchmarks\Release\bench_blocking_ab_default.exe"
-foreach ($exe in @($Det, $Def)) {
-    if (-not (Test-Path $exe)) { throw "missing $exe after build" }
+function Arm-Exe($arm) { Join-Path $Full "benchmarks\Release\bench_blocking_ab_$arm.exe" }
+function Arm-Csv($arm) { Join-Path $DataDir "blocking_ab_$arm.csv" }
+foreach ($a in $ArmList) {
+    if (-not (Test-Path (Arm-Exe $a))) { throw "missing $(Arm-Exe $a) after build" }
 }
+# Shapes come from the FIRST arm and go to every arm, so the arms are never
+# compared on different shapes.
+$FirstArm = $ArmList[0]
+$Det = Arm-Exe $FirstArm
 
 # --- run one arm, pinned -----------------------------------------------------
 # Affinity is applied immediately after Start(); see caveat 2 in the header for
@@ -252,23 +272,24 @@ if ($Shapes -eq "") {
 }
 Write-Host "shapes: $Shapes"
 
-$CsvDet = Join-Path $DataDir "blocking_ab_detected.csv"
-$CsvDef = Join-Path $DataDir "blocking_ab_default.csv"
-foreach ($f in @($CsvDet, $CsvDef, "$CsvDet.sysinfo", "$CsvDef.sysinfo")) {
-    if (Test-Path $f) { Remove-Item $f -Force }
+foreach ($a in $ArmList) {
+    foreach ($f in @((Arm-Csv $a), "$(Arm-Csv $a).sysinfo")) {
+        if (Test-Path $f) { Remove-Item $f -Force }
+    }
 }
 
+# Rotate the arm order by round so every arm leads an equal share. Running one
+# arm first every round would fold warm-up, frequency ramp and thermal drift into
+# the ratio in a fixed direction; this generalises the two-arm alternation to any
+# number of arms.
 for ($round = 1; $round -le $Rounds; $round++) {
+    $shiftBy = ($round - 1) % $ArmList.Count
+    $order = @($ArmList[$shiftBy..($ArmList.Count - 1)])
+    if ($shiftBy -gt 0) { $order += @($ArmList[0..($shiftBy - 1)]) }
     foreach ($T in $ThreadList) {
         $mask = Mask-ForThreads $T
-        Write-Host ("== round {0}, T={1}, affinity mask 0x{2:x}" -f $round, $T, $mask)
-        if ($round % 2 -eq 1) {
-            Run-Arm $Det "detected" $CsvDet $mask $T $Shapes
-            Run-Arm $Def "default"  $CsvDef $mask $T $Shapes
-        } else {
-            Run-Arm $Def "default"  $CsvDef $mask $T $Shapes
-            Run-Arm $Det "detected" $CsvDet $mask $T $Shapes
-        }
+        Write-Host ("== round {0}, T={1}, affinity mask 0x{2:x}, order: {3}" -f $round, $T, $mask, ($order -join ' '))
+        foreach ($a in $order) { Run-Arm (Arm-Exe $a) $a (Arm-Csv $a) $mask $T $Shapes }
     }
 }
 
@@ -295,8 +316,8 @@ if (-not ($AfterKv -match 'thermal_after_c=')) { $AfterKv = "thermal_after_c=una
 # error that hides completely in the numbers.
 $TreeCommit  = ($PreflightKv | Select-String -Pattern '^tree_git_commit=(.+)$').Matches.Groups[1].Value
 $BuildCommit = ""
-if (Test-Path "$CsvDet.sysinfo") {
-    $m = Get-Content "$CsvDet.sysinfo" | Select-String -Pattern '^git_commit=(.+)$' | Select-Object -First 1
+if (Test-Path "$(Arm-Csv $FirstArm).sysinfo") {
+    $m = Get-Content "$(Arm-Csv $FirstArm).sysinfo" | Select-String -Pattern '^git_commit=(.+)$' | Select-Object -First 1
     if ($m) { $BuildCommit = $m.Matches.Groups[1].Value }
 }
 $Stale = "unknown"
@@ -310,7 +331,7 @@ if ($TreeCommit -and $BuildCommit -and $TreeCommit -ne "unknown" -and $BuildComm
     }
 }
 
-foreach ($s in @("$CsvDet.sysinfo", "$CsvDef.sysinfo")) {
+foreach ($s in ($ArmList | ForEach-Object { "$(Arm-Csv $_).sysinfo" })) {
     if (Test-Path $s) {
         Add-Content -Path $s -Value $PreflightKv
         Add-Content -Path $s -Value $AfterKv
@@ -323,5 +344,13 @@ foreach ($s in @("$CsvDet.sysinfo", "$CsvDef.sysinfo")) {
 }
 
 Write-Host ""
-Write-Host "wrote $CsvDet and $CsvDef (+ .sysinfo sidecars)"
-Write-Host "compare with: python benchmarks/analyze_blocking_ab.py `"$CsvDet`" `"$CsvDef`""
+Write-Host "wrote (+ .sysinfo sidecars):"
+foreach ($a in $ArmList) { Write-Host "  $(Arm-Csv $a)" }
+# Every arm against the baseline. `default` is the baseline when present -- it is
+# what MTL5 ships, so every other arm is a proposed change to it.
+$Base = if ($ArmList -contains "default") { "default" } else { $FirstArm }
+Write-Host "compare with:"
+foreach ($a in $ArmList) {
+    if ($a -eq $Base) { continue }
+    Write-Host "  python benchmarks/analyze_blocking_ab.py `"$(Arm-Csv $a)`" `"$(Arm-Csv $Base)`""
+}

--- a/benchmarks/run_blocking_ab.sh
+++ b/benchmarks/run_blocking_ab.sh
@@ -60,16 +60,42 @@ if [ -z "${OUTDIR:-}" ]; then
     exit 2
 fi
 
-DET="$BUILD_DIR/benchmarks/bench_blocking_ab_detected"
-DEF="$BUILD_DIR/benchmarks/bench_blocking_ab_default"
-for b in "$DET" "$DEF"; do
+# The arms to run, in the order they lead the first round. All are the same
+# source; they differ only in which detected cache levels feed the blocking:
+#
+#   default    none  -- the compile-time model MTL5 ships
+#   detected   L1+L2 -- kc from L1 and mc from L2
+#   kconly     L1    -- kc detected, mc from the default model
+#   mconly     L2    -- mc detected, kc from the default model
+#
+# kconly/mconly exist because the four-machine result (#430) implicated kc and
+# exonerated mc without ever varying them separately: the Ryzen run happened to
+# move mc alone and cost nothing, while both machines whose kc moved lost. Run
+# all four in ONE session and that becomes a measurement rather than a
+# cross-machine inference:  ARMS="default detected kconly mconly"
+ARMS=${ARMS:-"detected default"}
+
+ARM_BINS=""
+for a in $ARMS; do
+    b="$BUILD_DIR/benchmarks/bench_blocking_ab_$a"
     if [ ! -x "$b" ]; then
         echo "missing $b" >&2
-        echo "build with:  cmake --preset release && cmake --build $BUILD_DIR --target bench_blocking_ab_detected bench_blocking_ab_default -j4" >&2
+        echo "known arms: default detected kconly mconly" >&2
+        echo "build with:  cmake --preset release && cmake --build $BUILD_DIR --target \\" >&2
+        for x in $ARMS; do echo "                 bench_blocking_ab_$x \\" >&2; done
+        echo "                 -j4" >&2
         exit 1
     fi
+    ARM_BINS="$ARM_BINS $b"
 done
+NARMS=$(echo "$ARMS" | wc -w)
+if [ "$NARMS" -lt 2 ]; then
+    echo "ARMS needs at least two arms to compare, got '$ARMS'" >&2; exit 2
+fi
 mkdir -p "$OUTDIR"
+
+arm_bin() { echo "$BUILD_DIR/benchmarks/bench_blocking_ab_$1"; }
+arm_csv() { echo "$OUTDIR/blocking_ab_$1.csv"; }
 
 # Pin to the first T ids of BENCH_PCPUS. On a hybrid part this is also what fixes
 # WHICH cache hierarchy gets detected, so it is applied to every run including
@@ -110,35 +136,43 @@ if ! PREFLIGHT_KV=$("$SCRIPT_DIR/preflight.sh" --threads "$TMAX" --repo "$SCRIPT
     exit 1
 fi
 
-# Shapes: derived ONCE, from the detected arm, at the largest thread count (the
-# wide/short shapes depend on the thread budget). Both arms then get this list.
-SHAPES=${SHAPES:-$(taskset -c "$(pin_for "$TMAX")" "$DET" --suggest-shapes --threads "$TMAX" --dtype "$DTYPE")}
+# Shapes: derived ONCE, from the FIRST arm, at the largest thread count (the
+# wide/short shapes depend on the thread budget). Every arm then gets this list,
+# so the arms are never compared on different shapes -- each would otherwise pick
+# its own from its own mc/nc.
+FIRST_ARM=$(echo "$ARMS" | awk '{print $1}')
+SHAPES=${SHAPES:-$(taskset -c "$(pin_for "$TMAX")" "$(arm_bin "$FIRST_ARM")" \
+                       --suggest-shapes --threads "$TMAX" --dtype "$DTYPE")}
+echo "arms:   $ARMS   (shapes derived from '$FIRST_ARM')"
 echo "shapes: $SHAPES"
 
-CSV_DET="$OUTDIR/blocking_ab_detected.csv"
-CSV_DEF="$OUTDIR/blocking_ab_default.csv"
-rm -f "$CSV_DET" "$CSV_DEF" "$CSV_DET.sysinfo" "$CSV_DEF.sysinfo"
+for a in $ARMS; do rm -f "$(arm_csv "$a")" "$(arm_csv "$a").sysinfo"; done
 
-run_arm() {   # bin label csv cpus threads
-    MTL5_NUM_THREADS=$5 taskset -c "$4" "$1" \
-        --label "$2" --dtype "$DTYPE" --threads "$5" --reps "$REPS" \
-        --shapes "$SHAPES" --csv "$3"
+run_arm() {   # arm cpus threads
+    MTL5_NUM_THREADS=$3 taskset -c "$2" "$(arm_bin "$1")" \
+        --label "$1" --dtype "$DTYPE" --threads "$3" --reps "$REPS" \
+        --shapes "$SHAPES" --csv "$(arm_csv "$1")"
+}
+
+# Rotate the arm order by round, so every arm leads an equal share of rounds.
+# Running one arm first every round would fold warm-up, frequency ramp and
+# thermal drift into the ratio in a fixed direction; rotating cancels it to first
+# order, and generalises the two-arm alternation to any number of arms.
+rotated() {   # round -> the arm list rotated left by (round-1) mod NARMS
+    local shift_by=$(( ($1 - 1) % NARMS )) i=0 head="" tail=""
+    for a in $ARMS; do
+        if [ "$i" -lt "$shift_by" ]; then tail="$tail $a"; else head="$head $a"; fi
+        i=$((i + 1))
+    done
+    echo "$head$tail"
 }
 
 for round in $(seq 1 "$ROUNDS"); do
     for t in $THREADS; do
         cpus=$(pin_for "$t")
-        echo "== round $round, T=$t, cpus=$cpus"
-        # Interleaved AND order-alternated. Running one arm first every round
-        # would fold warm-up, frequency ramp and thermal drift into the ratio in
-        # a fixed direction; alternating cancels it to first order.
-        if [ $((round % 2)) -eq 1 ]; then
-            run_arm "$DET" detected "$CSV_DET" "$cpus" "$t"
-            run_arm "$DEF" default  "$CSV_DEF" "$cpus" "$t"
-        else
-            run_arm "$DEF" default  "$CSV_DEF" "$cpus" "$t"
-            run_arm "$DET" detected "$CSV_DET" "$cpus" "$t"
-        fi
+        order=$(rotated "$round")
+        echo "== round $round, T=$t, cpus=$cpus, order:$order"
+        for a in $order; do run_arm "$a" "$cpus" "$t"; done
     done
 done
 
@@ -171,7 +205,7 @@ esac
 # error, and one that hides completely in the numbers. It happened while writing
 # this very script: the first run recorded a binary two commits behind.
 TREE_COMMIT=$(printf '%s\n' "$PREFLIGHT_KV" | sed -n 's/^tree_git_commit=//p')
-BUILD_COMMIT=$(sed -n 's/^git_commit=//p' "$CSV_DET.sysinfo" 2>/dev/null | head -1)
+BUILD_COMMIT=$(sed -n 's/^git_commit=//p' "$(arm_csv "$FIRST_ARM").sysinfo" 2>/dev/null | head -1)
 STALE=unknown
 if [ -n "$TREE_COMMIT" ] && [ -n "$BUILD_COMMIT" ] && \
    [ "$TREE_COMMIT" != unknown ] && [ "$BUILD_COMMIT" != unknown ]; then
@@ -184,7 +218,8 @@ if [ -n "$TREE_COMMIT" ] && [ -n "$BUILD_COMMIT" ] && \
     fi
 fi
 
-for s in "$CSV_DET.sysinfo" "$CSV_DEF.sysinfo"; do
+for a in $ARMS; do
+    s="$(arm_csv "$a").sysinfo"
     if [ -f "$s" ]; then
         printf '%s\n%s\n' "$PREFLIGHT_KV" "$AFTER_KV" >> "$s"
         printf 'binary_stale=%s\nharness=run_blocking_ab.sh\nharness_rounds=%s\nharness_reps=%s\n' \
@@ -193,5 +228,14 @@ for s in "$CSV_DET.sysinfo" "$CSV_DEF.sysinfo"; do
 done
 
 echo
-echo "wrote $CSV_DET and $CSV_DEF (+ .sysinfo sidecars)"
-echo "compare with: benchmarks/analyze_blocking_ab.py $CSV_DET $CSV_DEF"
+echo "wrote (+ .sysinfo sidecars):"
+for a in $ARMS; do echo "  $(arm_csv "$a")"; done
+# Every arm against the baseline. `default` is the baseline when it is present --
+# it is what MTL5 ships, so every other arm is a proposed change to it.
+BASE=default
+echo "$ARMS" | grep -qw "$BASE" || BASE=$FIRST_ARM
+echo "compare with:"
+for a in $ARMS; do
+    [ "$a" = "$BASE" ] && continue
+    echo "  benchmarks/analyze_blocking_ab.py $(arm_csv "$a") $(arm_csv "$BASE")"
+done

--- a/benchmarks/run_blocking_ab.sh
+++ b/benchmarks/run_blocking_ab.sh
@@ -222,8 +222,16 @@ for a in $ARMS; do
     s="$(arm_csv "$a").sysinfo"
     if [ -f "$s" ]; then
         printf '%s\n%s\n' "$PREFLIGHT_KV" "$AFTER_KV" >> "$s"
-        printf 'binary_stale=%s\nharness=run_blocking_ab.sh\nharness_rounds=%s\nharness_reps=%s\n' \
-               "$STALE" "$ROUNDS" "$REPS" >> "$s"
+        # The INVOCATION, not just the harness name. Which cpus were pinned,
+        # which arms ran and which machine profile chose them are what make a
+        # committed CSV re-runnable; without them the numbers depend on a command
+        # line that lives only in someone's shell history.
+        printf 'binary_stale=%s\nharness=run_blocking_ab.sh\nharness_profile=%s\n' \
+               "$STALE" "${BENCH_PROFILE:-none}" >> "$s"
+        printf 'harness_rounds=%s\nharness_reps=%s\nharness_arms=%s\n' \
+               "$ROUNDS" "$REPS" "$(echo "$ARMS" | tr ' ' ',')" >> "$s"
+        printf 'harness_pcpus=%s\nharness_threads=%s\nharness_dtype=%s\n' \
+               "$BENCH_PCPUS" "$(echo "$THREADS" | tr ' ' ',')" "$DTYPE" >> "$s"
     fi
 done
 

--- a/docs/benchmarks/systems.md
+++ b/docs/benchmarks/systems.md
@@ -468,22 +468,35 @@ level feeds the blocking:
 | `mconly` | L2 | mc |
 
 Run all four in **one session**, which is what makes them comparable — the arms
-rotate order round by round, so no arm systematically leads:
+rotate order round by round, so no arm systematically leads.
+
+Each machine has a committed profile under `benchmarks/machines/`, so the pin
+list, thread counts, ISA flag and output directory are **in the repository
+rather than in someone's shell history** — and land in the sidecar as
+`harness_profile`, `harness_pcpus`, `harness_arms`:
 
 ```bash
-BENCH_PCPUS=0,2,4,6,8,10,12,14 THREADS="1 8" ROUNDS=5 \
-    ARMS="default detected kconly mconly" \
-    OUTDIR=benchmarks/data/i7-12700k ./benchmarks/run_blocking_ab.sh
-
-# then each arm against the baseline
-./benchmarks/analyze_blocking_ab.py \
-    benchmarks/data/i7-12700k/blocking_ab_{kconly,default}.csv
+benchmarks/machines/i7-12700k.sh            # P-cores 0,2,...,14, T in {1,8}
+benchmarks/machines/jetson-orin-nano.sh     # 6 cores, T in {1,6}, OUTDIR follows nvpmodel
 ```
 
 ```powershell
-pwsh benchmarks/run_blocking_ab.ps1 -Arms "default,detected,kconly,mconly" `
-     -PCores "0,2,4,6,8,10,12,14" -Threads "1,8" -Rounds 5 `
-     -Arch "/arch:AVX512" -OutDir "benchmarks\data\ryzen-9-8945hs"
+pwsh benchmarks/machines/ryzen-9-8945hs.ps1  # /arch:AVX512, 8 physical cores
+```
+
+Every profile refuses to run on a machine it does not recognise (`-Force` /
+`FORCE=1` overrides). That is not fussiness: the CSVs are named by arm and the
+runner clears them before writing, so a profile executed on the wrong host
+replaces one machine's committed evidence with another's — the #439 failure
+wearing a friendlier face. Anything can still be overridden for a one-off
+(`ROUNDS=3 ARMS="detected default" benchmarks/machines/i7-12700k.sh`), and the
+profile prints when a pin list came from the environment rather than from itself.
+
+Then compare each arm against the baseline:
+
+```bash
+./benchmarks/analyze_blocking_ab.py \
+    benchmarks/data/i7-12700k/blocking_ab_{kconly,default}.csv
 ```
 
 If `kc` is the sole cause, the product of this whole line of work is not

--- a/docs/benchmarks/systems.md
+++ b/docs/benchmarks/systems.md
@@ -456,10 +456,45 @@ mc_cache=213, the planner caps mc to 128, giving nib=8 and a perfectly balanced
 8x1 grid. **The worst remaining point is the balanced one**, so thread starvation
 is ruled out and `kc` plus L2 residency is what is left.
 
-The experiment that would settle it is a **kc-only vs mc-only** A/B on the i7:
-detect L1 alone in one arm, L2 alone in the other. If `kc` is the sole cause, the
-product of this whole line of work is not "detection off" but "detect L2, ignore
-L1" — a *win* on every machine whose mc is currently pinned at the default 64.
+The experiment that settles it is a **kc-only vs mc-only** A/B, and the harness
+now runs it. Four arms, all the same source, differing only in which detected
+level feeds the blocking:
+
+| arm | detects | moves |
+|---|---|---|
+| `default` | nothing | — (what MTL5 ships) |
+| `detected` | L1 + L2 | kc and mc |
+| `kconly` | L1 | kc |
+| `mconly` | L2 | mc |
+
+Run all four in **one session**, which is what makes them comparable — the arms
+rotate order round by round, so no arm systematically leads:
+
+```bash
+BENCH_PCPUS=0,2,4,6,8,10,12,14 THREADS="1 8" ROUNDS=5 \
+    ARMS="default detected kconly mconly" \
+    OUTDIR=benchmarks/data/i7-12700k ./benchmarks/run_blocking_ab.sh
+
+# then each arm against the baseline
+./benchmarks/analyze_blocking_ab.py \
+    benchmarks/data/i7-12700k/blocking_ab_{kconly,default}.csv
+```
+
+```powershell
+pwsh benchmarks/run_blocking_ab.ps1 -Arms "default,detected,kconly,mconly" `
+     -PCores "0,2,4,6,8,10,12,14" -Threads "1,8" -Rounds 5 `
+     -Arch "/arch:AVX512" -OutDir "benchmarks\data\ryzen-9-8945hs"
+```
+
+If `kc` is the sole cause, the product of this whole line of work is not
+"detection off" but **"detect L2, ignore L1"** — a *win* on every machine whose
+mc is currently pinned at the default 64.
+
+One thing not to over-read: mc is derived from L2 *given kc*, so `mconly` does
+not reproduce the `detected` arm's mc. On the i7, `detected` gets mc=213 from
+kc=384 while `mconly` gets mc=320 from the default kc=256. That is the honest
+question — "what does this L2 imply for the blocking we ship?" — but it means the
+four arms are not a clean 2x2 of the same numbers.
 
 ### What the older CSVs cannot tell you
 

--- a/include/mtl/simd/blocking.hpp
+++ b/include/mtl/simd/blocking.hpp
@@ -220,14 +220,75 @@ inline constexpr blocking_params default_blocking = derive_blocking<T>(width<T>)
 /// four cores, and taking that at face value sized `mc` for roughly 4x the L2 a
 /// core actually has (#432). SMT siblings are deliberately NOT counted as sharers
 /// -- see cache_info -- so a hyperthreaded machine is unaffected.
-constexpr hw_traits with_detected_caches(hw_traits base, const util::cache_info& c) {
+/// Which detected levels may override the compile-time model.
+///
+/// Separable because the four-machine A/B (#430) says the two do NOT behave
+/// alike: the Ryzen run moved mc alone (kc identical, mc 64 -> 256) and cost
+/// nothing single-threaded, while both machines whose kc moved lost throughput.
+/// L1 feeds kc and L2 feeds mc, so splitting the switch turns that observation
+/// into an experiment instead of an inference from three machines that each
+/// happened to vary something different.
+enum class detect_levels : unsigned {
+    none = 0u,
+    l1   = 1u << 0,          ///< L1d size/assoc/line -> kc
+    l2   = 1u << 1,          ///< L2 size -> mc
+    both = l1 | l2,
+};
+
+constexpr detect_levels operator|(detect_levels a, detect_levels b) {
+    return static_cast<detect_levels>(static_cast<unsigned>(a) | static_cast<unsigned>(b));
+}
+constexpr bool has_level(detect_levels set, detect_levels one) {
+    return (static_cast<unsigned>(set) & static_cast<unsigned>(one)) != 0u;
+}
+
+/// Overlay the detected hierarchy on `base`, one level group at a time.
+///
+/// line_bytes travels with the L1 group: it is read from the same descriptor,
+/// and on every machine measured so far it is 64 -- identical to the default --
+/// so it cannot confound an L1-vs-L2 comparison in practice.
+///
+/// NOTE for anyone reading a split run: mc is derived from L2 *given kc*
+/// (mc ~ l2 / (2 * kc * sizeof)), so the l2-only arm does not reproduce the mc
+/// of the both arm. On the i7 the both arm gets mc=213 from kc=384, while the
+/// l2-only arm gets mc=320 from the default kc=256. That is the honest question
+/// -- "what does this L2 imply for the blocking we ship?" -- not a defect, but
+/// it does mean the four arms are not a clean 2x2 of the same numbers.
+constexpr hw_traits with_detected_caches(hw_traits base, const util::cache_info& c,
+                                         detect_levels lv = detect_levels::both) {
     const std::size_t l1_share = c.l1d_sharing_cores ? c.l1d_sharing_cores : 1;
     const std::size_t l2_share = c.l2_sharing_cores  ? c.l2_sharing_cores  : 1;
-    if (c.l1d_bytes  != 0) base.l1_bytes   = c.l1d_bytes / l1_share;   // -> kc
-    if (c.l1d_assoc  != 0) base.l1_assoc   = c.l1d_assoc;
-    if (c.line_bytes != 0) base.line_bytes = c.line_bytes;
-    if (c.l2_bytes   != 0) base.l2_bytes   = c.l2_bytes / l2_share;    // -> mc
+    if (has_level(lv, detect_levels::l1)) {
+        if (c.l1d_bytes  != 0) base.l1_bytes   = c.l1d_bytes / l1_share;   // -> kc
+        if (c.l1d_assoc  != 0) base.l1_assoc   = c.l1d_assoc;
+        if (c.line_bytes != 0) base.line_bytes = c.line_bytes;
+    }
+    if (has_level(lv, detect_levels::l2)) {
+        if (c.l2_bytes != 0) base.l2_bytes = c.l2_bytes / l2_share;        // -> mc
+    }
     return base;
+}
+
+/// The levels this translation unit was compiled to detect.
+///
+///   MTL5_ENABLE_CACHE_DETECTION      both (unchanged meaning)
+///   MTL5_ENABLE_CACHE_DETECTION_L1   kc only  -- the A/B arm that isolates kc
+///   MTL5_ENABLE_CACHE_DETECTION_L2   mc only  -- the arm that isolates mc
+///
+/// Defining the two single-level macros together is the same as defining the
+/// original one.
+constexpr detect_levels configured_detect_levels() {
+    detect_levels lv = detect_levels::none;
+#if defined(MTL5_ENABLE_CACHE_DETECTION)
+    lv = lv | detect_levels::both;
+#endif
+#if defined(MTL5_ENABLE_CACHE_DETECTION_L1)
+    lv = lv | detect_levels::l1;
+#endif
+#if defined(MTL5_ENABLE_CACHE_DETECTION_L2)
+    lv = lv | detect_levels::l2;
+#endif
+    return lv;
 }
 
 /// Runtime cache detection is OPT-IN: define MTL5_ENABLE_CACHE_DETECTION to let
@@ -269,13 +330,13 @@ constexpr hw_traits with_detected_caches(hw_traits base, const util::cache_info&
 /// byte-identical to pre-#426 until the model is shown to win on hardware.
 /// benchmarks/run_blocking_ab.sh is how that is decided; #430 is the experiment.
 inline const hw_traits& detected_hw_traits() {
-#if defined(MTL5_ENABLE_CACHE_DETECTION)
-    static const hw_traits hw =
-        with_detected_caches(default_hw_traits, util::cached_cache_info());
-    return hw;
-#else
-    return default_hw_traits;   // constexpr object: static storage, safe to bind
-#endif
+    if constexpr (configured_detect_levels() == detect_levels::none) {
+        return default_hw_traits;   // constexpr object: static storage, safe to bind
+    } else {
+        static const hw_traits hw = with_detected_caches(
+            default_hw_traits, util::cached_cache_info(), configured_detect_levels());
+        return hw;
+    }
 }
 
 /// Blocking parameters for `T` derived against the DETECTED hardware. Use kc and

--- a/tests/unit/util/test_cache_info.cpp
+++ b/tests/unit/util/test_cache_info.cpp
@@ -307,3 +307,71 @@ TEST_CASE("a detected L1 moves nc even with L3 held fixed",
     REQUIRE(simd::runtime_blocking<double>().nc == simd::default_blocking<double>.nc);
     REQUIRE(simd::runtime_blocking<float>().nc  == simd::default_blocking<float>.nc);
 }
+
+// --- detection level groups (#430 follow-up) --------------------------------
+//
+// L1 feeds kc and L2 feeds mc, and the four-machine A/B says the two do not
+// behave alike: the Ryzen run moved mc alone (kc identical, mc 64 -> 256) at no
+// single-thread cost, while both machines whose kc moved lost throughput. That
+// was an inference across machines that each happened to vary something
+// different; splitting the switch turns it into an experiment on one machine.
+//
+// These tests pin the SEPARATION -- that each group moves its own fields and
+// leaves the other's alone -- which is the property the kconly/mconly arms rest
+// on. If it broke, both arms would still run and would quietly measure the same
+// thing.
+TEST_CASE("detection levels are separable", "[util][cache_info][blocking]") {
+    using mtl::simd::detect_levels;
+    using mtl::simd::with_detected_caches;
+
+    const simd::hw_traits def = simd::default_hw_traits;
+
+    // A machine unlike the defaults in BOTH levels, so either leak is visible.
+    util::cache_info c{};
+    c.l1d_bytes = 4 * def.l1_bytes;
+    c.l1d_assoc = def.l1_assoc + 4;
+    c.l2_bytes  = 4 * def.l2_bytes;
+    c.line_bytes = def.line_bytes;      // 64 on every machine measured so far
+    c.l1d_sharing_cores = 1;
+    c.l2_sharing_cores  = 1;
+
+    SECTION("l1 only moves the kc inputs") {
+        const auto hw = with_detected_caches(def, c, detect_levels::l1);
+        REQUIRE(hw.l1_bytes == c.l1d_bytes);
+        REQUIRE(hw.l1_assoc == c.l1d_assoc);
+        REQUIRE(hw.l2_bytes == def.l2_bytes);      // mc input untouched
+    }
+    SECTION("l2 only moves the mc input") {
+        const auto hw = with_detected_caches(def, c, detect_levels::l2);
+        REQUIRE(hw.l2_bytes == c.l2_bytes);
+        REQUIRE(hw.l1_bytes == def.l1_bytes);      // kc inputs untouched
+        REQUIRE(hw.l1_assoc == def.l1_assoc);
+    }
+    SECTION("both is the union, and the default") {
+        const auto both = with_detected_caches(def, c, detect_levels::both);
+        REQUIRE(both.l1_bytes == c.l1d_bytes);
+        REQUIRE(both.l2_bytes == c.l2_bytes);
+        // The unparameterised call is what every pre-split caller compiles to.
+        const auto implicit_both = with_detected_caches(def, c);
+        REQUIRE(implicit_both.l1_bytes == both.l1_bytes);
+        REQUIRE(implicit_both.l2_bytes == both.l2_bytes);
+    }
+    SECTION("none changes nothing") {
+        const auto hw = with_detected_caches(def, c, detect_levels::none);
+        REQUIRE(hw.l1_bytes == def.l1_bytes);
+        REQUIRE(hw.l2_bytes == def.l2_bytes);
+        REQUIRE(hw.l1_assoc == def.l1_assoc);
+    }
+    SECTION("the arms are not measuring the same thing") {
+        // The point of the split: on a machine whose caches differ from the
+        // model, kc-only and mc-only must produce DIFFERENT blocking. Same
+        // hierarchy, one level each -- if these ever agreed, the experiment
+        // would be a null run that looks like a result.
+        const auto kc_only = mtl::simd::derive_blocking<double>(
+            4, with_detected_caches(def, c, detect_levels::l1));
+        const auto mc_only = mtl::simd::derive_blocking<double>(
+            4, with_detected_caches(def, c, detect_levels::l2));
+        REQUIRE(kc_only.kc != mc_only.kc);
+        REQUIRE(kc_only.mc != mc_only.mc);
+    }
+}


### PR DESCRIPTION
## Why

#430 implicated `kc` and exonerated `mc` **without ever varying them separately**. The Ryzen run happened to move `mc` alone — `kc` identical, `mc` 64 → 256 — and cost nothing single-threaded, while both machines whose `kc` moved lost throughput. That is a cross-machine inference from three machines that each varied something different: an argument, not a measurement.

This makes it a measurement.

## The four arms

L1 feeds `kc` and L2 feeds `mc`, so detection now splits into level groups:

| arm | detects | moves |
|---|---|---|
| `default` | nothing | — (what MTL5 ships) |
| `detected` | L1 + L2 | kc and mc (unchanged meaning) |
| `kconly` | L1 | kc |
| `mconly` | L2 | mc |

`with_detected_caches` takes the levels as an **argument** rather than reading macros, so all four combinations are unit-testable without recompiling; the macros only choose what the runtime call passes.

## One session, not four

Both harnesses take an arm list and **rotate the order round by round**, generalising the old two-arm alternation — every arm leads an equal share, so warm-up and thermal drift cannot accrue to one of them:

```
== round 1, T=6, order: default detected kconly mconly
== round 2, T=6, order: detected kconly mconly default
== round 3, T=6, order: kconly mconly default detected
```

Cross-session comparison is exactly what the run contract exists to prevent, and four arms in four sessions would have reintroduced it.

## Records that don't lie

- The arm's self-report is derived from the **compiled levels**, so a `kconly` arm no longer prints "detection not enabled" at the top of its own record.
- The analyzer takes its headings and verdicts from the `arm` column in the data. With four arms any pair can be compared, and a hardcoded "detected vs default" heading would mislabel three comparisons out of four.

## Tests

They pin the property the experiment rests on: each level group moves its own fields and leaves the other's alone, and the two single-level arms derive **different** blocking on a machine unlike the model. If that broke, both arms would still run and would quietly measure the same thing — a null run wearing the clothes of a result.

## One caveat, documented

`mc` is derived from L2 *given* `kc`, so `mconly` does not reproduce the `detected` arm's `mc`. On the i7, `detected` gets mc=213 from kc=384 while `mconly` gets mc=320 from the default kc=256. That is the honest question — "what does this L2 imply for the blocking we ship?" — but the four arms are **not** a clean 2×2 of the same numbers.

## Test Results

Verified end to end on the Xeon: four arms interleaved with rotating order, every sidecar carrying the state block, and all four deriving identical blocking there — correct, since that machine's caches already match the model.

| Suite | Result |
|---|---|
| GCC | 167/167 |
| Clang | 167/167 |

## How to run it

```bash
BENCH_PCPUS=0,2,4,6,8,10,12,14 THREADS="1 8" ROUNDS=5 \
    ARMS="default detected kconly mconly" \
    OUTDIR=benchmarks/data/i7-12700k ./benchmarks/run_blocking_ab.sh
```

```powershell
pwsh benchmarks/run_blocking_ab.ps1 -Arms "default,detected,kconly,mconly" `
     -PCores "0,2,4,6,8,10,12,14" -Threads "1,8" -Rounds 5 `
     -Arch "/arch:AVX512" -OutDir "benchmarks\data\ryzen-9-8945hs"
```

If `kc` is the sole cause, the product of this line of work is not "detection off" but **"detect L2, ignore L1"** — a win on every machine whose mc is currently pinned at the default 64.

Relates to #430

Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: per-machine run profiles (`eb0f63c`)

The pin list is not a preference, it is the machine — and on the i7 it also decides *which* cache hierarchy gets detected, so a wrongly pinned run there makes the `detected` arm unreproducible rather than merely noisy (#432). That fact lived in a command line retyped per session, per machine.

`benchmarks/machines/` commits it:

```bash
benchmarks/machines/i7-12700k.sh           # P-cores 0,2,...,14, T in {1,8}
benchmarks/machines/jetson-orin-nano.sh    # 6 cores, T in {1,6}, OUTDIR follows nvpmodel
```
```powershell
pwsh benchmarks/machines/ryzen-9-8945hs.ps1   # /arch:AVX512, 8 physical cores
```

**Each refuses to run on a machine it doesn't recognise.** The CSVs are named by arm and the runner clears them before writing, so a profile executed on the wrong host replaces one machine's committed evidence with another's — the #439 failure wearing a friendlier face. Verified: both shell profiles reject this Xeon by identity.

**The Jetson's output directory follows its power mode**, read from `nvpmodel` rather than remembered — a 15 W run and a MAXN run are not comparable, and one directory is how they'd end up averaged. It also reports whether clocks are pinned, asked of sysfs (`scaling_min_freq == scaling_max_freq`) rather than `jetson_clocks --show`, which needs root on some images.

**The Zen 4 profile hardcodes `/arch:AVX512`** with the reason attached: `MTL5_NATIVE_ARCH` is a no-op under MSVC, so without the flag the run silently measures SSE2 — and completes, and prints a clean table.

**The sidecar now records the invocation**, not just the harness name:

```
harness_profile=i7-12700k
harness_arms=default,detected,kconly,mconly
harness_pcpus=0,2,4,6,8,10,12,14
harness_threads=1,8
harness_dtype=double
```

A committed CSV that cannot say which cores it was pinned to cannot be re-run, which is most of what provenance is for.

One detail worth keeping: the i7 profile prints "(P-cores only; E-cores excluded)" **only** when the pin list is its own. Annotating an overridden list with a claim the profile didn't make is the same confident-wrong-label failure the rest of this work removes.
