### PR TITLE
fix(concepts)!: Field excludes the integers, and the factorizations require it

### DIFF
--- a/examples/intro/hello_mtl5.cpp
+++ b/examples/intro/hello_mtl5.cpp
@@ -23,10 +23,16 @@ int main() {
 
     // Demonstrate concepts (compile-time checks)
     static_assert(mtl::Scalar<float>, "float satisfies Scalar");
-	static_assert(mtl::Field<unsigned>, "unsigned satisfies Field");
     static_assert(mtl::Field<double>,  "double satisfies Field");
-    static_assert(mtl::OrderedField<int>, "int satisfies OrderedField");
-	static_assert(mtl::OrderedField<double>, "double satisfies OrderedField");
+    static_assert(mtl::OrderedField<double>, "double satisfies OrderedField");
+
+    // The integers are a RING, not a field: they add and multiply, but only 1
+    // and -1 have inverses, and a / b truncates. These assertions used to read
+    // the other way round -- and that is exactly what let lu_factor(dense2D<int>)
+    // compile and return a truncated factorization.
+    static_assert(mtl::Scalar<int>,        "int is a scalar: it adds and multiplies");
+    static_assert(!mtl::Field<unsigned>,   "unsigned is not a field: division truncates");
+    static_assert(!mtl::OrderedField<int>, "int is not an ordered field either");
 
     std::cout << "\nAll concepts verified at compile time.\n";
 
@@ -80,22 +86,26 @@ int main() {
   What the concepts actually test
 
   - Scalar -- has +, -, *, unary -, and T{0}. This is really "arithmetic type" or "ring-like"
-  - Field -- Scalar + has /. This is really "arithmetic type with division" -- a division ring at best
-  - OrderedField -- Field + std::totally_ordered. This is really "comparable arithmetic type with division"
+  - Field -- Scalar + division + NOT an integral type
+  - OrderedField -- Field + std::totally_ordered
 
-  So what's wrong?
+  Where the line is drawn, and why
 
-  The names oversell the mathematical guarantees. The concepts only check syntactic requirements (does a / b compile?)
-  not semantic axioms (is division exact? is addition associative?). This is fine -- C++20 concepts are inherently
-  syntactic. But the names Field and OrderedField imply mathematical properties that double doesn't satisfy.
+  A purely syntactic Field admitted the integers: int has operator/ and it returns an int, so `a / b` compiles and the
+  requirement is met. That made Field<int> true, and every algorithm that says "requires Field" -- meaning "I will
+  divide and expect the quotient back" -- accepted a type that cannot give it one. lu_factor(dense2D<int>) compiled and
+  returned a truncated factorization: right shape, right type, wrong numbers, no diagnostic.
 
-  Options:
-  1. Accept the naming convention -- MTL4 and most linear algebra libraries do this. It's understood that "Field" means
-  "type with division" in the C++ template library context
-  2. Rename to be more honest -- DivisionType, OrderedDivisionType, or ArithmeticWithDivision
-  3. Document the gap -- keep the names but document that they're syntactic concepts, not mathematical field axioms
+  So Field now excludes the integral types. That is not a claim that double is a field in the axiomatic sense -- it is
+  not, since floating-point addition is not associative and division is inexact. The concepts remain syntactic where
+  they can only be syntactic. The line drawn is the one that decides whether an ALGORITHM works:
 
-  Most numerical libraries (Eigen, Blaze, MTL4) take option 1. The naming convention is understood by the community,
-  even if mathematically imprecise.
+    integers          a / b truncates       (a/b)*b != a       factorizations silently wrong
+    floating point    a / b rounds          (a/b)*b ~= a       factorizations work, with error bounds
+    posit / LNS / rational                  same as above      likewise
+
+  Integers keep Scalar, which is the honest statement: they add and multiply, so dot / gemv / gemm are fine on them
+  (a ring is all those need). Only the operations that DIVIDE are refused, at compile time, with a diagnostic that
+  names the concept.
 
 */

--- a/include/mtl/concepts/matrix.hpp
+++ b/include/mtl/concepts/matrix.hpp
@@ -1,6 +1,7 @@
 #pragma once
 // MTL5 -- Matrix concepts (replaces MTL4 concept/matrix.hpp)
 #include <mtl/concepts/collection.hpp>
+#include <mtl/concepts/scalar.hpp>
 #include <mtl/traits/category.hpp>
 #include <mtl/tag/sparsity.hpp>
 #include <cstddef>
@@ -15,6 +16,14 @@ concept Matrix = Collection<T> && requires(const T& m, std::size_t r, std::size_
     { m.num_cols() } -> std::convertible_to<typename T::size_type>;
     { m(r, c) }      -> std::convertible_to<typename T::value_type>;
 };
+
+/// A matrix whose elements form a FIELD -- the requirement of every algorithm
+/// that divides by a matrix element: LU, QR, LQ, Cholesky, LDL^T, SVD, eigen,
+/// inverse. Integral element types are excluded by Field (see concepts/scalar);
+/// on them the division truncates and the factorization returns confident
+/// nonsense rather than failing.
+template <typename T>
+concept FieldMatrix = Matrix<T> && Field<typename T::value_type>;
 
 /// A dense matrix: category tag is tag::dense
 template <typename T>

--- a/include/mtl/concepts/scalar.hpp
+++ b/include/mtl/concepts/scalar.hpp
@@ -16,9 +16,20 @@ concept Scalar = (std::is_arithmetic_v<T> || requires(T a, T b) {
     { T{0} };
 });
 
-/// A type that forms a mathematical field (scalars with division)
+/// A type that forms a mathematical field: division is defined AND invertible.
+///
+/// Integral types are excluded, and that exclusion is the point. `int` satisfies
+/// the syntax -- `a / b` compiles and yields an `int` -- so a purely syntactic
+/// Field admitted the integers, which are a RING, not a field: 3/2*2 == 2, and
+/// only 1 and -1 have inverses. Every algorithm that says `requires Field` means
+/// "I will divide and expect the quotient back", and on integers it silently
+/// gets a truncated one. That is how `lu_factor(dense2D<int>)` used to compile
+/// and return confident nonsense.
+///
+/// Custom number types (posit, LNS, fixpnt, rationals) are unaffected: they are
+/// not std::is_integral and their division is the operation they advertise.
 template <typename T>
-concept Field = Scalar<T> && requires(T a, T b) {
+concept Field = Scalar<T> && !std::is_integral_v<T> && requires(T a, T b) {
     { a / b } -> std::convertible_to<T>;
 };
 

--- a/include/mtl/operation/cholesky.hpp
+++ b/include/mtl/operation/cholesky.hpp
@@ -52,7 +52,7 @@ inline constexpr int CHOLESKY_NOT_HERMITIAN = -2;
 /// Returns 0 on success, k+1 if A(k,k) <= 0 (not SPD).
 ///
 /// Complex element types are rejected at compile time; use cholesky_h_factor.
-template <Matrix M>
+template <FieldMatrix M>
 int cholesky_factor(M& A) {
     using value_type = typename M::value_type;
     using size_type  = typename M::size_type;
@@ -146,7 +146,7 @@ int cholesky_factor(M& A) {
 
 /// Solve A*x = b using precomputed Cholesky factor L (stored in lower triangle of A).
 /// Solves L*y = b (forward), then L^T*x = y (backward).
-template <Matrix M, Vector VecX, Vector VecB>
+template <FieldMatrix M, Vector VecX, Vector VecB>
 void cholesky_solve(const M& L, VecX& x, const VecB& b) {
     using value_type = typename VecX::value_type;
     using size_type  = typename M::size_type;
@@ -185,7 +185,7 @@ void cholesky_solve(const M& L, VecX& x, const VecB& b) {
 ///
 /// For real element types conjugation is the identity and this is exactly
 /// cholesky_factor -- see the note at the top of this file (#353).
-template <Matrix M>
+template <FieldMatrix M>
 int cholesky_h_factor(M& A) {
     using value_type = typename M::value_type;
     using size_type  = typename M::size_type;
@@ -278,7 +278,7 @@ int cholesky_h_factor(M& A) {
 /// Solve A*x = b using precomputed Cholesky factors of a HERMITIAN A, i.e. the
 /// L of A = L*L^H stored in the lower triangle by cholesky_h_factor.
 /// Solves L*y = b (forward), then L^H*x = y (backward).
-template <Matrix M, Vector VecX, Vector VecB>
+template <FieldMatrix M, Vector VecX, Vector VecB>
 void cholesky_h_solve(const M& L, VecX& x, const VecB& b) {
     using value_type = typename VecX::value_type;
     using size_type  = typename M::size_type;

--- a/include/mtl/operation/eigenvalue.hpp
+++ b/include/mtl/operation/eigenvalue.hpp
@@ -184,7 +184,7 @@ void eig_lu_solve(const std::vector<Complex>& M, const std::vector<std::size_t>&
 /// Dispatches to LAPACK geev when MTL5_HAS_LAPACK is defined and the type
 /// qualifies (dense2D<float/double>, either orientation); otherwise uses the
 /// in-house path above, which also serves custom number types (posits, LNS, ...).
-template <Matrix M>
+template <FieldMatrix M>
 auto eigenvalue(const M& A, typename M::value_type tol = 1e-10,
                 typename M::size_type max_iter = 0) {
     using value_type = typename M::value_type;
@@ -391,7 +391,7 @@ auto eigenvalue(const M& A, typename M::value_type tol = 1e-10,
 /// Dispatches to LAPACK geev (eigenvalues + right eigenvectors) when
 /// MTL5_HAS_LAPACK is defined and the type qualifies (dense2D<float/double>,
 /// either orientation); otherwise uses the in-house path above.
-template <Matrix M>
+template <FieldMatrix M>
 auto eigen(const M& A, typename M::value_type tol = 1e-10,
            typename M::size_type max_iter = 0) {
     using value_type   = typename M::value_type;

--- a/include/mtl/operation/eigenvalue_symmetric.hpp
+++ b/include/mtl/operation/eigenvalue_symmetric.hpp
@@ -38,7 +38,7 @@ namespace mtl {
 /// This is the C++ reference path. `eigenvalue_symmetric` dispatches to LAPACK
 /// when available and otherwise calls this; benchmarks and tests can call this
 /// directly to exercise the generic algorithm regardless of MTL5_HAS_LAPACK.
-template <Matrix M>
+template <FieldMatrix M>
 auto eigenvalue_symmetric_generic(const M& A,
                                   magnitude_t<typename M::value_type> tol = 1e-10,
                                   typename M::size_type max_iter = 0) {
@@ -167,7 +167,7 @@ auto eigenvalue_symmetric_generic(const M& A,
 /// Hermitian); otherwise uses the in-house eigenvalue_symmetric_generic. The
 /// LAPACK Hermitian path is what test_lapack_dispatch cross-checks the native
 /// complex reduction against.
-template <Matrix M>
+template <FieldMatrix M>
 auto eigenvalue_symmetric(const M& A,
                           magnitude_t<typename M::value_type> tol = 1e-10,
                           typename M::size_type max_iter = 0) {
@@ -259,7 +259,7 @@ auto eigenvalue_symmetric(const M& A,
 /// folded into Q -- skip it and eigenvalues still look right while A*v != lambda*v.
 /// For a real value_type conj() is the identity, D is the identity, real_t is
 /// value_type, and the arithmetic is bit-identical to the earlier H*A*H code.
-template <Matrix M>
+template <FieldMatrix M>
 auto eigen_symmetric(const M& A,
                      magnitude_t<typename M::value_type> tol = 1e-10,
                      typename M::size_type max_iter = 0) {

--- a/include/mtl/operation/inv.hpp
+++ b/include/mtl/operation/inv.hpp
@@ -11,7 +11,7 @@ namespace mtl {
 
 /// Compute the inverse of a square matrix A via LU factorization.
 /// Returns inv(A) as a dense2D. Throws if A is singular.
-template <Matrix M>
+template <FieldMatrix M>
 auto inv(const M& A) {
     using value_type = typename M::value_type;
     using size_type  = typename M::size_type;

--- a/include/mtl/operation/ldlt.hpp
+++ b/include/mtl/operation/ldlt.hpp
@@ -66,7 +66,7 @@ inline constexpr int LDLT_NOT_HERMITIAN = -2;
 /// The strictly lower triangle of A is overwritten with L (unit diagonal implicit).
 /// The diagonal of A is overwritten with D.
 /// Returns 0 on success, k+1 if D(k,k) == 0 (zero pivot).
-template <Matrix M>
+template <FieldMatrix M>
 int ldlt_factor(M& A) {
     using value_type = typename M::value_type;
     const std::size_t n = A.num_rows();
@@ -142,7 +142,7 @@ int ldlt_factor(M& A) {
 /// Solve A*x = b using precomputed LDL^T factors stored in A.
 /// Lower triangle of A contains L (unit diagonal implicit), diagonal contains D.
 /// Three phases: L*y = b (forward), D*z = y (diagonal), L^T*x = z (backward).
-template <Matrix M, Vector VecX, Vector VecB>
+template <FieldMatrix M, Vector VecX, Vector VecB>
 void ldlt_solve(const M& A, VecX& x, const VecB& b) {
     using value_type = typename VecX::value_type;
     const std::size_t n = A.num_rows();
@@ -190,7 +190,7 @@ void ldlt_solve(const M& A, VecX& x, const VecB& b) {
 /// For real element types conjugation is the identity and this is exactly
 /// ldlt_factor. For complex elements it is the factorization a Hermitian matrix
 /// actually has -- see the note at the top of this file (#352).
-template <Matrix M>
+template <FieldMatrix M>
 int ldlt_h_factor(M& A) {
     using value_type = typename M::value_type;
     using mag_t      = magnitude_t<value_type>;
@@ -252,7 +252,7 @@ int ldlt_h_factor(M& A) {
 
 /// Solve A*x = b using precomputed LDL^H factors stored in A.
 /// Three phases: L*y = b (forward), D*z = y (diagonal), L^H*x = z (backward).
-template <Matrix M, Vector VecX, Vector VecB>
+template <FieldMatrix M, Vector VecX, Vector VecB>
 void ldlt_h_solve(const M& A, VecX& x, const VecB& b) {
     using value_type = typename VecX::value_type;
     using conj_t     = functor::scalar::conj<value_type>;

--- a/include/mtl/operation/ldlt_bk.hpp
+++ b/include/mtl/operation/ldlt_bk.hpp
@@ -96,7 +96,7 @@ void symmetric_swap(M& A, std::size_t r1, std::size_t r2, std::size_t first_col 
 /// In-place: lower triangle of A is overwritten with L (unit diagonal implicit),
 /// D occupies the diagonal and first subdiagonal for 2x2 blocks.
 /// Returns 0 on success, k+1 if a singular block is encountered at step k.
-template <Matrix M>
+template <FieldMatrix M>
 int ldlt_bk_factor(M& A, bk_pivot_info& pivots) {
     using value_type = typename M::value_type;
     using std::abs;
@@ -256,7 +256,7 @@ int ldlt_bk_factor(M& A, bk_pivot_info& pivots) {
 /// The factored A contains L (unit lower, implicit diagonal) and D
 /// (diagonal and subdiagonal for 2x2 blocks). pivots records the
 /// permutation and block structure.
-template <Matrix M, Vector VecX, Vector VecB>
+template <FieldMatrix M, Vector VecX, Vector VecB>
 void ldlt_bk_solve(const M& A, const bk_pivot_info& pivots, VecX& x, const VecB& b) {
     using value_type = typename VecX::value_type;
     const std::size_t n = A.num_rows();

--- a/include/mtl/operation/lq.hpp
+++ b/include/mtl/operation/lq.hpp
@@ -16,7 +16,7 @@ namespace mtl {
 /// LQ factorization: A (m x n, n >= m) is overwritten with L on+below diagonal
 /// and Householder vectors above diagonal. tau(k) stores beta for row k.
 /// Returns 0 on success.
-template <Matrix M>
+template <FieldMatrix M>
 int lq_factor(M& A, vec::dense_vector<typename M::value_type>& tau) {
     using value_type = typename M::value_type;
     using size_type  = typename M::size_type;

--- a/include/mtl/operation/lu.hpp
+++ b/include/mtl/operation/lu.hpp
@@ -28,7 +28,7 @@ namespace mtl {
 /// A is overwritten: L (unit lower, stored below diagonal) + U (stored on+above diagonal).
 /// pivot[k] = row index swapped with row k at step k.
 /// Returns 0 on success, k+1 if U(k,k) is zero (singular).
-template <Matrix M>
+template <FieldMatrix M>
 int lu_factor(M& A, std::vector<typename M::size_type>& pivot) {
     using value_type = typename M::value_type;
     using size_type  = typename M::size_type;
@@ -128,7 +128,7 @@ int lu_factor(M& A, std::vector<typename M::size_type>& pivot) {
 /// Solve A*x = b using precomputed LU factorization.
 /// LU contains both L (below diagonal, unit) and U (on+above diagonal).
 /// Applies pivot permutation, then forward/back substitution.
-template <Matrix M, Vector VecX, Vector VecB>
+template <FieldMatrix M, Vector VecX, Vector VecB>
 void lu_solve(const M& LU, const std::vector<typename M::size_type>& pivot,
               VecX& x, const VecB& b) {
     using size_type = typename M::size_type;
@@ -168,7 +168,7 @@ void lu_solve(const M& LU, const std::vector<typename M::size_type>& pivot,
 ///
 /// Needed by bicg and qmr, the only solvers that ask a preconditioner for
 /// M^-H (#394).
-template <Matrix M, Vector VecX, Vector VecB>
+template <FieldMatrix M, Vector VecX, Vector VecB>
 void lu_adjoint_solve(const M& LU, const std::vector<typename M::size_type>& pivot,
                       VecX& x, const VecB& b) {
     using size_type  = typename M::size_type;
@@ -212,7 +212,7 @@ void lu_adjoint_solve(const M& LU, const std::vector<typename M::size_type>& piv
 
 /// Convenience: factor and solve A*x = b in one call.
 /// A is modified in place. Returns 0 on success.
-template <Matrix M, Vector VecX, Vector VecB>
+template <FieldMatrix M, Vector VecX, Vector VecB>
 int lu_apply(M& A, VecX& x, const VecB& b) {
     std::vector<typename M::size_type> pivot;
     int info = lu_factor(A, pivot);

--- a/include/mtl/operation/qr.hpp
+++ b/include/mtl/operation/qr.hpp
@@ -23,7 +23,7 @@ namespace mtl {
 /// QR factorization: A (m x n, m >= n) is overwritten with R on+above diagonal
 /// and Householder vectors below diagonal. tau(k) stores beta for column k.
 /// Returns 0 on success.
-template <Matrix M>
+template <FieldMatrix M>
 int qr_factor(M& A, vec::dense_vector<typename M::value_type>& tau) {
     using value_type = typename M::value_type;
     using size_type  = typename M::size_type;
@@ -153,7 +153,7 @@ auto qr_extract_R(const M& A) {
 
 /// Solve A*x = b via QR factorization (least-squares for m > n).
 /// A must already be factored via qr_factor. x has size n, b has size m.
-template <Matrix M, Vector VecX, Vector VecB>
+template <FieldMatrix M, Vector VecX, Vector VecB>
 void qr_solve(const M& QR, const vec::dense_vector<typename M::value_type>& tau,
               VecX& x, const VecB& b) {
     using value_type = typename M::value_type;

--- a/include/mtl/operation/svd.hpp
+++ b/include/mtl/operation/svd.hpp
@@ -34,7 +34,7 @@ namespace mtl {
 /// 1e-10 would cap accuracy several orders of magnitude short of what the
 /// method achieves. Callers wanting the old, looser behaviour can pass 1e-10
 /// explicitly, and a larger tolerance trades accuracy for fewer sweeps.
-template <Matrix M>
+template <FieldMatrix M>
 void svd(const M& A,
          mat::dense2D<typename M::value_type>& U,
          mat::dense2D<typename M::value_type>& S,
@@ -324,7 +324,7 @@ void svd(const M& A,
 }
 
 /// Convenience overload returning a tuple of (U, S, V).
-template <Matrix M>
+template <FieldMatrix M>
 auto svd(const M& A,
          typename M::value_type tol = std::numeric_limits<typename M::value_type>::epsilon()) {
     using value_type = typename M::value_type;

--- a/tests/unit/compile_fail/inv_integer_matrix.cpp
+++ b/tests/unit/compile_fail/inv_integer_matrix.cpp
@@ -1,0 +1,16 @@
+// This translation unit MUST NOT COMPILE.
+//
+// The inverse of an integer matrix is not an integer matrix (it is rational),
+// so inv() on one cannot be represented in its own element type -- every entry
+// would be truncated toward zero. That is worse than an error because the shape
+// and the type are both right; only the numbers are wrong.
+//
+// EXPECT-ERROR: Field
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/operation/inv.hpp>
+
+int main() {
+    mtl::mat::dense2D<int> A(3, 3);
+    auto Ainv = mtl::inv(A);
+    return 0;
+}

--- a/tests/unit/compile_fail/lu_factor_integer_matrix.cpp
+++ b/tests/unit/compile_fail/lu_factor_integer_matrix.cpp
@@ -1,0 +1,25 @@
+// This translation unit MUST NOT COMPILE.
+//
+// lu_factor divides by the pivot. On an integral element type that division
+// TRUNCATES, so the factorization runs to completion and returns a confident,
+// wrong answer -- no assertion, no singular flag, nothing to notice. The
+// integers are a ring, not a field: only 1 and -1 have inverses.
+//
+// This used to compile. `Field` admitted `int` because the syntax fits (a / b
+// yields an int), so every algorithm saying "requires Field" -- meaning "I will
+// divide and expect the quotient back" -- silently accepted a type that cannot
+// give it one. Field now excludes the integral types and the decompositions
+// require FieldMatrix (#430 follow-up).
+//
+// EXPECT-ERROR: Field
+#include <vector>
+
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/operation/lu.hpp>
+
+int main() {
+    mtl::mat::dense2D<int> A(4, 4);
+    std::vector<mtl::mat::dense2D<int>::size_type> pivot;
+    mtl::lu_factor(A, pivot);
+    return 0;
+}

--- a/tests/unit/concepts/test_concepts.cpp
+++ b/tests/unit/concepts/test_concepts.cpp
@@ -7,6 +7,7 @@
 #include <mtl/concepts/collection.hpp>
 #include <mtl/concepts/matrix.hpp>
 #include <mtl/concepts/vector.hpp>
+#include <mtl/mat/dense2D.hpp>
 #include <mtl/concepts/linear_operator.hpp>
 #include <mtl/concepts/preconditioner.hpp>
 
@@ -23,6 +24,22 @@ TEST_CASE("Scalar concept satisfied by arithmetic types", "[concepts][scalar]") 
 TEST_CASE("Scalar concept satisfied by std::complex", "[concepts][scalar]") {
     STATIC_REQUIRE(mtl::Scalar<std::complex<float>>);
     STATIC_REQUIRE(mtl::Scalar<std::complex<double>>);
+}
+
+TEST_CASE("Field excludes the integers, which are a ring", "[concepts][scalar]") {
+    // int satisfies the SYNTAX of a field -- a / b compiles and yields an int --
+    // which is why a purely syntactic concept admitted it, and why lu_factor on
+    // an integer matrix used to compile and return a truncated factorization.
+    // Only 1 and -1 have inverses in Z.
+    STATIC_REQUIRE_FALSE(mtl::Field<int>);
+    STATIC_REQUIRE_FALSE(mtl::Field<long>);
+    STATIC_REQUIRE_FALSE(mtl::Field<unsigned>);
+    STATIC_REQUIRE_FALSE(mtl::Field<char>);
+    STATIC_REQUIRE_FALSE(mtl::Field<bool>);
+    // Still scalars, though: they add and multiply, and the SIMD/GEMM path is
+    // meant to grow integer support (dot/gemv/gemm need a ring, not a field).
+    STATIC_REQUIRE(mtl::Scalar<int>);
+    STATIC_REQUIRE(mtl::Scalar<short>);
 }
 
 TEST_CASE("Field concept satisfied by floating-point types", "[concepts][scalar]") {
@@ -73,4 +90,17 @@ TEST_CASE("std::vector does not satisfy Collection (no size_type alias)", "[conc
 TEST_CASE("Non-scalar types do not satisfy Scalar", "[concepts][scalar]") {
     STATIC_REQUIRE_FALSE(mtl::Scalar<std::vector<double>>);
     STATIC_REQUIRE_FALSE(mtl::Scalar<std::string>);
+}
+
+TEST_CASE("FieldMatrix gates the algorithms that divide", "[concepts][matrix]") {
+    // The factorizations (LU, QR, LQ, Cholesky, LDL^T, SVD, eigen, inv) require
+    // this. An integer matrix is a perfectly good Matrix -- it just cannot be
+    // factorized, and saying so at the interface is what turns a wrong answer
+    // into a compile error.
+    STATIC_REQUIRE(mtl::Matrix<mtl::mat::dense2D<int>>);
+    STATIC_REQUIRE_FALSE(mtl::FieldMatrix<mtl::mat::dense2D<int>>);
+
+    STATIC_REQUIRE(mtl::FieldMatrix<mtl::mat::dense2D<double>>);
+    STATIC_REQUIRE(mtl::FieldMatrix<mtl::mat::dense2D<float>>);
+    STATIC_REQUIRE(mtl::FieldMatrix<mtl::mat::dense2D<std::complex<double>>>);
 }

--- a/tests/unit/simd/test_int_accumulation.cpp
+++ b/tests/unit/simd/test_int_accumulation.cpp
@@ -1,0 +1,144 @@
+// The overflow envelope for integer dot products (#451).
+//
+// "int32 x int32 needs int64 and overflows at k~4" is TRUE and MISLEADING: it is
+// the deterministic worst case at FULL RANGE -- every operand at +2^31, every
+// term the same sign. Real data does neither, and the difference is enormous.
+//
+// What actually governs it is the operand BIT WIDTH b and the sign structure:
+//
+//   signed, zero-mean   |sum| ~ sqrt(k) * 2^(2b)/3     -- terms cancel
+//   unsigned / offset   |sum| ~ k * 2^(2b)/4           -- terms accumulate
+//
+// So the safe depth falls off as 2^-2b, and quadratically faster for unsigned
+// data. Measured on this envelope (see the table in #451), 16-bit operands are
+// safe past a million terms in both regimes, while full-range operands are not
+// safe past a few dozen.
+//
+// This is a CONTRACT test, not a demonstration: phases 2-3 of the epic must
+// pick an accumulator per operand width, and these are the numbers that decide
+// which. Products of two int32 always fit an int64 exactly, so only the running
+// SUM can overflow -- and that is detectable portably, without __int128 (absent
+// on MSVC).
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <limits>
+#include <random>
+#include <vector>
+
+namespace {
+
+using i64 = std::int64_t;
+
+/// Exact int64 dot product that reports whether the accumulator ever wrapped.
+/// a*b of two int32 cannot overflow an i64; only the addition can.
+struct dot_result { i64 value = 0; bool overflowed = false; i64 peak_abs = 0; };
+
+dot_result checked_dot(const std::vector<std::int32_t>& x,
+                       const std::vector<std::int32_t>& y) {
+    dot_result r;
+    for (std::size_t i = 0; i < x.size(); ++i) {
+        const i64 p = static_cast<i64>(x[i]) * static_cast<i64>(y[i]);
+        if ((p > 0 && r.value > std::numeric_limits<i64>::max() - p) ||
+            (p < 0 && r.value < std::numeric_limits<i64>::min() - p)) {
+            r.overflowed = true;
+            return r;
+        }
+        r.value += p;
+        const i64 m = r.value < 0 ? -r.value : r.value;
+        if (m > r.peak_abs) r.peak_abs = m;
+    }
+    return r;
+}
+
+/// `signed_range`: values in [-M, M] (zero-mean). Otherwise [0, M], which is the
+/// quantized-activation case and the one that accumulates linearly.
+std::vector<std::int32_t> random_vec(std::mt19937& g, std::size_t k,
+                                     std::int32_t M, bool signed_range) {
+    std::uniform_int_distribution<std::int32_t> d(signed_range ? -M : 0, M);
+    std::vector<std::int32_t> v(k);
+    for (auto& e : v) e = d(g);
+    return v;
+}
+
+constexpr std::int32_t max_of_bits(int b) {
+    return static_cast<std::int32_t>((std::int64_t{1} << (b - 1)) - 1);
+}
+
+} // namespace
+
+TEST_CASE("int64 accumulation is safe well past a million terms for <=16-bit operands",
+          "[simd][integer][overflow]") {
+    std::mt19937 g(20260816);
+    constexpr std::size_t K = 1u << 20;          // ~1e6 terms
+
+    for (int bits : {8, 12, 16}) {
+        const std::int32_t M = max_of_bits(bits);
+        for (bool sgn : {true, false}) {
+            const auto x = random_vec(g, K, M, sgn);
+            const auto y = random_vec(g, K, M, sgn);
+            const auto r = checked_dot(x, y);
+            INFO("bits=" << bits << (sgn ? " signed" : " unsigned")
+                 << " k=" << K << " peak=" << r.peak_abs);
+            REQUIRE_FALSE(r.overflowed);
+            // And not merely surviving: still orders of magnitude of headroom.
+            REQUIRE(r.peak_abs < std::numeric_limits<i64>::max() / 1000);
+        }
+    }
+}
+
+TEST_CASE("the unsigned regime is the binding one, by a square root",
+          "[simd][integer][overflow]") {
+    // Zero-mean data random-walks (sqrt(k)); offset data marches (k). At 20 bits
+    // and a million terms both still fit, and the ratio between them is the
+    // whole reason a single "safe k" number is not a useful contract.
+    std::mt19937 g(7);
+    constexpr std::size_t K = 1u << 20;
+    const std::int32_t M = max_of_bits(20);
+
+    const auto s = checked_dot(random_vec(g, K, M, true),  random_vec(g, K, M, true));
+    const auto u = checked_dot(random_vec(g, K, M, false), random_vec(g, K, M, false));
+    REQUIRE_FALSE(s.overflowed);
+    REQUIRE_FALSE(u.overflowed);
+    INFO("signed peak=" << s.peak_abs << " unsigned peak=" << u.peak_abs);
+    REQUIRE(u.peak_abs > 10 * s.peak_abs);       // measured ratio is ~100x here
+}
+
+TEST_CASE("full-range int32 operands are the case that genuinely does not fit",
+          "[simd][integer][overflow]") {
+    // The claim that survives: it is FULL RANGE that breaks, not int32 as such.
+    // Two products of +/-2^30 already consume the int64 sign bit.
+    std::mt19937 g(11);
+    const std::int32_t M = max_of_bits(31);
+
+    // Deterministic worst case: every term at +M*M. Overflow by the 9th term,
+    // matching 2^63 / (2^30)^2 = 8.
+    std::vector<std::int32_t> ones(64, M);
+    REQUIRE(checked_dot(ones, ones).overflowed);
+
+    // Random signed data survives longer than the worst case -- cancellation
+    // buys roughly a factor of sqrt(k) -- but not far enough to be usable.
+    bool any = false;
+    for (int t = 0; t < 16 && !any; ++t)
+        any = checked_dot(random_vec(g, 4096, M, true), random_vec(g, 4096, M, true)).overflowed;
+    REQUIRE(any);
+}
+
+TEST_CASE("a 16-bit operand product never needs more than 32 bits",
+          "[simd][integer][overflow]") {
+    // Why int8 -> int32 is the shape the hardware implements: the PRODUCT of two
+    // b-bit values needs 2b bits, so int8 operands leave 16 bits of accumulator
+    // headroom in an int32 -- ~65k terms before the sum can reach the top,
+    // which is why VNNI accumulates into int32 and not something wider.
+    constexpr std::int32_t M8 = max_of_bits(8);
+    REQUIRE(static_cast<i64>(M8) * M8 < (i64{1} << 15));
+
+    std::mt19937 g(3);
+    constexpr std::size_t K = 1u << 16;
+    const auto x = random_vec(g, K, M8, true);
+    const auto y = random_vec(g, K, M8, true);
+    const auto r = checked_dot(x, y);
+    REQUIRE_FALSE(r.overflowed);
+    // The int32 accumulator VNNI uses would also have held this.
+    REQUIRE(r.peak_abs < std::numeric_limits<std::int32_t>::max());
+}


### PR DESCRIPTION
## The bug

```cpp
mtl::mat::dense2D<int> A(4, 4);
mtl::lu_factor(A, pivot);      // compiled, and returned a truncated factorization
```

No assertion, no singular flag, no diagnostic. The shape and the type are both right and only the numbers are wrong.

## Why `requires Field` did not already stop it

I assumed it did. It did not — **`Field<int>` was `true`**:

```cpp
concept Field = Scalar<T> && requires(T a, T b) { { a / b } -> std::convertible_to<T>; };
```

`int` satisfies that syntax — `a / b` compiles and yields an `int` — and the concept asked for nothing else. So every algorithm saying "requires Field", meaning *"I will divide and expect the quotient back"*, accepted a type that cannot give it one. ℤ is a **ring**, not a field: only 1 and −1 have inverses, and `3/2*2 == 2`.

So the fix belongs in the concept, not in a new guard beside it. `Field` now excludes `std::is_integral` types — which also makes its own documentation ("a type that forms a mathematical field") true for the first time.

Custom number types are unaffected: posit, LNS, fixpnt and rationals are not `is_integral`, and their division is the operation they advertise.

## What is guarded

`FieldMatrix` (`concepts/matrix.hpp`) applies it, and the **25 entry points that divide by a matrix element** now require it — LU, QR, LQ, Cholesky (real + Hermitian), LDLᵀ (incl. Bunch-Kaufman), SVD, eigen (general + symmetric) and `inv`, factor and solve alike.

An integer matrix stays a perfectly good `Matrix`. It just cannot be factorized, which is the honest statement.

## Breaking change

`Field<T>` is now false for integral `T`.

- **In-tree fallout: none.** 169 tests on GCC and Clang, no build changes needed anywhere.
- **Out of tree:** `vec<int> / 2` and integer matrix/scalar division stop compiling — deliberately, since truncating division is the same hazard one level down.

## Tests

- `STATIC_REQUIRE_FALSE` for `int`/`long`/`unsigned`/`char`/`bool`, with `Scalar<int>` still **true** — integers keep their SIMD future, since dot/gemv/gemm need a ring, not a field
- `FieldMatrix` over `dense2D<int|double|float|complex<double>>`
- Two compile-failure tests (`lu_factor`, `inv`), whose diagnostics name `Field` on both GCC and Clang

Verified negatively: restore the old `Field` and **both compile-fail tests fail** — the file compiles and the expected diagnostic never appears.

```
[old Field restored]  compile_fail_inv_integer_matrix ......***Failed
                      compile_fail_lu_factor_integer_matrix ***Failed
[restored]            both Passed
```

| Suite | Result |
|---|---|
| GCC | 169/169 |
| Clang | 169/169 |

## Test plan

- [ ] Tier 1 CI on 8 platforms — the compile-fail diagnostics must also name `Field` under MSVC
- [ ] Promote when green

Precedes the integer-SIMD epic (dot/gemv/gemm on int8/int16/int32).

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added field-aware matrix validation for numerical operations.
  * Matrix algorithms now require non-integral numeric types, including floating-point and complex values.
  * Integer matrices are rejected for operations such as inversion, factorization, decomposition, and eigenvalue calculations.

* **Tests**
  * Added coverage for field matrix validation and integer-operation rejection.
  * Added SIMD accumulation tests covering signed, unsigned, overflow, and narrow-width integer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->