### PR TITLE
test(sparse): move the KLU timing claim to the tier that can measure it

### DIFF
--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -48,4 +48,9 @@ if(ITL_REG_SRC)
     add_regression_tests("itl" "itl" "${ITL_REG_SRC}")
     set_tests_properties(regression_itl_test_cg PROPERTIES TIMEOUT 600)
     set_tests_properties(regression_itl_test_bicgstab PROPERTIES TIMEOUT 600)
+    # gmres belongs with them and was missed: it takes 8m06s on a Xeon E5-2420 v2
+    # (486 s), so it TIMES OUT at the 300 s default on any machine slower than a
+    # CI runner -- which makes the regression tier unrunnable locally for the
+    # people most likely to run it. It passes comfortably at 600.
+    set_tests_properties(regression_itl_test_gmres PROPERTIES TIMEOUT 600)
 endif()

--- a/tests/regression/sparse/test_klu_scaling.cpp
+++ b/tests/regression/sparse/test_klu_scaling.cpp
@@ -1,0 +1,97 @@
+// Native KLU: the wall-clock scaling claim, in the tier built for it (#454).
+//
+// The unit suite asserts that FILL grows sub-quadratically, which is the
+// deterministic observable and needs no clock. This is the complementary claim
+// -- that the *time* follows it, i.e. the implementation is not doing extra
+// asymptotic work the fill count cannot see -- and it belongs here rather than
+// in the fast tier for reasons that are measurement, not taste:
+//
+//   * this tier is gated behind MTL5_BUILD_REGRESSION_TESTS and runs Tier 2 on
+//     Linux GCC only, not on the shared macOS runners where the old assertion
+//     failed on a PR that changed no C++
+//   * 300 s timeouts leave room to take REPEATED samples, so the statistic can
+//     be a minimum rather than a single draw
+//
+// That second point is the substance. The retired assertion divided one timing
+// by another, doubling the variance of an already noisy quantity: sampled three
+// times on an idle machine it moved 5.24, 5.91, 6.87 -- 31% -- and CI produced
+// 15.0 against a threshold of 13.0. A minimum over several reps is the standard
+// fix (the benchmark harness in benchmarks/ uses it throughout: the minimum is
+// the least contaminated sample, where a mean folds in every interruption).
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <vector>
+
+#include <mtl/mat/compressed2D.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/generators/poisson.hpp>
+#include <mtl/sparse/factorization/native_klu.hpp>
+
+using namespace mtl;
+
+namespace {
+
+/// Minimum wall-clock over `reps` factor+solve rounds, in milliseconds.
+double min_factor_solve_ms(const mat::compressed2D<double>& A, int reps) {
+    const std::size_t n = A.num_rows();
+    vec::dense_vector<double> ones(n, 1.0), b(n, 0.0);
+
+    const auto& rp = A.ref_major();
+    const auto& ci = A.ref_minor();
+    const auto& dat = A.ref_data();
+    for (std::size_t r = 0; r < n; ++r) {
+        double s = 0.0;
+        for (std::size_t k = rp[r]; k < rp[r + 1]; ++k)
+            s += dat[k] * ones(static_cast<int>(ci[k]));
+        b(static_cast<int>(r)) = s;
+    }
+
+    double best = 0.0;
+    for (int i = 0; i < reps; ++i) {
+        vec::dense_vector<double> x(n, 0.0);
+        const auto t0 = std::chrono::steady_clock::now();
+        auto fac = sparse::factorization::native_klu_factor(A);
+        fac.solve(x, b);
+        const auto t1 = std::chrono::steady_clock::now();
+        const double ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+        if (i == 0 || ms < best) best = ms;
+    }
+    return best;
+}
+
+} // namespace
+
+TEST_CASE("native KLU factor+solve time grows sub-quadratically",
+          "[sparse][klu][native][scaling][regression]") {
+    constexpr int REPS = 3;
+    struct Row { std::size_t N, n; double ms; };
+    std::vector<Row> rows;
+
+    for (std::size_t N : {64u, 128u, 256u}) {
+        auto A = generators::poisson2d_dirichlet<double>(N, N);
+        const double ms = min_factor_solve_ms(A, REPS);
+        UNSCOPED_INFO("Poisson " << N << "x" << N << "  n=" << A.num_rows()
+                      << "  min of " << REPS << ": " << ms << " ms");
+        rows.push_back({N, A.num_rows(), ms});
+    }
+
+    // n quadruples per refinement. An O(n^2) factorization would grow ~16x per
+    // step; O(n^1.5) is ~8x, and the measured figure is 5-7x. The threshold sits
+    // between the two hypotheses rather than close to the measurement, so it
+    // discriminates the thing it names -- an asymptotic regression -- and not the
+    // machine's mood.
+    for (std::size_t i = 1; i < rows.size(); ++i) {
+        const double ratio = rows[i].ms / rows[i - 1].ms;
+        INFO("n " << rows[i - 1].n << " -> " << rows[i].n
+             << " (4x): time ratio " << ratio);
+        REQUIRE(ratio < 13.0);
+    }
+
+    // Sanity: the run must be long enough for the ratio to mean anything. A
+    // sub-millisecond baseline would make the quotient a timer-resolution
+    // artefact -- the failure mode that a threshold alone does not catch.
+    REQUIRE(rows.front().ms > 1.0);
+}

--- a/tests/unit/sparse/test_native_klu.cpp
+++ b/tests/unit/sparse/test_native_klu.cpp
@@ -212,14 +212,32 @@ TEST_CASE("native KLU on 2D Poisson scales sub-quadratically",
           "[sparse][klu][native][scaling][poisson]") {
     // 2D Poisson (5-point Laplacian) is the canonical fill-test matrix. With a
     // good ordering its factorization is O(n^1.5) flops / O(n log n) fill -- not
-    // literally O(nnz), but far from the old O(n^2) blowup. As the grid refines,
-    // n quadruples per step; an O(n^2) implementation would grow time ~16x per
-    // step. We solve 32x32, 64x64, 128x128, 256x256 grids, check the relative
-    // residual, and assert both time and factor fill grow sub-quadratically.
+    // literally O(nnz), but far from the old O(n^2) blowup. As the grid refines
+    // n quadruples per step, and an O(n^2) implementation would grow FILL ~16x
+    // per step. We solve 32x32, 64x64 and 128x128 grids, check the relative
+    // residual, and assert the factor fill grows sub-quadratically.
+    //
+    // FILL, NOT TIME. This test used to assert a wall-clock ratio as well
+    // (#454). It could not be stable: a ratio of two single timings, against a
+    // threshold only ~2x above the expected value, in the tier that gates every
+    // PR on shared cloud runners. Sampled three times on an IDLE machine the
+    // statistic itself moved 31% (5.24, 5.91, 6.87), and CI produced 15.0
+    // against a limit of 13.0 on a PR that changed no C++ at all.
+    //
+    // Nothing algorithmic was lost by removing it, because fill is the
+    // DETERMINISTIC observable of the same property: a sparse factorization's
+    // asymptotic cost is driven by fill growth, and the clock measures fill plus
+    // noise. The timing claim now lives in the regression tier
+    // (tests/regression/sparse/test_klu_scaling.cpp), which is gated, runs on
+    // one controlled platform, and takes a minimum of several samples per size.
+    //
+    // Dropping the 256x256 grid with it takes this test from ~10 s to ~1.5 s.
+    // The fill ratio is a per-refinement quantity, so 64 -> 128 tests it exactly
+    // as well as 128 -> 256 did.
     struct Row { std::size_t N, n, nnz, fill; double time_ms; };
     std::vector<Row> rows;
 
-    for (std::size_t N : {32u, 64u, 128u, 256u}) {
+    for (std::size_t N : {32u, 64u, 128u}) {
         auto A = generators::poisson2d_dirichlet<double>(N, N);
         std::size_t n = A.num_rows();
 
@@ -255,17 +273,10 @@ TEST_CASE("native KLU on 2D Poisson scales sub-quadratically",
             << "  time=" << r.time_ms << " ms");
 
     // Fill is deterministic: O(n log n)-ish, so each 4x-n refinement grows fill
-    // well under the 16x an O(n^2) factorization would require.
+    // well under the 16x an O(n^2) factorization would require. No clock is
+    // involved, so this holds identically on a loaded runner.
     double fill_ratio = double(rows.back().fill) / double(rows[rows.size() - 2].fill);
     REQUIRE(fill_ratio < 8.0);
-
-    // Time growth over the last refinement (n quadruples). Measured ~7-8x
-    // (O(n^1.5)); an O(n^2) factorization would be ~16x. A ratio cancels the
-    // build-dependent per-op constant, so this is stable across Debug/Release/
-    // sanitizer builds, unlike an absolute wall-clock ceiling. Both timings are
-    // large (tens-to-hundreds of ms), so jitter is small.
-    double time_ratio = rows.back().time_ms / rows[rows.size() - 2].time_ms;
-    REQUIRE(time_ratio < 13.0);
 }
 
 TEST_CASE("native KLU refactor reuses structure for same-pattern matrices",


### PR DESCRIPTION
## Summary

Resolves #454. A wall-clock ratio gated every PR and could not be stable — it failed on macOS on a PR that changed **no C++ at all** (14.997 against a limit of 13.0).

The statistic is unstable by construction: one timing divided by another, single samples, a threshold only ~2× above the expected value, on shared cloud runners. Sampled three times on an **idle** machine it moved 31%:

```
5.24   5.91   6.87      threshold 13.0, CI observed 15.00
```

## The unit tier keeps the deterministic claim

Fill is the observable the timing was a proxy for — a sparse factorization's asymptotic cost is driven by fill growth, and the clock measures fill plus noise. `fill_ratio < 8.0` was already there, **four lines above** the assertion that flaked, so removing the timing costs no algorithmic coverage.

Dropping the 256×256 grid with it:

| | before | after |
|---|---|---|
| `sparse_test_native_klu` | 10.19 s | **1.49 s** |

The fill ratio is per-refinement, so 64 → 128 tests it exactly as well as 128 → 256 did.

## The regression tier gets a *stricter* version

Not merely a quieter one. It is gated behind `MTL5_BUILD_REGRESSION_TESTS`, runs Tier 2 on Linux GCC rather than hosted macOS, and its 300 s budget leaves room to measure properly:

- **minimum of 3 samples** per size rather than a single draw — the minimum is the least contaminated sample, which is what `benchmarks/` has used throughout
- **both** refinement steps checked, not just the last
- the baseline must exceed 1 ms, so the ratio cannot degenerate into a timer-resolution artefact — the failure a threshold alone does not catch

Measured with min-of-3:

```
Poisson  64x64   n=4096    min of 3:   20.24 ms
Poisson 128x128  n=16384   min of 3:  144.45 ms     ratio 7.14
Poisson 256x256  n=65536   min of 3:  966.38 ms     ratio 6.69
```

against a threshold of 13.0 — which sits **between** the O(n^1.5) and O(n²) hypotheses rather than beside the measurement, so it discriminates an asymptotic regression and not the machine's mood.

## Also: `regression_itl_test_gmres` gets the 600 s timeout its siblings have

It was missed when `cg` and `bicgstab` were raised, and it takes **8m06s** on a Xeon E5-2420 v2 — so the regression tier is unrunnable locally on any machine slower than a CI runner, which is the wrong way round. Verified pre-existing by reproducing it with these changes stashed.

## Test Results

| Suite | Result |
|---|---|
| GCC unit | 170/170 |
| Clang unit | 170/170 |
| `regression_sparse_test_klu_scaling` | passes, 3.7 s |

Resolves #454

Generated with [Claude Code](https://claude.com/claude-code)
