### PR TITLE
perf(simd): bound mc by the C strip at runtime, as a measurable arm

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -50,11 +50,30 @@ set_target_properties(bench_sparse PROPERTIES FOLDER "Benchmarks")
 #
 # All four are the SAME source; only the macro differs, so any difference in
 # throughput is a difference in blocking.
-set(_ab_arms      default        detected                        kconly                             mconly)
-set(_ab_arm_defs  ""             MTL5_ENABLE_CACHE_DETECTION     MTL5_ENABLE_CACHE_DETECTION_L1     MTL5_ENABLE_CACHE_DETECTION_L2)
-foreach(_i RANGE 3)
-    list(GET _ab_arms     ${_i} _arm)
-    list(GET _ab_arm_defs ${_i} _def)
+# `ccap` is the #453 arm: L2 detection PLUS the runtime C-strip bound on mc. It
+# is deliberately mconly + the cap, so `ccap` vs `mconly` isolates the cap and
+# `ccap` vs `default` answers the shipped question.
+# One if-chain rather than two parallel lists: an arm needs TWO defines, and a
+# ";"-joined list element is silently FLATTENED into the outer list by CMake, so
+# the parallel-list form shifted every later index and handed `ccap` only half
+# its configuration. It still built and ran, reporting "L2 only" -- a
+# misconfigured arm that looks like a working one, which is the failure this
+# whole benchmark tree exists to make impossible.
+set(_ab_arms default detected kconly mconly ccap)
+foreach(_arm ${_ab_arms})
+    if(_arm STREQUAL "default")
+        set(_def "")
+    elseif(_arm STREQUAL "detected")
+        set(_def MTL5_ENABLE_CACHE_DETECTION)
+    elseif(_arm STREQUAL "kconly")
+        set(_def MTL5_ENABLE_CACHE_DETECTION_L1)
+    elseif(_arm STREQUAL "mconly")
+        set(_def MTL5_ENABLE_CACHE_DETECTION_L2)
+    elseif(_arm STREQUAL "ccap")
+        set(_def MTL5_ENABLE_CACHE_DETECTION_L2 MTL5_GEMM_C_STRIP_CAP)
+    else()
+        message(FATAL_ERROR "no defines configured for A/B arm '${_arm}'")
+    endif()
     add_executable(bench_blocking_ab_${_arm} bench_blocking_ab.cpp)
     target_link_libraries(bench_blocking_ab_${_arm} PRIVATE MTL5::mtl5)
     target_include_directories(bench_blocking_ab_${_arm} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/benchmarks/bench_blocking_ab.cpp
+++ b/benchmarks/bench_blocking_ab.cpp
@@ -219,6 +219,13 @@ int main(int argc, char** argv) {
           : mtl::simd::has_level(lv, detect_levels::l1) ? "L1 only -- kc detected, mc from the default model"
           :                                              "L2 only -- mc detected, kc from the default model";
         std::fprintf(stderr, "  cache detection: %s\n", what);
+#if defined(MTL5_GEMM_C_STRIP_CAP)
+        // The cap changes mc per CALL, so an arm carrying it must say so: two
+        // arms with the same kc/mc line and different behaviour is precisely
+        // what the identical-arm integrity check reads as a broken session.
+        std::fprintf(stderr, "  mc bound: C-strip cap ON -- mc also bounded by "
+                             "L2 / ((kc + min(n,nc)) * sizeof) per call (#453)\n");
+#endif
     }
     std::fprintf(stderr, "  fp64 mr=%zu nr=%zu kc=%zu mc=%zu nc=%zu\n",
                  bpd.mr, bpd.nr, bpd.kc, bpd.mc, bpd.nc);

--- a/benchmarks/run_blocking_ab.ps1
+++ b/benchmarks/run_blocking_ab.ps1
@@ -70,6 +70,7 @@ param(
     #   detected L1+L2  -- kc from L1, mc from L2
     #   kconly   L1     -- kc detected, mc from the default model
     #   mconly   L2     -- mc detected, kc from the default model
+    #   ccap     L2     -- mconly PLUS the runtime C-strip bound on mc (#453)
     # kconly/mconly exist because #430 implicated kc and exonerated mc without
     # ever varying them separately. Run all four in ONE session to settle it:
     #   -Arms "default,detected,kconly,mconly"
@@ -206,7 +207,7 @@ if ($Rounds % $ArmList.Count -ne 0) {
     Write-Host "NOTE: -Rounds $asked over $($ArmList.Count) arms cannot balance the rotation;"
     Write-Host "      running $Rounds rounds so each arm leads $($Rounds / $ArmList.Count)."
 }
-$known = @("default", "detected", "kconly", "mconly")
+$known = @("default", "detected", "kconly", "mconly", "ccap")
 foreach ($a in $ArmList) {
     if ($known -notcontains $a) { throw "unknown arm '$a'; known arms: $($known -join ', ')" }
 }

--- a/benchmarks/run_blocking_ab.sh
+++ b/benchmarks/run_blocking_ab.sh
@@ -67,6 +67,7 @@ fi
 #   detected   L1+L2 -- kc from L1 and mc from L2
 #   kconly     L1    -- kc detected, mc from the default model
 #   mconly     L2    -- mc detected, kc from the default model
+#   ccap       L2    -- mconly PLUS the runtime C-strip bound on mc (#453)
 #
 # kconly/mconly exist because the four-machine result (#430) implicated kc and
 # exonerated mc without ever varying them separately: the Ryzen run happened to
@@ -80,7 +81,7 @@ for a in $ARMS; do
     b="$BUILD_DIR/benchmarks/bench_blocking_ab_$a"
     if [ ! -x "$b" ]; then
         echo "missing $b" >&2
-        echo "known arms: default detected kconly mconly" >&2
+        echo "known arms: default detected kconly mconly ccap" >&2
         echo "build with:  cmake --preset release && cmake --build $BUILD_DIR --target \\" >&2
         for x in $ARMS; do echo "                 bench_blocking_ab_$x \\" >&2; done
         echo "                 -j4" >&2

--- a/docs/performance/cache-blocking-ab-study.md
+++ b/docs/performance/cache-blocking-ab-study.md
@@ -215,9 +215,40 @@ holds the C strip being accumulated, which is `mc × nc`:
 | `default`, mc=60 | 123 KB | 1.97 MB | 1.25 MB |
 | `mconly`, mc=318 | 651 KB | **10.4 MB** | 1.25 MB |
 
-C dominates and is absent from the derivation. That predicts `mc` should be
-bounded by `mc·(kc + nc)`, not by `mc·kc` — a concrete, falsifiable model change
-and the next arm to add.
+C dominates and is absent from the derivation.
+
+**The obvious repair does not survive its own calibration point.** Adding the C
+term to the *compile-time* model forces the strip to be `mc × nc`, since `n` is
+unknown there, and reproducing the shipped `mc = 64` then needs
+
+```
+mc * (kc + nc) * sizeof  <=  8.5 * L2
+```
+
+which is not a residency statement at all — and the `nr = 4` hardware family
+needs 2.5 rather than 8.5, so no constant repairs it.
+
+The reason is that the strip is `mc × min(n, nc)`, and **`n` is known at the
+call** — which is already where `mc` is capped for the thread budget. So the
+bound belongs in the runtime planner, not in the model:
+
+```
+mc  <=  L2 / ((kc + min(n, nc)) * sizeof)
+```
+
+On the i7 that yields **128** at `n = 1024` (the shipped `mc = 64` untouched),
+**71** at `n = 2048`, and **37** at `n = 4096` — tightening exactly where the
+measurements preferred a smaller `mc`, and leaving alone where they did not. It
+is also nearly independent of `kc`, where the current model is inversely
+proportional to it; that difference in *shape* is the thing to measure.
+
+Implemented as `detail::c_strip_mc_cap` and the **`ccap` arm** (#453): L2
+detection plus the cap, so `ccap` vs `mconly` isolates the bound and `ccap` vs
+`default` answers the shipped question. Run it with
+
+```bash
+ARMS="default mconly ccap" benchmarks/machines/i7-12700k.sh
+```
 
 ## What this experiment changed in the harness
 

--- a/include/mtl/detail/gemm_blocked.hpp
+++ b/include/mtl/detail/gemm_blocked.hpp
@@ -102,6 +102,38 @@ inline std::size_t balanced_mc(std::size_t m, std::size_t mc_max, unsigned ic_nt
     return mc == 0 ? mc_max : mc;
 }
 
+/// The largest mc for which the packed A block AND the strip of C it accumulates
+/// both fit in L2. Returns 0 for "no bound" on degenerate input.
+///
+/// WHY THIS IS A RUNTIME BOUND AND NOT PART OF THE MODEL (#453). derive_blocking
+/// sizes mc so the A block `mc x kc` fills about half of L2 and counts nothing
+/// else, while the same cache simultaneously holds the C strip the ic block is
+/// accumulating into. The obvious repair -- add the C term to the compile-time
+/// model -- is FALSIFIED by its own calibration point: the strip there has to be
+/// `mc x nc`, since n is unknown, and reproducing the shipped mc = 64 then needs
+///
+///     mc * (kc + nc) * sizeof <= 8.5 * L2
+///
+/// which is not a residency statement at all, and a different family of hardware
+/// needs 2.5 rather than 8.5. The model cannot be fixed with a constant.
+///
+/// The reason is that the strip is `mc x min(n, nc)`, not `mc x nc` -- and n is
+/// known exactly HERE, at the call, which is already where mc is capped for the
+/// thread budget. On an i7 (L2 = 1.25 MB, kc = 256) this yields 128 at n = 1024,
+/// where the shipped mc = 64 is untouched, and 37 at n = 4096, where the
+/// measurements preferred a smaller mc than the model chose (#430: the 4096^2
+/// single-thread point was the one place a smaller-mc arm WON, at 1.029).
+constexpr std::size_t c_strip_mc_cap(std::size_t l2_bytes, std::size_t kc,
+                                     std::size_t n, std::size_t nc,
+                                     std::size_t sdata) {
+    if (l2_bytes == 0 || sdata == 0) return 0;          // nothing known -> no bound
+    const std::size_t strip = (nc != 0 && nc < n) ? nc : n;   // min(n, nc)
+    const std::size_t per_row = (kc + strip) * sdata;
+    if (per_row == 0) return 0;
+    const std::size_t cap = l2_bytes / per_row;
+    return cap == 0 ? 1 : cap;      // never 0: mc is a loop step
+}
+
 /// The threaded nest's shape decision: the ic block size and the ic x jc thread
 /// grid. Pure, so it can be unit-tested and enumerated offline (#430) instead of
 /// being inferred from a throughput change.
@@ -136,10 +168,16 @@ struct gemm_grid {
 ///    difference. The search below is exhaustive over ic (a handful of values)
 ///    and maximises ic_nt * jc_nt, preferring the larger ic_nt on ties because a
 ///    wider ic team keeps the shared packed-B panel resident.
+///
+/// `mc_extra_cap` is an additional upper bound on mc (0 = none), used for the
+/// C-strip bound above. It is applied BEFORE the budget cap, so both can bind
+/// and the smaller wins; like the budget cap it only ever LOWERS mc.
 constexpr gemm_grid plan_gemm_grid(std::size_t m, std::size_t n,
                                    std::size_t mc_cache, std::size_t nc,
-                                   std::size_t mr, unsigned budget) {
+                                   std::size_t mr, unsigned budget,
+                                   std::size_t mc_extra_cap = 0) {
     if (budget < 1) budget = 1;
+    if (mc_extra_cap != 0 && mc_extra_cap < mc_cache) mc_cache = mc_extra_cap;
     // mc is a divisor and a loop step, so it must never leave here as 0 even on
     // a degenerate call -- a 0 step would not terminate. Everything else about a
     // degenerate call is "nothing to do": no blocks, a 1x1 grid.
@@ -212,12 +250,25 @@ inline gemm_plan gemm_plan_for(std::size_t m, std::size_t n, unsigned nthreads) 
         p.njb = NC ? (n + NC - 1) / NC : 0;
         return p;
     };
-    // Serial: balanced_mc with ic_nt = 1 rounds the bound down to whole mr
-    // panels, which is what serial_nest steps by.
-    if (budget <= 1) return finish(balanced_mc(m, MC, 1, MR), 1, 1);
+    // The C-strip bound (#453), off unless this translation unit asked for it.
+    // It needs the machine's real L2, so it is only meaningful together with L2
+    // detection -- the `ccap` benchmark arm compiles both.
+#if defined(MTL5_GEMM_C_STRIP_CAP)
+    const std::size_t c_cap = c_strip_mc_cap(simd::detected_hw_traits().l2_bytes,
+                                             rbp.kc, n, NC, sizeof(TC));
+#else
+    const std::size_t c_cap = 0;
+#endif
+    const std::size_t serial_mc = (c_cap != 0 && c_cap < MC) ? c_cap : MC;
 
-    const gemm_grid g = plan_gemm_grid(m, n, MC, NC, MR, budget);
-    if (g.ic_nt * g.jc_nt <= 1) return finish(balanced_mc(m, MC, 1, MR), 1, 1);
+    // Serial: balanced_mc with ic_nt = 1 rounds the bound down to whole mr
+    // panels, which is what serial_nest steps by. The C-strip bound applies here
+    // too -- it is about cache residency, not about threads, and the measured
+    // losses it targets are visible at one thread (#430).
+    if (budget <= 1) return finish(balanced_mc(m, serial_mc, 1, MR), 1, 1);
+
+    const gemm_grid g = plan_gemm_grid(m, n, MC, NC, MR, budget, c_cap);
+    if (g.ic_nt * g.jc_nt <= 1) return finish(balanced_mc(m, serial_mc, 1, MR), 1, 1);
     return finish(balanced_mc(m, g.mc, g.ic_nt, MR), g.ic_nt, g.jc_nt);
 }
 

--- a/tests/unit/detail/test_gemm_grid.cpp
+++ b/tests/unit/detail/test_gemm_grid.cpp
@@ -215,3 +215,77 @@ TEST_CASE("gemm_plan_for reports a derived mc, not the configured one",
         if (p.budget >= 8) REQUIRE(p.nib >= p.ic_nt);
     }
 }
+
+// --- the C-strip bound on mc (#453) ----------------------------------------
+//
+// derive_blocking sizes mc so the packed A block fills ~half of L2 and counts
+// nothing else, while the same cache holds the strip of C being accumulated.
+// Adding the C term to the COMPILE-TIME model does not work, and the arithmetic
+// says so rather than a measurement: the static strip has to be `mc x nc`, since
+// n is unknown there, and reproducing the shipped mc = 64 then needs
+// `mc*(kc+nc)*sizeof <= 8.5*L2` -- not a residency statement, and a different
+// hardware family needs 2.5 instead. The strip is `mc x min(n, nc)`, and n is
+// known at the call.
+TEST_CASE("the C-strip cap bounds mc by what L2 must actually hold",
+          "[detail][gemm][grid][cstrip]") {
+    using mtl::detail::c_strip_mc_cap;
+    constexpr std::size_t SD = 8;                 // double
+
+    SECTION("i7-12700K: binds where the model overshot, not where it was fine") {
+        constexpr std::size_t L2 = 1310720;       // 1.25 MB, one P-core
+        // n <= nc: the strip is the problem width, so a narrow problem allows a
+        // large mc and the shipped 64 is untouched.
+        REQUIRE(c_strip_mc_cap(L2, 256, 1024, 4096, SD) == 128);
+        // As n grows the strip does too, and the bound tightens below 64 --
+        // which is the direction the 4096^2 measurements preferred (#430).
+        REQUIRE(c_strip_mc_cap(L2, 256, 2048, 4096, SD) == 71);
+        REQUIRE(c_strip_mc_cap(L2, 256, 4096, 4096, SD) == 37);
+        // Beyond nc the strip stops growing: jc blocks the problem at nc.
+        REQUIRE(c_strip_mc_cap(L2, 256, 8192, 4096, SD)
+                == c_strip_mc_cap(L2, 256, 4096, 4096, SD));
+    }
+
+    SECTION("a larger kc tightens the bound, but weakly") {
+        // The kc term is small next to the strip, so the cap is nearly
+        // independent of kc -- unlike the current model, where mc is inversely
+        // proportional to it. That difference in SHAPE is what the ccap arm
+        // measures.
+        constexpr std::size_t L2 = 1310720;
+        const auto lo = c_strip_mc_cap(L2, 256, 1024, 4096, SD);
+        const auto hi = c_strip_mc_cap(L2, 384, 1024, 4096, SD);
+        REQUIRE(hi < lo);
+        REQUIRE(hi * 10 > lo * 8);      // within ~20%, not the 1.5x of mc ~ 1/kc
+    }
+
+    SECTION("degenerate input yields no bound rather than a zero step") {
+        REQUIRE(c_strip_mc_cap(0, 256, 1024, 4096, SD) == 0);      // L2 unknown
+        REQUIRE(c_strip_mc_cap(1310720, 256, 1024, 4096, 0) == 0); // sizeof 0
+        // A cache too small for even one row must still leave a usable step.
+        REQUIRE(c_strip_mc_cap(64, 256, 4096, 4096, SD) == 1);
+    }
+}
+
+TEST_CASE("plan_gemm_grid honours the extra cap and still never starves",
+          "[detail][gemm][grid][cstrip]") {
+    // The cap is applied BEFORE the budget cap, so both can bind and the smaller
+    // wins -- and neither may push mc to 0, which is a loop step.
+    for (std::size_t cap : {std::size_t{0}, std::size_t{16}, std::size_t{37},
+                            std::size_t{128}, std::size_t{4096}})
+        for (std::size_t m : {std::size_t{64}, std::size_t{1024}, std::size_t{4096}})
+            for (unsigned b : {1u, 8u}) {
+                const auto g = plan_gemm_grid(m, 4096, 213, NC, MR, b, cap);
+                INFO("cap=" << cap << " m=" << m << " budget=" << b
+                     << " -> mc=" << g.mc << " grid=" << g.ic_nt << "x" << g.jc_nt);
+                REQUIRE(g.mc >= 1);
+                REQUIRE(g.mc <= 213);                       // the L2 bound holds
+                if (cap != 0 && cap < 213) REQUIRE(g.mc <= cap);
+                REQUIRE(g.nib == (m + g.mc - 1) / g.mc);
+                REQUIRE(g.ic_nt * g.jc_nt <= (b < 1 ? 1 : b));
+            }
+
+    // A cap looser than the cache bound changes nothing.
+    const auto uncapped = plan_gemm_grid(1024, 4096, 64, NC, MR, 8, 0);
+    const auto loose    = plan_gemm_grid(1024, 4096, 64, NC, MR, 8, 4096);
+    REQUIRE(uncapped.mc == loose.mc);
+    REQUIRE(uncapped.ic_nt == loose.ic_nt);
+}


### PR DESCRIPTION
## The proposed fix is falsified — by arithmetic, before any measurement

#453 proposed adding the C term to the compile-time model. It does not survive its own calibration point. At compile time `n` is unknown, so the strip has to be `mc × nc`, and reproducing the **shipped** `mc = 64` then needs

```
mc * (kc + nc) * sizeof  <=  8.5 * L2
```

which is not a residency statement at all. And the `nr = 4` hardware family needs **2.5** rather than 8.5, so no constant repairs it. If C genuinely had to be L2-resident the model would prescribe `mc = 3` on the reference hierarchy, against a shipped 64 that works.

I opened that issue proposing exactly that formula. It's wrong, and the arithmetic says so without spending a machine-hour.

## What survives: the same idea in the right place

The strip is `mc × min(n, nc)`, and **`n` is known at the call** — which is already where `mc` is capped for the thread budget. So the bound belongs in the runtime planner:

```
mc  <=  L2 / ((kc + min(n, nc)) * sizeof)
```

| i7-12700K (L2 1.25 MB, kc 256) | cap | shipped mc=64 |
|---|---|---|
| n = 1024 | 128 | untouched |
| n = 2048 | 71 | untouched |
| n = 4096 | 37 | **tightened** |
| n = 8192 | 37 (saturates at nc) | tightened |

It tightens exactly where the measurements preferred a smaller `mc` — the 4096² single-thread point was the one place a smaller-mc arm *won* (1.029) — and leaves alone where they did not. It is also nearly **independent of kc**, where the current model is inversely proportional to it; that difference in shape is what the experiment discriminates.

## Not shipped — it's an arm

`ccap` = L2 detection **plus** the cap, so `ccap` vs `mconly` isolates the bound and `ccap` vs `default` answers the shipped question:

```bash
ARMS="default mconly ccap" benchmarks/machines/i7-12700k.sh
```

`plan_gemm_grid` takes the cap as a parameter (0 = none), so it stays pure and testable. The serial path gets it too: cache residency is not about threads, and the losses it targets are visible at one thread.

## Two traps caught before they could produce data

- **CMake flattens a `;`-joined element into the outer list.** My parallel arm/defines lists shifted every later index, and `ccap` was built with **half** its configuration — it compiled, ran, and reported "L2 only": a misconfigured arm indistinguishable from a working one. Replaced with an if-chain that `FATAL_ERROR`s on an arm it has no defines for.
- **The arm's self-report said "L2 only" while behaving differently.** It now declares the cap. Two arms with the same `kc/mc` line and different behaviour is exactly what the identical-arm integrity gate reads as a broken session.

Observed engaging on the Xeon: `mc 32->18` at n=1024, `mc 32->12` at n=4096.

## Test Results

| Suite | Result |
|---|---|
| GCC | 170/170 |
| Clang | 170/170 |

New tests pin the cap on the measured hierarchies (128/71/37, saturating at `nc`), its weak-vs-inverse dependence on `kc`, degenerate input yielding *no bound* rather than a zero loop step, and `plan_gemm_grid` applying it without ever starving the partition.

Relates to #453, #430

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved GEMM cache blocking by applying an additional runtime limit based on the L2 cache and C-matrix strip size.
  - Updated serial and threaded execution planning to respect the new limit, potentially improving performance across varying matrix shapes.

- **Benchmarks**
  - Added the `ccap` benchmark configuration for comparing C-strip-aware blocking against existing strategies.
  - Expanded benchmark validation, reporting, and usage documentation.

- **Tests**
  - Added coverage for cache limits, matrix widths, block sizes, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->