### PR TITLE
feat(simd): 32-bit integer lanes for batch, dot and gemv (#451 phase 0)

### DIFF
--- a/include/mtl/detail/gemv.hpp
+++ b/include/mtl/detail/gemv.hpp
@@ -55,10 +55,10 @@ void gemv_rowmajor(std::size_t m, std::size_t n, const T* A, std::size_t lda,
             // wrap_* so an integer tail wraps like the SIMD body above rather
             // than being signed-overflow UB (see simd/batch.hpp); identity on
             // floating lanes.
-            s0 = simd::detail::wrap_add(s0, simd::detail::wrap_mul(a0[j], xj));
-            s1 = simd::detail::wrap_add(s1, simd::detail::wrap_mul(a1[j], xj));
-            s2 = simd::detail::wrap_add(s2, simd::detail::wrap_mul(a2[j], xj));
-            s3 = simd::detail::wrap_add(s3, simd::detail::wrap_mul(a3[j], xj));
+            s0 = mtl::detail::wrap_add(s0, mtl::detail::wrap_mul(a0[j], xj));
+            s1 = mtl::detail::wrap_add(s1, mtl::detail::wrap_mul(a1[j], xj));
+            s2 = mtl::detail::wrap_add(s2, mtl::detail::wrap_mul(a2[j], xj));
+            s3 = mtl::detail::wrap_add(s3, mtl::detail::wrap_mul(a3[j], xj));
         }
         y[i + 0] = s0; y[i + 1] = s1; y[i + 2] = s2; y[i + 3] = s3;
     }
@@ -101,7 +101,7 @@ void gemv_colmajor(std::size_t m, std::size_t n, const T* A, std::size_t lda,
     for (; i < m; ++i) {                          // remaining rows (< W), scalar
         T s = T(0);
         for (std::size_t j = 0; j < n; ++j)
-            s = simd::detail::wrap_add(s, simd::detail::wrap_mul(A[j * lda + i], x[j]));
+            s = mtl::detail::wrap_add(s, mtl::detail::wrap_mul(A[j * lda + i], x[j]));
         y[i] = s;
     }
 }

--- a/include/mtl/detail/gemv.hpp
+++ b/include/mtl/detail/gemv.hpp
@@ -52,7 +52,13 @@ void gemv_rowmajor(std::size_t m, std::size_t n, const T* A, std::size_t lda,
           s2 = reduce_add(acc2), s3 = reduce_add(acc3);
         for (; j < n; ++j) {                      // scalar tail over columns
             const T xj = x[j];
-            s0 += a0[j] * xj; s1 += a1[j] * xj; s2 += a2[j] * xj; s3 += a3[j] * xj;
+            // wrap_* so an integer tail wraps like the SIMD body above rather
+            // than being signed-overflow UB (see simd/batch.hpp); identity on
+            // floating lanes.
+            s0 = simd::detail::wrap_add(s0, simd::detail::wrap_mul(a0[j], xj));
+            s1 = simd::detail::wrap_add(s1, simd::detail::wrap_mul(a1[j], xj));
+            s2 = simd::detail::wrap_add(s2, simd::detail::wrap_mul(a2[j], xj));
+            s3 = simd::detail::wrap_add(s3, simd::detail::wrap_mul(a3[j], xj));
         }
         y[i + 0] = s0; y[i + 1] = s1; y[i + 2] = s2; y[i + 3] = s3;
     }
@@ -94,7 +100,8 @@ void gemv_colmajor(std::size_t m, std::size_t n, const T* A, std::size_t lda,
     }
     for (; i < m; ++i) {                          // remaining rows (< W), scalar
         T s = T(0);
-        for (std::size_t j = 0; j < n; ++j) s += A[j * lda + i] * x[j];
+        for (std::size_t j = 0; j < n; ++j)
+            s = simd::detail::wrap_add(s, simd::detail::wrap_mul(A[j * lda + i], x[j]));
         y[i] = s;
     }
 }

--- a/include/mtl/detail/wrapping_arithmetic.hpp
+++ b/include/mtl/detail/wrapping_arithmetic.hpp
@@ -103,12 +103,22 @@ constexpr T wrap_mul(T a, T b) noexcept {
 /// is only lossless between integers: with a floating-point operand and an
 /// integral result -- `mult(dense2D<double>, dense_vector<double>,
 /// dense_vector<int>)` -- it would truncate each factor before multiplying and
-/// turn 2.5 * 2.5 into 2 * 2, where the plain expression rounds 6.25 once on
-/// assignment. Those mixed cases keep the original expression.
+/// turn 2.5 * 2.5 into 2 * 2, where the plain expression accumulates in the
+/// result type and rounds each term once. Those mixed cases keep the original
+/// expression.
+///
+/// The operand test is `std::is_integral_v`, NOT `is_wrapping_integer_v`. The
+/// difference is `bool`, and it matters in the direction that is easy to get
+/// backwards: `bool` must be excluded as a RESULT type, because
+/// `std::make_unsigned_t<bool>` is ill-formed, but it must be INCLUDED as an
+/// operand, because converting it to an integral `Result` is exact (0 or 1) and
+/// excluding it would push the whole expression onto the plain branch --
+/// reinstating the signed-overflow UB this helper exists to remove.
+/// `dot(dense_vector<bool>, dense_vector<int32_t>)` is that case.
 template <typename Result, typename A, typename B>
 constexpr Result generic_fma(Result acc, const A& a, const B& b) {
     if constexpr (is_wrapping_integer_v<Result> &&
-                  is_wrapping_integer_v<A> && is_wrapping_integer_v<B>) {
+                  std::is_integral_v<A> && std::is_integral_v<B>) {
         return wrap_add(acc, wrap_mul(static_cast<Result>(a), static_cast<Result>(b)));
     } else {
         return acc + a * b;

--- a/include/mtl/detail/wrapping_arithmetic.hpp
+++ b/include/mtl/detail/wrapping_arithmetic.hpp
@@ -25,11 +25,37 @@
 
 namespace mtl::detail {
 
+/// Integral types these helpers wrap.
+///
+/// `bool` is excluded: `std::make_unsigned_t<bool>` is ill-formed, and boolean
+/// arithmetic promotes to `int` and cannot overflow, so it belongs on the plain
+/// branch rather than in a modular one.
+template <typename T>
+inline constexpr bool is_wrapping_integer_v =
+    std::is_integral_v<T> && !std::is_same_v<T, bool>;
+
+/// The type the modular arithmetic is actually performed in: the unsigned
+/// counterpart of `T`, or `unsigned int` when that is narrower than `int`.
+///
+/// This width promise is the whole correctness argument, and casting to
+/// `make_unsigned_t<T>` alone does NOT deliver it. Integral promotion runs
+/// before any arithmetic operator, and it promotes any type narrower than `int`
+/// to *signed* `int` -- so for `T = int16_t`, `static_cast<uint16_t>(-1) *
+/// static_cast<uint16_t>(-1)` is `65535 * 65535` evaluated in `int`, which
+/// overflows and is undefined. The unsigned cast meant to prevent UB
+/// reintroduced it for every type narrower than `int`. Multiplying in
+/// `common_type_t<U, unsigned>` keeps the operation unsigned, where overflow is
+/// defined as reduction, and the result is then narrowed back to `U`.
+template <typename T>
+using wrap_op_t = std::common_type_t<std::make_unsigned_t<T>, unsigned int>;
+
 template <typename T>
 constexpr T wrap_add(T a, T b) noexcept {
-    if constexpr (std::is_integral_v<T>) {
+    if constexpr (is_wrapping_integer_v<T>) {
         using U = std::make_unsigned_t<T>;
-        return static_cast<T>(static_cast<U>(static_cast<U>(a) + static_cast<U>(b)));
+        using P = wrap_op_t<T>;
+        return static_cast<T>(static_cast<U>(static_cast<P>(static_cast<U>(a)) +
+                                             static_cast<P>(static_cast<U>(b))));
     } else {
         return a + b;
     }
@@ -37,9 +63,11 @@ constexpr T wrap_add(T a, T b) noexcept {
 
 template <typename T>
 constexpr T wrap_sub(T a, T b) noexcept {
-    if constexpr (std::is_integral_v<T>) {
+    if constexpr (is_wrapping_integer_v<T>) {
         using U = std::make_unsigned_t<T>;
-        return static_cast<T>(static_cast<U>(static_cast<U>(a) - static_cast<U>(b)));
+        using P = wrap_op_t<T>;
+        return static_cast<T>(static_cast<U>(static_cast<P>(static_cast<U>(a)) -
+                                             static_cast<P>(static_cast<U>(b))));
     } else {
         return a - b;
     }
@@ -47,9 +75,11 @@ constexpr T wrap_sub(T a, T b) noexcept {
 
 template <typename T>
 constexpr T wrap_mul(T a, T b) noexcept {
-    if constexpr (std::is_integral_v<T>) {
+    if constexpr (is_wrapping_integer_v<T>) {
         using U = std::make_unsigned_t<T>;
-        return static_cast<T>(static_cast<U>(static_cast<U>(a) * static_cast<U>(b)));
+        using P = wrap_op_t<T>;
+        return static_cast<T>(static_cast<U>(static_cast<P>(static_cast<U>(a)) *
+                                             static_cast<P>(static_cast<U>(b))));
     } else {
         return a * b;
     }
@@ -65,10 +95,20 @@ constexpr T wrap_mul(T a, T b) noexcept {
 ///
 /// The operands are converted to `Result` BEFORE multiplying, which is what
 /// makes the integer case exact mod 2^N rather than merely defined: it is the
-/// product that overflows first, not the sum.
+/// product that overflows first, not the sum. Narrowing first loses nothing,
+/// because reduction mod 2^N is a ring homomorphism -- (a mod 2^N)(b mod 2^N)
+/// and (a b) mod 2^N agree.
+///
+/// The OPERANDS must be integral too, not just `Result`. Converting them first
+/// is only lossless between integers: with a floating-point operand and an
+/// integral result -- `mult(dense2D<double>, dense_vector<double>,
+/// dense_vector<int>)` -- it would truncate each factor before multiplying and
+/// turn 2.5 * 2.5 into 2 * 2, where the plain expression rounds 6.25 once on
+/// assignment. Those mixed cases keep the original expression.
 template <typename Result, typename A, typename B>
 constexpr Result generic_fma(Result acc, const A& a, const B& b) {
-    if constexpr (std::is_integral_v<Result>) {
+    if constexpr (is_wrapping_integer_v<Result> &&
+                  is_wrapping_integer_v<A> && is_wrapping_integer_v<B>) {
         return wrap_add(acc, wrap_mul(static_cast<Result>(a), static_cast<Result>(b)));
     } else {
         return acc + a * b;

--- a/include/mtl/detail/wrapping_arithmetic.hpp
+++ b/include/mtl/detail/wrapping_arithmetic.hpp
@@ -1,0 +1,78 @@
+#pragma once
+// MTL5 -- two's-complement wrapping integer arithmetic (#451).
+//
+// Integer lanes in mtl::simd are defined to WRAP: `+ - *` and `fma` return the
+// exact mathematical result reduced mod 2^N. That is the native semantics of
+// every target ISA and of Highway's integer ops, and it is what makes an integer
+// reduction bit-identical across lane counts, backends and thread partitions
+// (see simd/batch.hpp for the full contract).
+//
+// Plain C++ cannot express it directly. Signed integer overflow is UB, so a
+// scalar tail written `s += a[i] * b[i]` over int32 is undefined exactly where
+// the SIMD body it completes wraps and defines the result -- the two halves of
+// one kernel disagreeing on whether an answer exists. Routing the scalar
+// arithmetic through the unsigned counterpart makes both halves produce the SAME
+// well-defined value: C++20 fixes two's complement, so the round trip through
+// std::make_unsigned_t is exact and the narrowing cast back is modular rather
+// than implementation-defined.
+//
+// These live here, outside simd/, because the generic element-wise loops in
+// operation/ need them for the same reason the kernels do: an integer `mult` or
+// `dot` that misses the SIMD fast path must still land on the documented answer
+// rather than on UB. Floating-point and custom number types fall through every
+// helper unchanged.
+#include <type_traits>
+
+namespace mtl::detail {
+
+template <typename T>
+constexpr T wrap_add(T a, T b) noexcept {
+    if constexpr (std::is_integral_v<T>) {
+        using U = std::make_unsigned_t<T>;
+        return static_cast<T>(static_cast<U>(static_cast<U>(a) + static_cast<U>(b)));
+    } else {
+        return a + b;
+    }
+}
+
+template <typename T>
+constexpr T wrap_sub(T a, T b) noexcept {
+    if constexpr (std::is_integral_v<T>) {
+        using U = std::make_unsigned_t<T>;
+        return static_cast<T>(static_cast<U>(static_cast<U>(a) - static_cast<U>(b)));
+    } else {
+        return a - b;
+    }
+}
+
+template <typename T>
+constexpr T wrap_mul(T a, T b) noexcept {
+    if constexpr (std::is_integral_v<T>) {
+        using U = std::make_unsigned_t<T>;
+        return static_cast<T>(static_cast<U>(static_cast<U>(a) * static_cast<U>(b)));
+    } else {
+        return a * b;
+    }
+}
+
+/// `acc + a * b` for the generic element-wise loops: wrapping when the result
+/// type is integral, the plain expression otherwise.
+///
+/// The generic path is where an integer `mult` lands whenever the native kernel
+/// is not selected -- which is the DEFAULT build, since MTL5_NATIVE_FAST_GEMM is
+/// off -- and where a non-contiguous integer vector lands in `dot`. Both must
+/// agree with the SIMD path bit for bit, and neither may be undefined.
+///
+/// The operands are converted to `Result` BEFORE multiplying, which is what
+/// makes the integer case exact mod 2^N rather than merely defined: it is the
+/// product that overflows first, not the sum.
+template <typename Result, typename A, typename B>
+constexpr Result generic_fma(Result acc, const A& a, const B& b) {
+    if constexpr (std::is_integral_v<Result>) {
+        return wrap_add(acc, wrap_mul(static_cast<Result>(a), static_cast<Result>(b)));
+    } else {
+        return acc + a * b;
+    }
+}
+
+} // namespace mtl::detail

--- a/include/mtl/interface/dispatch_traits.hpp
+++ b/include/mtl/interface/dispatch_traits.hpp
@@ -6,6 +6,7 @@
 #include <complex>
 #include <mtl/tag/orientation.hpp>
 #include <mtl/mat/compressed2D.hpp>
+#include <mtl/simd/batch.hpp>
 
 namespace mtl::interface {
 
@@ -64,6 +65,35 @@ concept BlasDenseVector =
     requires(const V& v) {
         { v.data() } -> std::convertible_to<const typename V::value_type*>;
         { v.size() };
+    };
+
+/// Concept satisfied by dense vector types eligible for MTL5's OWN SIMD kernels.
+///
+/// Strictly wider than `BlasDenseVector`: same storage shape (contiguous
+/// `data()`, `size()`), but the value type only has to be a lane `mtl::simd`
+/// can hold -- float, double, int32_t, uint32_t -- rather than a type an
+/// external BLAS has a symbol for. The two are distinct on purpose: there is no
+/// `sdot` for int32, so the integer lanes are reachable ONLY through the native
+/// path, and gating them on the BLAS predicate is what kept them on the generic
+/// scalar loop (#451).
+template <typename V>
+concept SimdDenseVector =
+    simd::is_lane_v<typename V::value_type> &&
+    requires(const V& v) {
+        { v.data() } -> std::convertible_to<const typename V::value_type*>;
+        { v.size() };
+    };
+
+/// Concept satisfied by dense matrix types eligible for MTL5's own SIMD
+/// kernels -- `BlasDenseMatrix` widened to every `mtl::simd` lane type, for the
+/// same reason as `SimdDenseVector`.
+template <typename M>
+concept SimdDenseMatrix =
+    simd::is_lane_v<typename M::value_type> &&
+    requires(const M& m) {
+        { m.data() } -> std::convertible_to<const typename M::value_type*>;
+        { m.num_rows() };
+        { m.num_cols() };
     };
 
 /// Check if a matrix type uses row-major orientation.

--- a/include/mtl/interface/dispatch_traits.hpp
+++ b/include/mtl/interface/dispatch_traits.hpp
@@ -57,11 +57,40 @@ concept BlasHermitianMatrix =
         { m.num_cols() };
     };
 
+/// True when a vector type's storage is CONTIGUOUS -- `data()[i]` IS element i.
+///
+/// Every fast path below hands `data()` to a kernel that walks it with unit
+/// stride, so this is a precondition of dispatching there at all. Asking only
+/// for `data()` and `size()` did not establish it: `vec::strided_vector_ref`
+/// supplies both while storing element i at `data()[i * stride()]`, so it was
+/// accepted by `BlasDenseVector` and every operation gated on it read the wrong
+/// elements and returned a confident wrong answer. Measured on a stride-2 view:
+/// `dot_real` gave 14 where the answer is 44. A column of a row-major matrix is
+/// exactly such a view, which is the case that makes this worth catching.
+///
+/// A type qualifies when it either has no stride notion at all -- `data()` and
+/// `size()` are then the whole layout, which is what these concepts always
+/// assumed -- or pins its stride to 1 at COMPILE time, as `vec::dense_vector`
+/// does with `static constexpr size_type stride() { return 1; }`.
+///
+/// A runtime stride cannot qualify: `strided_vector_ref::stride()` is an
+/// instance value, so no concept can admit only its unit-stride objects. Those
+/// types take the generic element-wise loop instead, which indexes through
+/// `operator()` and is correct for any stride. That costs a stride-1
+/// `strided_vector_ref` its fast path -- the right side to err on, and
+/// recoverable later with a runtime `stride() == 1` check at the call sites if
+/// it ever measures.
+template <typename V>
+concept ContiguousVector =
+    !requires(const V& v) { v.stride(); } ||     // no stride notion
+    requires { requires V::stride() == 1; };     // ... or unit stride, statically
+
 /// Concept satisfied by dense vector types eligible for BLAS dispatch.
-/// Requires: float/double value_type, contiguous data() pointer, size().
+/// Requires: float/double value_type, contiguous unit-stride storage, size().
 template <typename V>
 concept BlasDenseVector =
     is_blas_scalar_v<typename V::value_type> &&
+    ContiguousVector<V> &&
     requires(const V& v) {
         { v.data() } -> std::convertible_to<const typename V::value_type*>;
         { v.size() };
@@ -79,6 +108,7 @@ concept BlasDenseVector =
 template <typename V>
 concept SimdDenseVector =
     simd::is_lane_v<typename V::value_type> &&
+    ContiguousVector<V> &&
     requires(const V& v) {
         { v.data() } -> std::convertible_to<const typename V::value_type*>;
         { v.size() };

--- a/include/mtl/operation/dot.hpp
+++ b/include/mtl/operation/dot.hpp
@@ -78,6 +78,20 @@ auto dot(const V1& v1, const V2& v2) {
         return detail::thread_pool::instance().parallel_reduce<T>(
             v1.size(), /*grain=*/std::size_t{65536},
             [&](std::size_t lo, std::size_t hi) { return simd::reduce_dot<T>(a + lo, b + lo, hi - lo); });
+    } else if constexpr (interface::SimdDenseVector<V1> && interface::SimdDenseVector<V2> &&
+                         std::is_same_v<typename V1::value_type, typename V2::value_type>) {
+        // Integer lanes (#451 phase 0). conj is the identity on the integers, so
+        // reduce_dot is the Hermitian product here too. The sum is exact mod
+        // 2^32 -- see simd/batch.hpp for the contract.
+        //
+        // SERIAL, unlike the float branch above. parallel_reduce combines its
+        // partials with `acc = acc + partials[t]`, and on int32 that plain `+`
+        // is signed-overflow UB. Wrapping addition IS associative, so a parallel
+        // integer reduction would be bit-identical and is worth having; making
+        // the combine wrap-safe means touching parallel_reduce's documented
+        // plus-only contract for every T, which is not a phase-0 change.
+        using T = typename V1::value_type;
+        return simd::reduce_dot<T>(v1.data(), v2.data(), v1.size());
     } else {
         using result_type = std::common_type_t<typename V1::value_type, typename V2::value_type>;
         auto acc = math::zero<result_type>();
@@ -122,7 +136,10 @@ auto dot_real(const V1& v1, const V2& v2) {
         }
     }
 #endif
-    if constexpr (interface::BlasDenseVector<V1> && interface::BlasDenseVector<V2> &&
+    // SimdDenseVector is BlasDenseVector widened to every mtl::simd lane type,
+    // so this also picks up the integer lanes (#451 phase 0); on those the sum
+    // is exact mod 2^32 rather than order-dependent.
+    if constexpr (interface::SimdDenseVector<V1> && interface::SimdDenseVector<V2> &&
                   std::is_same_v<typename V1::value_type, typename V2::value_type>) {
         return simd::reduce_dot<typename V1::value_type>(v1.data(), v2.data(), v1.size());
     } else {

--- a/include/mtl/operation/dot.hpp
+++ b/include/mtl/operation/dot.hpp
@@ -13,6 +13,7 @@
 #include <mtl/math/accumulator_traits.hpp>
 #include <mtl/functor/scalar/conj.hpp>
 #include <mtl/detail/thread_pool.hpp>
+#include <mtl/detail/wrapping_arithmetic.hpp>
 #include <mtl/interface/dispatch_traits.hpp>
 #include <mtl/simd/algorithm.hpp>
 #ifdef MTL5_HAS_BLAS
@@ -96,7 +97,11 @@ auto dot(const V1& v1, const V2& v2) {
         using result_type = std::common_type_t<typename V1::value_type, typename V2::value_type>;
         auto acc = math::zero<result_type>();
         for (typename V1::size_type i = 0; i < v1.size(); ++i) {
-            acc += functor::scalar::conj<typename V1::value_type>::apply(v1(i)) * v2(i);
+            // generic_fma wraps on integral result types, so a non-contiguous
+            // integer vector (which the concepts route here) gets the same
+            // mod-2^32 answer as the SIMD path rather than signed-overflow UB.
+            acc = detail::generic_fma<result_type>(
+                acc, functor::scalar::conj<typename V1::value_type>::apply(v1(i)), v2(i));
         }
         return acc;
     }
@@ -146,7 +151,7 @@ auto dot_real(const V1& v1, const V2& v2) {
         using result_type = std::common_type_t<typename V1::value_type, typename V2::value_type>;
         auto acc = math::zero<result_type>();
         for (typename V1::size_type i = 0; i < v1.size(); ++i) {
-            acc += v1(i) * v2(i);
+            acc = detail::generic_fma<result_type>(acc, v1(i), v2(i));   // wraps on integers
         }
         return acc;
     }

--- a/include/mtl/operation/mult.hpp
+++ b/include/mtl/operation/mult.hpp
@@ -216,10 +216,17 @@ void mult(const M& A, const VIn& x, VOut& y) {
 #endif
 #ifdef MTL5_NATIVE_FAST_GEMM
     // Native SIMD GEMV: preferred over the generic scalar loop for dense
-    // contiguous float/double when no external BLAS handled it above.
-    if constexpr (interface::BlasDenseMatrix<M> &&
-                  interface::BlasDenseVector<VIn> &&
-                  interface::BlasDenseVector<VOut> &&
+    // contiguous lane types when no external BLAS handled it above.
+    //
+    // Gated on the Simd* concepts, not the Blas* ones, so the integer lanes are
+    // reachable (#451 phase 0). There is no external ?gemv for int32, so this
+    // native path is the only one they can take; the BLAS branch above is
+    // unreachable for them and needs no extra guard. The result is exact mod
+    // 2^32 and bit-identical across lane counts and thread partitions -- the
+    // per-row partitioning below is already order-preserving.
+    if constexpr (interface::SimdDenseMatrix<M> &&
+                  interface::SimdDenseVector<VIn> &&
+                  interface::SimdDenseVector<VOut> &&
                   std::is_same_v<typename M::value_type, typename VIn::value_type> &&
                   std::is_same_v<typename M::value_type, typename VOut::value_type>) {
         using T = typename M::value_type;

--- a/include/mtl/operation/mult.hpp
+++ b/include/mtl/operation/mult.hpp
@@ -7,6 +7,7 @@
 #include <mtl/concepts/vector.hpp>
 #include <mtl/math/identity.hpp>
 #include <mtl/math/accumulator_traits.hpp>
+#include <mtl/detail/wrapping_arithmetic.hpp>
 #include <mtl/interface/dispatch_traits.hpp>
 #include <mtl/mat/compressed2D.hpp>
 #include <mtl/mat/view/transposed_view.hpp>
@@ -36,7 +37,7 @@ void mult_generic(const M& A, const VIn& x, VOut& y) {
         for (typename M::size_type r = 0; r < A.num_rows(); ++r) {
             auto acc = math::zero<Result>();
             for (typename M::size_type c = 0; c < A.num_cols(); ++c) {
-                acc += A(r, c) * x(c);
+                acc = generic_fma<Result>(acc, A(r, c), x(c));
             }
             y(r) = acc;
         }
@@ -102,7 +103,7 @@ void mult_generic(const MA& A, const MB& B, MC& C) {
             for (typename MC::size_type c = 0; c < C.num_cols(); ++c) {
                 auto acc = math::zero<Result>();
                 for (typename MA::size_type k = 0; k < A.num_cols(); ++k) {
-                    acc += A(r, k) * B(k, c);
+                    acc = generic_fma<Result>(acc, A(r, k), B(k, c));
                 }
                 C(r, c) = acc;
             }

--- a/include/mtl/simd/algorithm.hpp
+++ b/include/mtl/simd/algorithm.hpp
@@ -12,6 +12,15 @@
 // Unaligned loads/stores are used so these work on any contiguous span
 // (sub-vectors, views); on modern cores aligned vs unaligned cost is
 // negligible. The packed-panel GEMM path (#89) uses aligned loads instead.
+//
+// Lane types are whatever batch<T> supports (mtl::simd::is_lane_v): float,
+// double, int32_t, uint32_t. On integer lanes every kernel here is EXACT mod
+// 2^32 -- the four independent accumulators, the horizontal reduce and the
+// scalar tail all commute, because wrapping addition is associative. So the
+// integer results are bit-identical across lane counts and backends, and the
+// scalar tails go through the wrapping helpers rather than raw `+`/`*` so that
+// a tail overflow is defined rather than UB. Widening accumulation (int8/int16
+// into int32) is #451 phases 2-3 and is not offered here.
 
 #include <cstddef>
 #include <type_traits>
@@ -20,10 +29,10 @@
 
 namespace mtl::simd {
 
-/// dot product: sum_i a[i]*b[i]  (real float/double).
+/// dot product: sum_i a[i]*b[i]  (real float/double, or int32/uint32 mod 2^32).
 template <typename T>
 T reduce_dot(const T* a, const T* b, std::size_t n) {
-    static_assert(std::is_floating_point_v<T>);
+    static_assert(is_lane_v<T>);
     using B = batch<T>;
     constexpr std::size_t W = B::size;
     constexpr std::size_t U = 4;             // independent accumulators
@@ -39,7 +48,8 @@ T reduce_dot(const T* a, const T* b, std::size_t n) {
     for (; i + W <= n; i += W)
         a0 = fma(B::load_unaligned(a + i), B::load_unaligned(b + i), a0);
     T s = reduce_add((a0 + a1) + (a2 + a3));
-    for (; i < n; ++i) s += a[i] * b[i];     // scalar tail
+    for (; i < n; ++i)                       // scalar tail
+        s = detail::wrap_add(s, detail::wrap_mul(a[i], b[i]));
     return s;
 }
 
@@ -75,7 +85,7 @@ Wide reduce_dot_widen(const Narrow* a, const Narrow* b, std::size_t n) {
 /// sum of squares: sum_i a[i]*a[i]  (two_norm computes sqrt of this).
 template <typename T>
 T reduce_sum_squares(const T* a, std::size_t n) {
-    static_assert(std::is_floating_point_v<T>);
+    static_assert(is_lane_v<T>);
     using B = batch<T>;
     constexpr std::size_t W = B::size;
     constexpr std::size_t U = 4;
@@ -90,14 +100,14 @@ T reduce_sum_squares(const T* a, std::size_t n) {
     }
     for (; i + W <= n; i += W) { B v = B::load_unaligned(a + i); a0 = fma(v, v, a0); }
     T s = reduce_add((a0 + a1) + (a2 + a3));
-    for (; i < n; ++i) s += a[i] * a[i];
+    for (; i < n; ++i) s = detail::wrap_add(s, detail::wrap_mul(a[i], a[i]));
     return s;
 }
 
 /// axpy: y[i] += alpha*x[i].
 template <typename T>
 void axpy(T alpha, const T* x, T* y, std::size_t n) {
-    static_assert(std::is_floating_point_v<T>);
+    static_assert(is_lane_v<T>);
     using B = batch<T>;
     constexpr std::size_t W = B::size;
     const B va(alpha);
@@ -106,20 +116,20 @@ void axpy(T alpha, const T* x, T* y, std::size_t n) {
         B r = fma(va, B::load_unaligned(x + i), B::load_unaligned(y + i));
         r.store_unaligned(y + i);
     }
-    for (; i < n; ++i) y[i] += alpha * x[i];
+    for (; i < n; ++i) y[i] = detail::wrap_add(y[i], detail::wrap_mul(alpha, x[i]));
 }
 
 /// scal: x[i] *= alpha.
 template <typename T>
 void scal(T alpha, T* x, std::size_t n) {
-    static_assert(std::is_floating_point_v<T>);
+    static_assert(is_lane_v<T>);
     using B = batch<T>;
     constexpr std::size_t W = B::size;
     const B va(alpha);
     std::size_t i = 0;
     for (; i + W <= n; i += W)
         (va * B::load_unaligned(x + i)).store_unaligned(x + i);
-    for (; i < n; ++i) x[i] *= alpha;
+    for (; i < n; ++i) x[i] = detail::wrap_mul(x[i], alpha);
 }
 
 } // namespace mtl::simd

--- a/include/mtl/simd/algorithm.hpp
+++ b/include/mtl/simd/algorithm.hpp
@@ -15,12 +15,40 @@
 //
 // Lane types are whatever batch<T> supports (mtl::simd::is_lane_v): float,
 // double, int32_t, uint32_t. On integer lanes every kernel here is EXACT mod
-// 2^32 -- the four independent accumulators, the horizontal reduce and the
-// scalar tail all commute, because wrapping addition is associative. So the
-// integer results are bit-identical across lane counts and backends, and the
-// scalar tails go through the wrapping helpers rather than raw `+`/`*` so that
-// a tail overflow is defined rather than UB. Widening accumulation (int8/int16
-// into int32) is #451 phases 2-3 and is not offered here.
+// 2^32 -- the accumulators, the horizontal reduce and the scalar tail all
+// commute, because wrapping addition is associative. So the integer results are
+// bit-identical across lane counts and backends, and the scalar tails go
+// through the wrapping helpers rather than raw `+`/`*` so that a tail overflow
+// is defined rather than UB. Widening accumulation (int8/int16 into int32) is
+// #451 phases 2-3 and is not offered here.
+//
+// ACCUMULATOR COUNT IS A FLOATING-POINT DECISION
+//
+// The four independent accumulators exist to hide FP add/FMA latency: an FMA
+// retires in 3-5 cycles, so a single accumulator serializes the loop on that
+// chain. Integer lanes have no such problem -- the loop-carried dependency is
+// an integer add (1 cycle), while the body needs two loads and a multiply, so
+// the loop is throughput-bound long before it is latency-bound. The integer
+// reductions therefore run ONE accumulator, and the hand unroll is skipped.
+//
+// That is also what keeps them correct today. On the scalar-fallback backend
+// (W == 1) the hand unroll is four interleaved scalar chains, and the
+// autovectorizer has to fuse them back into one contiguous reduction -- legal
+// for integers, because their addition reassociates, and NOT attempted for
+// floats, because FP addition does not. GCC 13 performs that fusion and gets
+// the bookkeeping wrong: at -O3 -march=x86-64-v3 it vectorizes the first chain
+// with 8-wide contiguous loads (advancing 8 elements per iteration) while
+// leaving the other three chains advancing 4, so they cover half the range and
+// the result is silently wrong. Measured on GCC 13.3: 176 of the first 299
+// compile-time-constant lengths, int32_t and uint32_t only, float and double
+// never. Clang is unaffected.
+//
+// The single-accumulator form is not a workaround chosen to dodge that -- it is
+// the right shape for integers on its own terms, and it happens to be the shape
+// the compiler already handles, because there is nothing left to un-unroll.
+// tests/unit/simd/test_integer_lanes.cpp sweeps compile-time-constant lengths
+// against both the runtime-length result and a closed-form reference, which is
+// how the miscompile was caught and what will catch the next one.
 
 #include <cstddef>
 #include <type_traits>
@@ -35,15 +63,19 @@ T reduce_dot(const T* a, const T* b, std::size_t n) {
     static_assert(is_lane_v<T>);
     using B = batch<T>;
     constexpr std::size_t W = B::size;
-    constexpr std::size_t U = 4;             // independent accumulators
-    constexpr std::size_t step = W * U;
     B a0{}, a1{}, a2{}, a3{};                // default ctor zero-initializes
     std::size_t i = 0;
-    for (; i + step <= n; i += step) {
-        a0 = fma(B::load_unaligned(a + i),           B::load_unaligned(b + i),           a0);
-        a1 = fma(B::load_unaligned(a + i + W),       B::load_unaligned(b + i + W),       a1);
-        a2 = fma(B::load_unaligned(a + i + 2 * W),   B::load_unaligned(b + i + 2 * W),   a2);
-        a3 = fma(B::load_unaligned(a + i + 3 * W),   B::load_unaligned(b + i + 3 * W),   a3);
+    // Four-accumulator body: floating lanes only (see the header note). On
+    // integer lanes a1..a3 stay zero and fold out of the combine exactly.
+    if constexpr (std::is_floating_point_v<T>) {
+        constexpr std::size_t U = 4;         // independent accumulators
+        constexpr std::size_t step = W * U;
+        for (; i + step <= n; i += step) {
+            a0 = fma(B::load_unaligned(a + i),           B::load_unaligned(b + i),           a0);
+            a1 = fma(B::load_unaligned(a + i + W),       B::load_unaligned(b + i + W),       a1);
+            a2 = fma(B::load_unaligned(a + i + 2 * W),   B::load_unaligned(b + i + 2 * W),   a2);
+            a3 = fma(B::load_unaligned(a + i + 3 * W),   B::load_unaligned(b + i + 3 * W),   a3);
+        }
     }
     for (; i + W <= n; i += W)
         a0 = fma(B::load_unaligned(a + i), B::load_unaligned(b + i), a0);
@@ -88,15 +120,17 @@ T reduce_sum_squares(const T* a, std::size_t n) {
     static_assert(is_lane_v<T>);
     using B = batch<T>;
     constexpr std::size_t W = B::size;
-    constexpr std::size_t U = 4;
-    constexpr std::size_t step = W * U;
     B a0{}, a1{}, a2{}, a3{};
     std::size_t i = 0;
-    for (; i + step <= n; i += step) {
-        B v0 = B::load_unaligned(a + i);          a0 = fma(v0, v0, a0);
-        B v1 = B::load_unaligned(a + i + W);      a1 = fma(v1, v1, a1);
-        B v2 = B::load_unaligned(a + i + 2 * W);  a2 = fma(v2, v2, a2);
-        B v3 = B::load_unaligned(a + i + 3 * W);  a3 = fma(v3, v3, a3);
+    if constexpr (std::is_floating_point_v<T>) {   // see reduce_dot / header note
+        constexpr std::size_t U = 4;
+        constexpr std::size_t step = W * U;
+        for (; i + step <= n; i += step) {
+            B v0 = B::load_unaligned(a + i);          a0 = fma(v0, v0, a0);
+            B v1 = B::load_unaligned(a + i + W);      a1 = fma(v1, v1, a1);
+            B v2 = B::load_unaligned(a + i + 2 * W);  a2 = fma(v2, v2, a2);
+            B v3 = B::load_unaligned(a + i + 3 * W);  a3 = fma(v3, v3, a3);
+        }
     }
     for (; i + W <= n; i += W) { B v = B::load_unaligned(a + i); a0 = fma(v, v, a0); }
     T s = reduce_add((a0 + a1) + (a2 + a3));

--- a/include/mtl/simd/algorithm.hpp
+++ b/include/mtl/simd/algorithm.hpp
@@ -81,7 +81,7 @@ T reduce_dot(const T* a, const T* b, std::size_t n) {
         a0 = fma(B::load_unaligned(a + i), B::load_unaligned(b + i), a0);
     T s = reduce_add((a0 + a1) + (a2 + a3));
     for (; i < n; ++i)                       // scalar tail
-        s = detail::wrap_add(s, detail::wrap_mul(a[i], b[i]));
+        s = mtl::detail::wrap_add(s, mtl::detail::wrap_mul(a[i], b[i]));
     return s;
 }
 
@@ -134,7 +134,7 @@ T reduce_sum_squares(const T* a, std::size_t n) {
     }
     for (; i + W <= n; i += W) { B v = B::load_unaligned(a + i); a0 = fma(v, v, a0); }
     T s = reduce_add((a0 + a1) + (a2 + a3));
-    for (; i < n; ++i) s = detail::wrap_add(s, detail::wrap_mul(a[i], a[i]));
+    for (; i < n; ++i) s = mtl::detail::wrap_add(s, mtl::detail::wrap_mul(a[i], a[i]));
     return s;
 }
 
@@ -150,7 +150,7 @@ void axpy(T alpha, const T* x, T* y, std::size_t n) {
         B r = fma(va, B::load_unaligned(x + i), B::load_unaligned(y + i));
         r.store_unaligned(y + i);
     }
-    for (; i < n; ++i) y[i] = detail::wrap_add(y[i], detail::wrap_mul(alpha, x[i]));
+    for (; i < n; ++i) y[i] = mtl::detail::wrap_add(y[i], mtl::detail::wrap_mul(alpha, x[i]));
 }
 
 /// scal: x[i] *= alpha.
@@ -163,7 +163,7 @@ void scal(T alpha, T* x, std::size_t n) {
     std::size_t i = 0;
     for (; i + W <= n; i += W)
         (va * B::load_unaligned(x + i)).store_unaligned(x + i);
-    for (; i < n; ++i) x[i] = detail::wrap_mul(x[i], alpha);
+    for (; i < n; ++i) x[i] = mtl::detail::wrap_mul(x[i], alpha);
 }
 
 } // namespace mtl::simd

--- a/include/mtl/simd/batch.hpp
+++ b/include/mtl/simd/batch.hpp
@@ -84,9 +84,18 @@ namespace mtl::simd {
 /// 32-bit is exactly the width where the multiply is a single native
 /// instruction on every target ISA (`vpmulld` / NEON `mul.4s`), which is what
 /// makes it the honest plumbing case.
+///
+/// The floating half lists `float` and `double` rather than asking
+/// `std::is_floating_point_v`, which also admits `long double`. Highway has no
+/// `long double` vector type, so `batch<long double>` is a hard compile error
+/// there -- and since this trait gates `SimdDenseVector`, saying otherwise sent
+/// `dot(dense_vector<long double>, ...)` into `reduce_dot<long double>` and
+/// broke a build that previously worked, because the old `BlasDenseVector` gate
+/// kept it on the generic loop. The static_assert below already claimed "float,
+/// double, int32_t and uint32_t"; this is the trait finally agreeing with it.
 template <typename T>
 inline constexpr bool is_lane_v =
-    std::is_floating_point_v<T> ||
+    std::is_same_v<T, float>        || std::is_same_v<T, double> ||
     std::is_same_v<T, std::int32_t> || std::is_same_v<T, std::uint32_t>;
 
 /// True for the integer lane types -- the ones whose arithmetic WRAPS.

--- a/include/mtl/simd/batch.hpp
+++ b/include/mtl/simd/batch.hpp
@@ -47,6 +47,13 @@
 #include <cstdint>
 #include <type_traits>
 
+// wrap_add / wrap_sub / wrap_mul: the two's-complement helpers the scalar paths
+// here use. They live in mtl::detail rather than in this header because the
+// generic element-wise loops in operation/ need them for the same reason these
+// kernels do -- an integer op that misses the fast path must still land on the
+// documented answer instead of on signed-overflow UB.
+#include <mtl/detail/wrapping_arithmetic.hpp>
+
 #if defined(MTL5_HAS_HIGHWAY)
 #  include <hwy/highway.h>
 #  if HWY_HAVE_SCALABLE
@@ -85,50 +92,6 @@ inline constexpr bool is_lane_v =
 /// True for the integer lane types -- the ones whose arithmetic WRAPS.
 template <typename T>
 inline constexpr bool is_integer_lane_v = is_lane_v<T> && std::is_integral_v<T>;
-
-namespace detail {
-
-// Two's-complement wrapping add/multiply for the scalar paths (the fallback
-// backend and every kernel's scalar tail).
-//
-// This is not pedantry. Signed integer overflow is UB in C++, so a tail written
-// `s += a[i] * b[i]` over int32 is UB the moment it overflows -- while the SIMD
-// body it completes wraps silently and defines the result. Routing the scalar
-// arithmetic through the unsigned counterpart makes both halves agree on the
-// SAME well-defined value: C++20 fixes two's complement, so the round trip
-// through std::make_unsigned_t is exact and the narrowing cast back is modular
-// rather than implementation-defined. Floating lanes fall through unchanged.
-template <typename T>
-constexpr T wrap_add(T a, T b) noexcept {
-    if constexpr (std::is_integral_v<T>) {
-        using U = std::make_unsigned_t<T>;
-        return static_cast<T>(static_cast<U>(static_cast<U>(a) + static_cast<U>(b)));
-    } else {
-        return a + b;
-    }
-}
-
-template <typename T>
-constexpr T wrap_sub(T a, T b) noexcept {
-    if constexpr (std::is_integral_v<T>) {
-        using U = std::make_unsigned_t<T>;
-        return static_cast<T>(static_cast<U>(static_cast<U>(a) - static_cast<U>(b)));
-    } else {
-        return a - b;
-    }
-}
-
-template <typename T>
-constexpr T wrap_mul(T a, T b) noexcept {
-    if constexpr (std::is_integral_v<T>) {
-        using U = std::make_unsigned_t<T>;
-        return static_cast<T>(static_cast<U>(static_cast<U>(a) * static_cast<U>(b)));
-    } else {
-        return a * b;
-    }
-}
-
-} // namespace detail
 
 #if MTL5_SIMD_USE_HIGHWAY
 
@@ -246,9 +209,9 @@ public:
         return batch(static_cast<T>(p[0]));
     }
 
-    friend batch operator+(batch a, batch b) { return batch(detail::wrap_add(a.v_, b.v_)); }
-    friend batch operator-(batch a, batch b) { return batch(detail::wrap_sub(a.v_, b.v_)); }
-    friend batch operator*(batch a, batch b) { return batch(detail::wrap_mul(a.v_, b.v_)); }
+    friend batch operator+(batch a, batch b) { return batch(mtl::detail::wrap_add(a.v_, b.v_)); }
+    friend batch operator-(batch a, batch b) { return batch(mtl::detail::wrap_sub(a.v_, b.v_)); }
+    friend batch operator*(batch a, batch b) { return batch(mtl::detail::wrap_mul(a.v_, b.v_)); }
 
     /// Lane-wise division -- floating lanes only; see the Highway variant for why.
     friend batch operator/(batch a, batch b)
@@ -262,7 +225,7 @@ public:
     /// Highway backend's `MulAdd` lane for lane.
     friend batch fma(batch a, batch b, batch c) {
         if constexpr (std::is_integral_v<T>) {
-            return batch(detail::wrap_add(detail::wrap_mul(a.v_, b.v_), c.v_));
+            return batch(mtl::detail::wrap_add(mtl::detail::wrap_mul(a.v_, b.v_), c.v_));
         } else {
             using std::fma;
             return batch(fma(a.v_, b.v_, c.v_));

--- a/include/mtl/simd/batch.hpp
+++ b/include/mtl/simd/batch.hpp
@@ -19,9 +19,32 @@
 //
 // The API surface is identical across backends, so the dense kernels (#86-#90)
 // never need to know which one is active.
+//
+// LANE TYPES AND THE INTEGER OVERFLOW CONTRACT (#451 phase 0)
+//
+// Supported lanes are float, double, int32_t and uint32_t -- see is_lane_v for
+// why the integer entry stops at 32 bits. Integer arithmetic here is
+// **two's-complement wrapping**: + - * and fma each return the exact
+// mathematical result reduced mod 2^32. That is not a fallback, it is the
+// native semantics of every target ISA (Highway specifies `operator*` as
+// "truncating to the lower half for integer inputs"), and it buys a property
+// floating point cannot offer:
+//
+//   addition mod 2^32 is associative and commutative, so an integer reduction
+//   is BIT-IDENTICAL across lane counts, unroll factors, backends and thread
+//   partitions.
+//
+// A float reduce_dot has to qualify every equality claim with an accumulation
+// order; the int32 one does not. The cost is that the caller owns overflow:
+// int32 x int32 accumulated in int32 wraps within a couple of terms at full
+// range. Choosing an accumulator wide enough for the data is #451 phases 2-3,
+// and tests/unit/simd/test_int_accumulation.cpp already pins the envelope.
+//
+// Division is NOT provided for integer lanes -- deliberately; see operator/.
 
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <type_traits>
 
 #if defined(MTL5_HAS_HIGHWAY)
@@ -37,6 +60,76 @@
 
 namespace mtl::simd {
 
+/// Lane types `batch<T>` supports.
+///
+/// Real floating point (the dense-BLAS case), plus **32-bit integers** as of
+/// phase 0 of the integer-lane epic (#451). The integer entry is deliberately
+/// narrow:
+///
+///   * 8- and 16-bit lanes are excluded because their VALUE is the widening
+///     accumulate (`vpdpbusd` / `vpdpwssd` / SDOT), not the plain lane -- and
+///     x86 has no 8-bit vector multiply at all. They arrive with the
+///     accumulator contract, in phases 2-3.
+///   * 64-bit lanes are excluded because `Mul` is emulated on x86 before
+///     AVX512DQ, so a `batch<int64_t>` would advertise a vector multiply that
+///     is a scalar loop in disguise.
+///
+/// 32-bit is exactly the width where the multiply is a single native
+/// instruction on every target ISA (`vpmulld` / NEON `mul.4s`), which is what
+/// makes it the honest plumbing case.
+template <typename T>
+inline constexpr bool is_lane_v =
+    std::is_floating_point_v<T> ||
+    std::is_same_v<T, std::int32_t> || std::is_same_v<T, std::uint32_t>;
+
+/// True for the integer lane types -- the ones whose arithmetic WRAPS.
+template <typename T>
+inline constexpr bool is_integer_lane_v = is_lane_v<T> && std::is_integral_v<T>;
+
+namespace detail {
+
+// Two's-complement wrapping add/multiply for the scalar paths (the fallback
+// backend and every kernel's scalar tail).
+//
+// This is not pedantry. Signed integer overflow is UB in C++, so a tail written
+// `s += a[i] * b[i]` over int32 is UB the moment it overflows -- while the SIMD
+// body it completes wraps silently and defines the result. Routing the scalar
+// arithmetic through the unsigned counterpart makes both halves agree on the
+// SAME well-defined value: C++20 fixes two's complement, so the round trip
+// through std::make_unsigned_t is exact and the narrowing cast back is modular
+// rather than implementation-defined. Floating lanes fall through unchanged.
+template <typename T>
+constexpr T wrap_add(T a, T b) noexcept {
+    if constexpr (std::is_integral_v<T>) {
+        using U = std::make_unsigned_t<T>;
+        return static_cast<T>(static_cast<U>(static_cast<U>(a) + static_cast<U>(b)));
+    } else {
+        return a + b;
+    }
+}
+
+template <typename T>
+constexpr T wrap_sub(T a, T b) noexcept {
+    if constexpr (std::is_integral_v<T>) {
+        using U = std::make_unsigned_t<T>;
+        return static_cast<T>(static_cast<U>(static_cast<U>(a) - static_cast<U>(b)));
+    } else {
+        return a - b;
+    }
+}
+
+template <typename T>
+constexpr T wrap_mul(T a, T b) noexcept {
+    if constexpr (std::is_integral_v<T>) {
+        using U = std::make_unsigned_t<T>;
+        return static_cast<T>(static_cast<U>(static_cast<U>(a) * static_cast<U>(b)));
+    } else {
+        return a * b;
+    }
+}
+
+} // namespace detail
+
 #if MTL5_SIMD_USE_HIGHWAY
 
 namespace hn = hwy::HWY_NAMESPACE;
@@ -44,11 +137,11 @@ namespace hn = hwy::HWY_NAMESPACE;
 /// SIMD register of `T`, backed by Google Highway (static dispatch).
 template <typename T>
 class batch {
-    static_assert(std::is_floating_point_v<T>,
-                  "mtl::simd::batch currently supports floating-point lanes "
-                  "(float/double) -- the dense-BLAS use case. The ops (/, fma, "
-                  "reductions) assume floating semantics; integer lanes are a "
-                  "future extension.");
+    static_assert(is_lane_v<T>,
+                  "mtl::simd::batch supports float, double, int32_t and uint32_t "
+                  "lanes. 8/16-bit integers arrive with the widening accumulate "
+                  "(#451 phases 2-3); 64-bit integer multiply is emulated on x86 "
+                  "before AVX512DQ.");
     using D = hn::ScalableTag<T>;
     using V = hn::VFromD<D>;
     static constexpr D d_{};
@@ -71,8 +164,16 @@ public:
     /// Load `size` values of a NARROWER type `Src` and widen each lane to `T`
     /// (e.g. load float, accumulate in double). The float descriptor is rebound
     /// to the same lane count as `T`'s, so exactly `size` source values are read.
+    ///
+    /// Floating lanes only. Widening an integer lane is the whole substance of
+    /// #451 phases 2-3 -- it has to pick a signedness convention and an overflow
+    /// contract for the accumulate -- so it is excluded here rather than
+    /// inherited by accident from `sizeof(Src) < sizeof(T)`.
     template <typename Src>
     static batch load_widen(const Src* p) {
+        static_assert(std::is_floating_point_v<T> && std::is_floating_point_v<Src>,
+                      "load_widen is floating-point only; widening integer lanes "
+                      "needs an accumulator contract (#451 phases 2-3)");
         static_assert(sizeof(Src) < sizeof(T),
                       "load_widen widens; use load_unaligned for equal-width types");
         const hn::Rebind<Src, D> ds;
@@ -82,9 +183,27 @@ public:
     friend batch operator+(batch a, batch b) { return batch(hn::Add(a.v_, b.v_)); }
     friend batch operator-(batch a, batch b) { return batch(hn::Sub(a.v_, b.v_)); }
     friend batch operator*(batch a, batch b) { return batch(hn::Mul(a.v_, b.v_)); }
-    friend batch operator/(batch a, batch b) { return batch(hn::Div(a.v_, b.v_)); }
+
+    /// Lane-wise division -- FLOATING LANES ONLY, and the omission is deliberate.
+    ///
+    /// Highway does offer an integer `Div`, but it is implementation-defined
+    /// where `b[i] == 0` and where `a[i] == INT_MIN && b[i] == -1`, and it
+    /// truncates. #450 took exactly this position one level up: `Field` now
+    /// excludes the integers so `lu_factor(dense2D<int>)` fails to compile
+    /// rather than returning a truncated factorization. Offering `batch<int32_t>
+    /// / batch<int32_t>` would reopen that door underneath the concept. Generic
+    /// code that divides therefore fails to compile on integer lanes, which is
+    /// the intended answer.
+    friend batch operator/(batch a, batch b)
+        requires std::is_floating_point_v<T>
+    { return batch(hn::Div(a.v_, b.v_)); }
 
     /// Fused multiply-add: a*b + c (the single FMA decision point).
+    ///
+    /// On integer lanes there is nothing to fuse and nothing to round: `MulAdd`
+    /// is a multiply and an add, and the result is the exact product-sum reduced
+    /// mod 2^32. So the "fused" in the name is a floating-point concern only,
+    /// and the integer answer is exact by construction.
     friend batch fma(batch a, batch b, batch c) { return batch(hn::MulAdd(a.v_, b.v_, c.v_)); }
 
     friend T reduce_add(batch a) { return hn::ReduceSum(d_, a.v_); }
@@ -96,11 +215,11 @@ public:
 
 template <typename T>
 class batch {
-    static_assert(std::is_floating_point_v<T>,
-                  "mtl::simd::batch currently supports floating-point lanes "
-                  "(float/double) -- the dense-BLAS use case. The ops (/, fma, "
-                  "reductions) assume floating semantics; integer lanes are a "
-                  "future extension.");
+    static_assert(is_lane_v<T>,
+                  "mtl::simd::batch supports float, double, int32_t and uint32_t "
+                  "lanes. 8/16-bit integers arrive with the widening accumulate "
+                  "(#451 phases 2-3); 64-bit integer multiply is emulated on x86 "
+                  "before AVX512DQ.");
     T v_{};
 
 public:
@@ -119,20 +238,35 @@ public:
     /// widening load; see the Highway variant).
     template <typename Src>
     static batch load_widen(const Src* p) {
+        static_assert(std::is_floating_point_v<T> && std::is_floating_point_v<Src>,
+                      "load_widen is floating-point only; widening integer lanes "
+                      "needs an accumulator contract (#451 phases 2-3)");
         static_assert(sizeof(Src) < sizeof(T),
                       "load_widen widens; use load_unaligned for equal-width types");
         return batch(static_cast<T>(p[0]));
     }
 
-    friend batch operator+(batch a, batch b) { return batch(a.v_ + b.v_); }
-    friend batch operator-(batch a, batch b) { return batch(a.v_ - b.v_); }
-    friend batch operator*(batch a, batch b) { return batch(a.v_ * b.v_); }
-    friend batch operator/(batch a, batch b) { return batch(a.v_ / b.v_); }
+    friend batch operator+(batch a, batch b) { return batch(detail::wrap_add(a.v_, b.v_)); }
+    friend batch operator-(batch a, batch b) { return batch(detail::wrap_sub(a.v_, b.v_)); }
+    friend batch operator*(batch a, batch b) { return batch(detail::wrap_mul(a.v_, b.v_)); }
+
+    /// Lane-wise division -- floating lanes only; see the Highway variant for why.
+    friend batch operator/(batch a, batch b)
+        requires std::is_floating_point_v<T>
+    { return batch(a.v_ / b.v_); }
 
     /// Fused multiply-add: a*b + c (the single FMA decision point).
+    ///
+    /// `std::fma` is a floating-point function, so the integer case is the plain
+    /// wrapping multiply-add -- which is exact mod 2^32 and therefore matches the
+    /// Highway backend's `MulAdd` lane for lane.
     friend batch fma(batch a, batch b, batch c) {
-        using std::fma;
-        return batch(fma(a.v_, b.v_, c.v_));
+        if constexpr (std::is_integral_v<T>) {
+            return batch(detail::wrap_add(detail::wrap_mul(a.v_, b.v_), c.v_));
+        } else {
+            using std::fma;
+            return batch(fma(a.v_, b.v_, c.v_));
+        }
     }
 
     friend T reduce_add(batch a) { return a.v_; }

--- a/tests/unit/detail/test_wrapping_arithmetic.cpp
+++ b/tests/unit/detail/test_wrapping_arithmetic.cpp
@@ -1,0 +1,120 @@
+// mtl::detail wrapping arithmetic -- the modular helpers behind the integer
+// contract in #451.
+//
+// Two things are being pinned here, and the first is subtler than it looks.
+//
+// 1. THE OPERATION MUST BE PERFORMED WIDE ENOUGH.
+//
+//    Casting the operands to `std::make_unsigned_t<T>` is not sufficient to
+//    make the arithmetic defined. Integral promotion runs before any operator
+//    and promotes anything narrower than `int` to *signed* `int`, so for
+//    T = int16_t the expression `uint16_t(-1) * uint16_t(-1)` is `65535 * 65535`
+//    evaluated in `int` -- which overflows, and is undefined. The unsigned cast
+//    intended to prevent UB reintroduced it for every type narrower than `int`.
+//    Reachable from the public API: `dot_real` over a `dense_vector<int16_t>`
+//    of -1s tripped it. The helpers now multiply in
+//    `common_type_t<make_unsigned_t<T>, unsigned>`, so the operation stays
+//    unsigned, where overflow is defined as reduction.
+//
+//    The cases below therefore sweep every standard width, INCLUDING the
+//    narrow ones that no mtl::simd lane type uses -- `generic_fma` is
+//    instantiated on whatever element type a caller's vector holds, not on the
+//    lane types, so int8_t and int16_t are live even while batch<> rejects them.
+//    Run this file under -fsanitize=undefined to make the claim real.
+//
+// 2. `generic_fma` MAY ONLY TAKE THE MODULAR PATH WHEN EVERYTHING IS INTEGRAL.
+//
+//    It converts the operands to the result type before multiplying, which is
+//    lossless between integers -- reduction mod 2^N is a ring homomorphism -- but
+//    destructive with a floating-point operand and an integral result, where it
+//    would turn 2.5 * 2.5 into 2 * 2 rather than rounding 6.25 once.
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+
+#include <mtl/detail/wrapping_arithmetic.hpp>
+
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
+namespace {
+
+/// Reference: do it in 64-bit unsigned, then reduce to T's width. Correct for
+/// 64-bit T too, since uint64 arithmetic already wraps mod 2^64.
+template <typename T, typename Op>
+T ref(T a, T b, Op op) {
+    using U = std::make_unsigned_t<T>;
+    const std::uint64_t wide = op(static_cast<std::uint64_t>(static_cast<U>(a)),
+                                  static_cast<std::uint64_t>(static_cast<U>(b)));
+    const std::uint64_t mask = sizeof(T) == 8
+        ? ~std::uint64_t{0}
+        : (std::uint64_t{1} << (8 * sizeof(T))) - 1;
+    return static_cast<T>(static_cast<U>(wide & mask));
+}
+
+} // namespace
+
+TEMPLATE_TEST_CASE("wrapping arithmetic is modular at every width", "[detail][wrapping]",
+                   std::int8_t, std::uint8_t, std::int16_t, std::uint16_t,
+                   std::int32_t, std::uint32_t, std::int64_t, std::uint64_t) {
+    using T = TestType;
+    constexpr T lo = std::numeric_limits<T>::lowest();
+    constexpr T hi = std::numeric_limits<T>::max();
+    const T values[] = {T(0), T(1), T(2), T(3), lo, hi, static_cast<T>(hi - 1),
+                        static_cast<T>(lo + 1), static_cast<T>(-1), static_cast<T>(hi / 2)};
+
+    for (T a : values)
+        for (T b : values) {
+            INFO("a=" << std::int64_t(a) << " b=" << std::int64_t(b)
+                      << " width=" << (8 * sizeof(T)));
+            CHECK(mtl::detail::wrap_add(a, b) == ref(a, b, [](auto x, auto y) { return x + y; }));
+            CHECK(mtl::detail::wrap_sub(a, b) == ref(a, b, [](auto x, auto y) { return x - y; }));
+            CHECK(mtl::detail::wrap_mul(a, b) == ref(a, b, [](auto x, auto y) { return x * y; }));
+        }
+}
+
+TEST_CASE("the narrow-width promotion case, stated directly", "[detail][wrapping]") {
+    // Each of these was signed-overflow UB when the multiply was performed in
+    // the promoted `int` rather than in an unsigned type wide enough to hold it.
+    CHECK(mtl::detail::wrap_mul<std::int16_t>(-1, -1) == 1);
+    CHECK(mtl::detail::wrap_mul<std::uint16_t>(65535, 65535) == 1);
+    CHECK(mtl::detail::wrap_mul<std::int16_t>(256, 256) == 0);       // 65536 mod 2^16
+    CHECK(mtl::detail::wrap_mul<std::int8_t>(-1, -1) == 1);
+    CHECK(mtl::detail::wrap_mul<std::int16_t>(181, 181) == 32761);   // no wrap, still exact
+}
+
+TEST_CASE("bool is not a wrapping integer", "[detail][wrapping]") {
+    // std::make_unsigned_t<bool> is ill-formed, so bool must not reach the
+    // modular branch -- a dense_vector<bool> would otherwise fail to compile.
+    STATIC_REQUIRE_FALSE(mtl::detail::is_wrapping_integer_v<bool>);
+    STATIC_REQUIRE(mtl::detail::is_wrapping_integer_v<std::int32_t>);
+    STATIC_REQUIRE_FALSE(mtl::detail::is_wrapping_integer_v<double>);
+    CHECK(mtl::detail::generic_fma<bool>(false, true, true) == true);
+}
+
+TEST_CASE("generic_fma wraps only when every operand is integral", "[detail][wrapping]") {
+    SECTION("all integral -> modular, and exact mod 2^N") {
+        const auto a = static_cast<std::int32_t>(0x9E3779B9u);
+        const auto b = static_cast<std::int32_t>(0x85EBCA77u);
+        const auto expect = static_cast<std::int32_t>(static_cast<std::uint32_t>(
+            static_cast<std::uint64_t>(static_cast<std::uint32_t>(a)) *
+            static_cast<std::uint32_t>(b) + 7u));
+        CHECK(mtl::detail::generic_fma<std::int32_t>(7, a, b) == expect);
+    }
+
+    SECTION("narrowing the operands to the result width is lossless") {
+        // (a mod 2^32)(b mod 2^32) == (a b) mod 2^32, so an int64 operand pair
+        // with an int32 result gets the same low bits either way.
+        const std::int64_t a = 0x1'0000'9E37LL, b = 0x2'0000'85EBLL;
+        const auto expect = static_cast<std::int32_t>(
+            static_cast<std::uint32_t>(static_cast<std::uint64_t>(a) * static_cast<std::uint64_t>(b)));
+        CHECK(mtl::detail::generic_fma<std::int32_t>(0, a, b) == expect);
+    }
+
+    SECTION("floating operands with an integral result keep the plain expression") {
+        // Truncating first would give int(2.5) * int(2.5) == 4; the original
+        // expression accumulates 6.25 and rounds once on conversion.
+        CHECK(mtl::detail::generic_fma<int>(0, 2.5, 2.5) == 6);
+        CHECK(mtl::detail::generic_fma<double>(1.0, 2.5, 2.5) == 7.25);
+    }
+}

--- a/tests/unit/detail/test_wrapping_arithmetic.cpp
+++ b/tests/unit/detail/test_wrapping_arithmetic.cpp
@@ -92,6 +92,21 @@ TEST_CASE("bool is not a wrapping integer", "[detail][wrapping]") {
     CHECK(mtl::detail::generic_fma<bool>(false, true, true) == true);
 }
 
+TEST_CASE("a bool OPERAND still takes the modular path", "[detail][wrapping]") {
+    // The asymmetry is deliberate and easy to get backwards. `bool` is excluded
+    // as a RESULT type, because make_unsigned_t<bool> is ill-formed. It must NOT
+    // be excluded as an OPERAND: converting it to an integral result is exact
+    // (0 or 1), and pushing the expression onto the plain branch instead would
+    // reinstate the signed-overflow UB the helper exists to remove. Reachable as
+    // dot(dense_vector<bool>, dense_vector<int32_t>), whose result type is int.
+    constexpr auto big = std::numeric_limits<std::int32_t>::max();
+    CHECK(mtl::detail::generic_fma<std::int32_t>(1, true, big) ==
+          static_cast<std::int32_t>(static_cast<std::uint32_t>(1u) +
+                                    static_cast<std::uint32_t>(big)));
+    CHECK(mtl::detail::generic_fma<std::int32_t>(5, false, big) == 5);
+    CHECK(mtl::detail::generic_fma<std::int32_t>(0, true, true) == 1);
+}
+
 TEST_CASE("generic_fma wraps only when every operand is integral", "[detail][wrapping]") {
     SECTION("all integral -> modular, and exact mod 2^N") {
         const auto a = static_cast<std::int32_t>(0x9E3779B9u);

--- a/tests/unit/operation/test_dot.cpp
+++ b/tests/unit/operation/test_dot.cpp
@@ -132,3 +132,21 @@ TEST_CASE("generic integer mat*vec wraps rather than overflowing",
         REQUIRE(y(i) == static_cast<std::int32_t>(static_cast<std::uint32_t>(acc)));
     }
 }
+
+// Element types NARROWER than a SIMD lane still reach the generic loop, and
+// therefore mtl::detail::generic_fma. int16_t is the width where the modular
+// helpers were undefined: uint16_t operands promote to signed `int`, so
+// 65535 * 65535 overflowed it. `dot_real` over a vector of -1 is the shortest
+// path from the public API to that bug.
+TEST_CASE("dot over a 16-bit element type is defined and modular",
+          "[operation][dot][integer][generic]") {
+    STATIC_REQUIRE_FALSE(mtl::interface::SimdDenseVector<dense_vector<std::int16_t>>);
+
+    dense_vector<std::int16_t> u(4), v(4);
+    for (std::size_t i = 0; i < 4; ++i) { u(i) = -1; v(i) = -1; }
+    CHECK(dot_real(u, v) == 4);                       // (-1)*(-1) four times
+
+    // And a case that actually wraps: 256 * 256 == 0 mod 2^16, summed 3 times.
+    dense_vector<std::int16_t> p(3, static_cast<std::int16_t>(256));
+    CHECK(dot_real(p, p) == 0);
+}

--- a/tests/unit/operation/test_dot.cpp
+++ b/tests/unit/operation/test_dot.cpp
@@ -1,8 +1,11 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <mtl/interface/dispatch_traits.hpp>
 #include <mtl/vec/dense_vector.hpp>
 #include <mtl/operation/dot.hpp>
 #include <complex>
+#include <cstddef>
+#include <cstdint>
 
 using namespace mtl;
 using Catch::Matchers::WithinAbs;
@@ -61,4 +64,41 @@ TEST_CASE("dot product of single-element vectors", "[operation][dot]") {
     dense_vector<double> a = {5.0};
     dense_vector<double> b = {3.0};
     REQUIRE(dot(a, b) == 15.0);
+}
+
+// Integer dot after #451 phase 0: same values, different route. dense_vector<int>
+// used to fall to the generic accumulate loop because the SIMD gate asked for a
+// BLAS scalar type; it now goes through simd::reduce_dot. The results below are
+// small enough to be order-independent either way -- the point of stating them
+// is that widening the gate did not change any answer.
+TEST_CASE("integer dot takes the SIMD path and keeps its values", "[operation][dot][integer]") {
+    STATIC_REQUIRE(mtl::interface::SimdDenseVector<dense_vector<std::int32_t>>);
+    STATIC_REQUIRE_FALSE(mtl::interface::BlasDenseVector<dense_vector<std::int32_t>>);
+
+    dense_vector<std::int32_t> a = {1, 2, 3, 4, 5};
+    dense_vector<std::int32_t> b = {2, 3, 4, 5, 6};
+    // 2 + 6 + 12 + 20 + 30 = 70
+    CHECK(dot(a, b) == 70);
+    CHECK(dot_real(a, b) == 70);
+}
+
+// Long enough to run the four-accumulator SIMD body, the single-batch loop and
+// the scalar tail, with operands large enough that the sum overflows int32 many
+// times over. The contract is that the answer is the exact sum reduced mod 2^32,
+// and that it does not depend on where the kernel happened to split the work.
+TEST_CASE("integer dot overflows into a defined value, not an order-dependent one",
+          "[operation][dot][integer]") {
+    constexpr std::size_t n = 1031;                       // prime, so tails are ragged
+    dense_vector<std::int32_t> a(n), b(n);
+    std::uint64_t acc = 0;
+    for (std::size_t i = 0; i < n; ++i) {
+        const auto ai = static_cast<std::uint32_t>(0x9E3779B9u * (i + 1));
+        const auto bi = static_cast<std::uint32_t>(0x85EBCA77u * (i + 3));
+        a(i) = static_cast<std::int32_t>(ai);
+        b(i) = static_cast<std::int32_t>(bi);
+        acc += static_cast<std::uint64_t>(ai) * bi;       // uint64 wrap keeps low 32 bits
+    }
+    const auto expected = static_cast<std::int32_t>(static_cast<std::uint32_t>(acc));
+    CHECK(dot(a, b) == expected);
+    CHECK(dot_real(a, b) == expected);
 }

--- a/tests/unit/operation/test_dot.cpp
+++ b/tests/unit/operation/test_dot.cpp
@@ -3,6 +3,8 @@
 #include <mtl/interface/dispatch_traits.hpp>
 #include <mtl/vec/dense_vector.hpp>
 #include <mtl/operation/dot.hpp>
+#include <mtl/operation/mult.hpp>
+#include <mtl/mat/dense2D.hpp>
 #include <complex>
 #include <cstddef>
 #include <cstdint>
@@ -101,4 +103,32 @@ TEST_CASE("integer dot overflows into a defined value, not an order-dependent on
     const auto expected = static_cast<std::int32_t>(static_cast<std::uint32_t>(acc));
     CHECK(dot(a, b) == expected);
     CHECK(dot_real(a, b) == expected);
+}
+
+// The GENERIC dense mult path, which is what an integer matrix takes in the
+// DEFAULT build: MTL5_NATIVE_FAST_GEMM is off, so mult() falls to
+// detail::mult_generic. Its inner loop used to be `acc += A(r,c) * x(c)`, which
+// on int32 is signed-overflow UB and disagrees with the mod-2^32 answer the SIMD
+// kernel is documented to give. Both paths must land on the same value.
+TEST_CASE("generic integer mat*vec wraps rather than overflowing",
+          "[operation][mult][integer][generic]") {
+    constexpr std::size_t n = 37;
+    mtl::mat::dense2D<std::int32_t> A(n, n);
+    dense_vector<std::int32_t> x(n), y(n);
+    for (std::size_t i = 0; i < n; ++i) {
+        x(i) = static_cast<std::int32_t>(static_cast<std::uint32_t>(0x85EBCA77u * (i + 3)));
+        for (std::size_t j = 0; j < n; ++j)
+            A(i, j) = static_cast<std::int32_t>(
+                static_cast<std::uint32_t>(0x9E3779B9u * (i * n + j + 1)));
+    }
+    mtl::mult(A, x, y);                       // generic path (no MTL5_NATIVE_FAST_GEMM here)
+
+    for (std::size_t i = 0; i < n; ++i) {
+        std::uint64_t acc = 0;
+        for (std::size_t j = 0; j < n; ++j)
+            acc += static_cast<std::uint64_t>(static_cast<std::uint32_t>(A(i, j)))
+                 * static_cast<std::uint32_t>(x(j));
+        INFO("row " << i);
+        REQUIRE(y(i) == static_cast<std::int32_t>(static_cast<std::uint32_t>(acc)));
+    }
 }

--- a/tests/unit/operation/test_dot.cpp
+++ b/tests/unit/operation/test_dot.cpp
@@ -150,3 +150,58 @@ TEST_CASE("dot over a 16-bit element type is defined and modular",
     dense_vector<std::int16_t> p(3, static_cast<std::int16_t>(256));
     CHECK(dot_real(p, p) == 0);
 }
+
+// The mat*mat generic loop is the sibling of the mat*vec one above and took the
+// identical generic_fma change, but nothing exercised it with integers -- the
+// only mult(A, B, C) coverage is over double. A changed line with no test is
+// exactly where the next defect hides, so pin it the same way.
+TEST_CASE("generic integer mat*mat wraps rather than overflowing",
+          "[operation][mult][integer][generic]") {
+    constexpr std::size_t n = 8;
+    mtl::mat::dense2D<std::int32_t> A(n, n), B(n, n), C(n, n);
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j) {
+            A(i, j) = static_cast<std::int32_t>(
+                static_cast<std::uint32_t>(0x9E3779B9u * (i * n + j + 1)));
+            B(i, j) = static_cast<std::int32_t>(
+                static_cast<std::uint32_t>(0x85EBCA77u * (i * n + j + 3)));
+        }
+    mtl::mult(A, B, C);
+
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j) {
+            std::uint64_t acc = 0;
+            for (std::size_t k = 0; k < n; ++k)
+                acc += static_cast<std::uint64_t>(static_cast<std::uint32_t>(A(i, k)))
+                     * static_cast<std::uint32_t>(B(k, j));
+            INFO("C(" << i << "," << j << ")");
+            REQUIRE(C(i, j) == static_cast<std::int32_t>(static_cast<std::uint32_t>(acc)));
+        }
+}
+
+// Mixed operands with an integral result must NOT take the modular path: casting
+// the factors to the result type first would turn 2.5 * 2.5 into 2 * 2. Checked
+// through mult() rather than generic_fma directly, so the guard is verified where
+// a caller would actually hit it.
+//
+// The expected value is the PRE-EXISTING semantics, which are worth stating
+// because they are not the obvious ones. `acc` has the result type, so with an
+// integral y the accumulator is an `int` and every term is rounded into it as it
+// is added -- the sum is not accumulated in double and rounded once at the end:
+//
+//     acc = 0;  acc += 2.5 * 2.5  ->  int(0 + 6.25)  = 6
+//               acc += 0.5 * 1.5  ->  int(6 + 0.75)  = 6
+//
+// so 6, not the 7 that accumulating in double would give. This test exists to
+// pin that behaviour UNCHANGED, not to endorse it; truncating the factors first
+// would have given 4, which is what the guard prevents.
+TEST_CASE("float operands with an integer result keep their rounding",
+          "[operation][mult][generic]") {
+    mtl::mat::dense2D<double> A(1, 2);
+    dense_vector<double> x(2);
+    dense_vector<int> y(1);
+    A(0, 0) = 2.5; A(0, 1) = 0.5;
+    x(0) = 2.5;    x(1) = 1.5;
+    mtl::mult(A, x, y);
+    CHECK(y(0) == 6);          // per-term rounding; truncate-first would give 4
+}

--- a/tests/unit/operation/test_gemv.cpp
+++ b/tests/unit/operation/test_gemv.cpp
@@ -3,6 +3,10 @@
 // SIMD/FMA order, so we compare bit-exactly to a naive reference. One assertion
 // per configuration (bool "all matched"), not one per element.
 //
+// The int32_t/uint32_t arms (#451 phase 0) get that exactness unconditionally:
+// integer arithmetic here is wrapping, and wrapping addition is associative, so
+// the naive reference and the kernel agree bit for bit whatever the lane count.
+//
 // Define the gate BEFORE including mult.hpp so the native path is exercised
 // through mtl::mult for this translation unit.
 #define MTL5_NATIVE_FAST_GEMM 1
@@ -11,6 +15,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 
 #include <mtl/detail/gemv.hpp>
+#include <mtl/interface/dispatch_traits.hpp>
 #include <mtl/operation/mult.hpp>
 #include <mtl/mat/dense2D.hpp>
 #include <mtl/mat/parameter.hpp>
@@ -18,6 +23,7 @@
 #include <mtl/vec/dense_vector.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <vector>
 
 namespace {
@@ -52,7 +58,11 @@ const std::size_t kDims[] = {0, 1, 2, 3, 4, 5, 7, 8, 9, 13, 16, 17, 31, 33, 64, 
 
 } // namespace
 
-TEMPLATE_TEST_CASE("gemv: row-major and col-major vs naive, all sizes", "[operation][gemv]", float, double) {
+// int32_t/uint32_t are lanes as of #451 phase 0. The naive reference below is
+// plain C++ integer arithmetic, so on the unsigned arm it wraps mod 2^32 exactly
+// as the kernel does -- the comparison stays bit-exact without special-casing.
+TEMPLATE_TEST_CASE("gemv: row-major and col-major vs naive, all sizes", "[operation][gemv]",
+                   float, double, std::int32_t, std::uint32_t) {
     for (std::size_t m : kDims)
         for (std::size_t n : kDims) {
             INFO("m=" << m << " n=" << n);
@@ -61,8 +71,9 @@ TEMPLATE_TEST_CASE("gemv: row-major and col-major vs naive, all sizes", "[operat
         }
 }
 
-// mult(A,x,y) dispatch: with MTL5_NATIVE_FAST_GEMM defined, dense2D float/double
-// x dense_vector routes through the native GEMV for both A orientations.
+// mult(A,x,y) dispatch: with MTL5_NATIVE_FAST_GEMM defined, a dense2D over any
+// mtl::simd lane type x dense_vector routes through the native GEMV for both A
+// orientations.
 namespace {
 using rowmaj = mtl::mat::parameters<mtl::tag::row_major>;
 using colmaj = mtl::mat::parameters<mtl::tag::col_major>;
@@ -87,11 +98,37 @@ bool mult_matches(std::size_t m, std::size_t n) {
 }
 } // namespace
 
-TEMPLATE_TEST_CASE("mult() native GEMV dispatch matches naive (row- and col-major A)", "[operation][gemv][dispatch]", float, double) {
+TEMPLATE_TEST_CASE("mult() native GEMV dispatch matches naive (row- and col-major A)",
+                   "[operation][gemv][dispatch]", float, double, std::int32_t, std::uint32_t) {
     const std::size_t cases[][2] = {{0, 0}, {0, 5}, {7, 0}, {1, 1}, {7, 5}, {16, 16}, {33, 20}, {100, 64}};
     for (auto& c : cases) {
         INFO("m=" << c[0] << " n=" << c[1]);
         CHECK(mult_matches<mtl::mat::dense2D<TestType, rowmaj>>(c[0], c[1]));
         CHECK(mult_matches<mtl::mat::dense2D<TestType, colmaj>>(c[0], c[1]));
     }
+}
+
+// The dispatch predicate itself, stated directly. The correctness cases above
+// would pass on the generic scalar loop too, so on their own they cannot show
+// that integer operands stopped taking it. This is the claim that changed in
+// #451 phase 0: the native GEMV is gated on SimdDenseMatrix/SimdDenseVector, and
+// an int32 dense2D satisfies that while satisfying no BLAS predicate -- there is
+// no external ?gemv for int32, so the native path is the only one it can take.
+TEST_CASE("integer operands satisfy the SIMD dispatch predicate, not the BLAS one",
+          "[operation][gemv][dispatch]") {
+    using imat = mtl::mat::dense2D<std::int32_t, rowmaj>;
+    using ivec = mtl::vec::dense_vector<std::int32_t>;
+    STATIC_REQUIRE(mtl::interface::SimdDenseMatrix<imat>);
+    STATIC_REQUIRE(mtl::interface::SimdDenseVector<ivec>);
+    STATIC_REQUIRE_FALSE(mtl::interface::BlasDenseMatrix<imat>);
+    STATIC_REQUIRE_FALSE(mtl::interface::BlasDenseVector<ivec>);
+
+    // ... and the float case still satisfies both, so the widening did not
+    // reroute anything that an external BLAS was handling.
+    using dmat = mtl::mat::dense2D<double, rowmaj>;
+    using dvec = mtl::vec::dense_vector<double>;
+    STATIC_REQUIRE(mtl::interface::SimdDenseMatrix<dmat>);
+    STATIC_REQUIRE(mtl::interface::BlasDenseMatrix<dmat>);
+    STATIC_REQUIRE(mtl::interface::SimdDenseVector<dvec>);
+    STATIC_REQUIRE(mtl::interface::BlasDenseVector<dvec>);
 }

--- a/tests/unit/operation/test_strided_dispatch.cpp
+++ b/tests/unit/operation/test_strided_dispatch.cpp
@@ -1,0 +1,124 @@
+// Non-contiguous vectors must not reach the contiguous fast paths.
+//
+// `strided_vector_ref` stores element i at `data()[i * stride()]`, but it
+// supplies both `data()` and `size()` -- which is all `BlasDenseVector` used to
+// ask for. So every operation gated on that concept accepted it and then walked
+// `data()` with unit stride, reading the wrong elements and returning a
+// confident wrong answer. On the stride-2 case below `dot_real` gave 14 where
+// the answer is 44: it summed {1,0,3}.{2,0,4} instead of {1,3,5}.{2,4,6}.
+//
+// This is not a corner case invented for the test. A column of a row-major
+// matrix is exactly such a view -- `strided_vector_ref<double> col(A.data() + j,
+// nrows, ncols)` is the documented construction in test_strided_vector_ref.cpp
+// -- so "dot product of two matrix columns" was silently wrong for float and
+// double alike, independent of the integer-lane work that exposed it.
+//
+// A stride is a runtime value, so no concept can admit only the unit-stride
+// instances; the fix excludes types that advertise `stride()` outright and lets
+// them take the generic element-wise loop, which indexes through `operator()`
+// and is right for any stride. These cases pin that, per operation, against a
+// hand-computed reference.
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <mtl/interface/dispatch_traits.hpp>
+#include <mtl/operation/axpy.hpp>
+#include <mtl/operation/dot.hpp>
+#include <mtl/operation/norms.hpp>
+#include <mtl/operation/scale.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/vec/strided_vector_ref.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+using Catch::Approx;
+
+TEST_CASE("strided vectors are excluded from the contiguous dispatch concepts",
+          "[operation][dispatch][strided]") {
+    using SVd = mtl::vec::strided_vector_ref<double>;
+    using SVi = mtl::vec::strided_vector_ref<std::int32_t>;
+    using DVd = mtl::vec::dense_vector<double>;
+    using DVi = mtl::vec::dense_vector<std::int32_t>;
+
+    // The layout predicate itself: a type that advertises stride() is not
+    // contiguous for dispatch purposes, whatever its stride happens to be.
+    STATIC_REQUIRE_FALSE(mtl::interface::ContiguousVector<SVd>);
+    STATIC_REQUIRE(mtl::interface::ContiguousVector<DVd>);
+
+    STATIC_REQUIRE_FALSE(mtl::interface::BlasDenseVector<SVd>);
+    STATIC_REQUIRE_FALSE(mtl::interface::SimdDenseVector<SVd>);
+    STATIC_REQUIRE_FALSE(mtl::interface::SimdDenseVector<SVi>);
+
+    // ... and the owning dense vectors still qualify, so nothing that was on a
+    // fast path lost it.
+    STATIC_REQUIRE(mtl::interface::BlasDenseVector<DVd>);
+    STATIC_REQUIRE(mtl::interface::SimdDenseVector<DVd>);
+    STATIC_REQUIRE(mtl::interface::SimdDenseVector<DVi>);
+}
+
+TEST_CASE("dot over strided views reads the strided elements", "[operation][dot][strided]") {
+    // {1,3,5} . {2,4,6} = 2 + 12 + 30 = 44.  The contiguous misread gives 14.
+    std::vector<double> a{1, 0, 3, 0, 5, 0}, b{2, 0, 4, 0, 6, 0};
+    mtl::vec::strided_vector_ref<double> x(a.data(), 3, 2), y(b.data(), 3, 2);
+
+    REQUIRE(x(0) == 1.0);
+    REQUIRE(x(2) == 5.0);
+    CHECK(mtl::dot_real(x, y) == Approx(44.0));
+    CHECK(mtl::dot(x, y) == Approx(44.0));
+}
+
+TEST_CASE("dot over strided integer views wraps like the SIMD path",
+          "[operation][dot][strided][integer]") {
+    // Integer lanes reach the same generic loop, and must land on the same
+    // mod-2^32 answer the contiguous kernel would give -- not on
+    // signed-overflow UB.
+    std::vector<std::int32_t> a(6), b(6);
+    std::uint64_t acc = 0;
+    for (std::size_t k = 0; k < 3; ++k) {
+        const auto ai = static_cast<std::uint32_t>(0x9E3779B9u * (k + 1));
+        const auto bi = static_cast<std::uint32_t>(0x85EBCA77u * (k + 3));
+        a[2 * k] = static_cast<std::int32_t>(ai);
+        b[2 * k] = static_cast<std::int32_t>(bi);
+        acc += static_cast<std::uint64_t>(ai) * bi;
+    }
+    mtl::vec::strided_vector_ref<std::int32_t> x(a.data(), 3, 2), y(b.data(), 3, 2);
+    const auto expected = static_cast<std::int32_t>(static_cast<std::uint32_t>(acc));
+    CHECK(mtl::dot_real(x, y) == expected);
+}
+
+TEST_CASE("two_norm over a strided view uses the strided elements",
+          "[operation][norms][strided]") {
+    std::vector<double> a{3, 99, 4, 99};                 // {3,4} -> 5
+    mtl::vec::strided_vector_ref<double> x(a.data(), 2, 2);
+    CHECK(mtl::two_norm(x) == Approx(5.0));
+}
+
+TEST_CASE("axpy and scale over strided views touch only the strided elements",
+          "[operation][axpy][scale][strided]") {
+    SECTION("axpy") {
+        std::vector<double> xs{1, -1, 2, -1, 3, -1};
+        std::vector<double> ys{10, -2, 20, -2, 30, -2};
+        mtl::vec::strided_vector_ref<double> x(xs.data(), 3, 2), y(ys.data(), 3, 2);
+        mtl::axpy(2.0, x, y);                            // y += 2x on the stride
+        CHECK(ys[0] == Approx(12.0));
+        CHECK(ys[2] == Approx(24.0));
+        CHECK(ys[4] == Approx(36.0));
+        CHECK(ys[1] == Approx(-2.0));                    // gaps untouched
+        CHECK(ys[3] == Approx(-2.0));
+        CHECK(ys[5] == Approx(-2.0));
+    }
+    SECTION("scale") {
+        std::vector<double> cs{1, -1, 2, -1, 3, -1};
+        mtl::vec::strided_vector_ref<double> c(cs.data(), 3, 2);
+        mtl::scale(3.0, c);
+        CHECK(cs[0] == Approx(3.0));
+        CHECK(cs[2] == Approx(6.0));
+        CHECK(cs[4] == Approx(9.0));
+        CHECK(cs[1] == Approx(-1.0));                    // gaps untouched
+        CHECK(cs[3] == Approx(-1.0));
+        CHECK(cs[5] == Approx(-1.0));
+    }
+}

--- a/tests/unit/simd/test_integer_lanes.cpp
+++ b/tests/unit/simd/test_integer_lanes.cpp
@@ -131,6 +131,14 @@ TEST_CASE("is_lane_v admits exactly the supported lane types", "[simd][integer]"
     STATIC_REQUIRE_FALSE(is_lane_v<std::uint64_t>);
     STATIC_REQUIRE_FALSE(is_lane_v<bool>);
 
+    // long double is NOT a lane, despite being a floating-point type. Highway
+    // has no long double vector, so batch<long double> is a hard compile error
+    // there -- and because this trait gates SimdDenseVector, admitting it sent
+    // dot(dense_vector<long double>, ...) into reduce_dot<long double> and broke
+    // a build that had worked, since the older BlasDenseVector gate (float and
+    // double only) kept it on the generic loop.
+    STATIC_REQUIRE_FALSE(is_lane_v<long double>);
+
     STATIC_REQUIRE(is_integer_lane_v<std::int32_t>);
     STATIC_REQUIRE(is_integer_lane_v<std::uint32_t>);
     STATIC_REQUIRE_FALSE(is_integer_lane_v<double>);

--- a/tests/unit/simd/test_integer_lanes.cpp
+++ b/tests/unit/simd/test_integer_lanes.cpp
@@ -50,6 +50,56 @@ T big_b(std::size_t i) { return static_cast<T>(static_cast<std::uint32_t>(0x85EB
 
 const std::size_t kLengths[] = {0, 1, 2, 3, 7, 8, 9, 15, 16, 17, 31, 33, 64, 100, 257};
 
+/// Closed-form mod-2^32 reference for the first `n` products.
+template <typename T>
+std::uint64_t ref_dot(const T* a, const T* b, std::size_t n) {
+    std::uint64_t acc = 0;
+    for (std::size_t i = 0; i < n; ++i) acc += bits(a[i]) * bits(b[i]);
+    return acc;
+}
+
+/// `reduce_dot` at a COMPILE-TIME-CONSTANT length, checked against both the
+/// closed form and the same call with the length made opaque.
+///
+/// The second comparison is the one that earns its place. A constant trip count
+/// is a different code path -- the compiler may unroll it, specialize the loop
+/// bounds, or vectorize it differently from the runtime-length version -- and
+/// the two must still agree. GCC 13 at -O3 -march=x86-64-v3 did not: it fused
+/// the four interleaved integer accumulator chains into one contiguous
+/// reduction and advanced three of them at half the required stride, so the
+/// constant-length answer was silently wrong while the runtime-length answer
+/// was right. Every test that reached reduce_dot through a runtime length
+/// passed. See the note in simd/algorithm.hpp.
+template <typename T, std::size_t N>
+bool const_length_ok(const T* a, const T* b) {
+    const T folded = mtl::simd::reduce_dot<T>(a, b, N);       // N is constant here
+    volatile std::size_t opaque = N;                          // ... and not here
+    const T runtime = mtl::simd::reduce_dot<T>(a, b, opaque);
+    return folded == runtime && folded == wrap32<T>(ref_dot(a, b, N));
+}
+
+template <typename T, std::size_t N>
+bool const_length_sq_ok(const T* a) {
+    const T folded = mtl::simd::reduce_sum_squares<T>(a, N);
+    volatile std::size_t opaque = N;
+    const T runtime = mtl::simd::reduce_sum_squares<T>(a, opaque);
+    return folded == runtime && folded == wrap32<T>(ref_dot(a, a, N));
+}
+
+template <typename T, std::size_t... Ns>
+std::vector<std::size_t> failing_dot_lengths(const T* a, const T* b) {
+    std::vector<std::size_t> bad;
+    ((const_length_ok<T, Ns>(a, b) ? void() : bad.push_back(Ns)), ...);
+    return bad;
+}
+
+template <typename T, std::size_t... Ns>
+std::vector<std::size_t> failing_sq_lengths(const T* a) {
+    std::vector<std::size_t> bad;
+    ((const_length_sq_ok<T, Ns>(a) ? void() : bad.push_back(Ns)), ...);
+    return bad;
+}
+
 /// Is `batch<T> / batch<T>` a valid expression?
 ///
 /// Written as a variable TEMPLATE rather than inline in the assertion on
@@ -196,6 +246,29 @@ TEMPLATE_TEST_CASE("integer reduce_dot equals the exact mod-2^32 sum",
         INFO("n=" << n);
         CHECK(mtl::simd::reduce_dot<TestType>(a.data(), b.data(), n) == wrap32<TestType>(acc));
     }
+}
+
+TEMPLATE_TEST_CASE("integer reductions agree at compile-time-constant lengths",
+                   "[simd][integer][l1]", std::int32_t, std::uint32_t) {
+    // Lengths chosen to straddle the SIMD width and the unroll factor on every
+    // backend, and to include the two that GCC 13 miscompiled (137, 257).
+    constexpr std::size_t kMax = 1031;
+    std::vector<TestType> a(kMax), b(kMax);
+    for (std::size_t i = 0; i < kMax; ++i) { a[i] = big_a<TestType>(i); b[i] = big_b<TestType>(i); }
+
+    const auto bad_dot = failing_dot_lengths<TestType,
+        1, 2, 3, 7, 8, 12, 13, 16, 17, 20, 25, 31, 33, 40, 64, 100,
+        128, 137, 200, 256, 257, 512, 1031>(a.data(), b.data());
+    for (std::size_t n : bad_dot)
+        UNSCOPED_INFO("reduce_dot disagrees at compile-time-constant length " << n);
+    CHECK(bad_dot.empty());
+
+    const auto bad_sq = failing_sq_lengths<TestType,
+        1, 2, 3, 7, 8, 12, 13, 16, 17, 20, 25, 31, 33, 40, 64, 100,
+        128, 137, 200, 256, 257, 512, 1031>(a.data());
+    for (std::size_t n : bad_sq)
+        UNSCOPED_INFO("reduce_sum_squares disagrees at compile-time-constant length " << n);
+    CHECK(bad_sq.empty());
 }
 
 TEMPLATE_TEST_CASE("integer reduce_dot is invariant under partitioning",

--- a/tests/unit/simd/test_integer_lanes.cpp
+++ b/tests/unit/simd/test_integer_lanes.cpp
@@ -1,0 +1,254 @@
+// Integer lanes for batch<> and the L1 kernels -- #451 phase 0.
+//
+// The whole point of these tests is that they can assert EXACT equality with a
+// closed-form reference and never mention accumulation order. On floating lanes
+// a reduction's value depends on how the four independent accumulators, the
+// horizontal reduce and the scalar tail happen to group the additions, so the
+// float tests either pick order-independent data or fall back to Approx. On
+// integer lanes addition is associative and commutative mod 2^32, so:
+//
+//   * the SIMD result equals the scalar result bit for bit,
+//   * splitting a reduction anywhere and adding the pieces gives the same value,
+//   * and the answer does not change with lane width, backend or unroll factor.
+//
+// The reference is computed in uint64_t and truncated: two's-complement multiply
+// and add agree with unsigned multiply and add in the low bits, and 2^32 divides
+// 2^64, so wrapping the uint64 accumulator cannot disturb the low 32 bits.
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+
+#include <mtl/simd/algorithm.hpp>
+#include <mtl/simd/batch.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+#include <vector>
+
+namespace {
+
+/// Exact mod-2^32 truncation of a uint64 accumulator back into the lane type.
+template <typename T>
+T wrap32(std::uint64_t acc) {
+    return static_cast<T>(static_cast<std::uint32_t>(acc));
+}
+
+/// Lane-type-agnostic view of a value as its 32 raw bits.
+template <typename T>
+std::uint64_t bits(T v) {
+    return static_cast<std::uint64_t>(static_cast<std::uint32_t>(v));
+}
+
+// Data with a deliberately wide dynamic range: the products below overflow an
+// int32 within a few terms, which is exactly the regime the wrapping contract
+// has to define rather than avoid.
+template <typename T>
+T big_a(std::size_t i) { return static_cast<T>(static_cast<std::uint32_t>(0x9E3779B9u * (i + 1))); }
+template <typename T>
+T big_b(std::size_t i) { return static_cast<T>(static_cast<std::uint32_t>(0x85EBCA77u * (i + 3))); }
+
+const std::size_t kLengths[] = {0, 1, 2, 3, 7, 8, 9, 15, 16, 17, 31, 33, 64, 100, 257};
+
+/// Is `batch<T> / batch<T>` a valid expression?
+///
+/// Written as a variable TEMPLATE rather than inline in the assertion on
+/// purpose: a requires-expression whose operands are non-dependent gets its
+/// requirements checked eagerly, so `static_assert(!requires(batch<int> a,
+/// batch<int> b){ a / b; })` is a hard "no match for operator/" on both GCC and
+/// Clang instead of evaluating to false. Parameterizing on T makes the
+/// expression dependent, which is what lets the detector answer rather than
+/// abort.
+template <typename T>
+inline constexpr bool has_lane_division =
+    requires(mtl::simd::batch<T> a, mtl::simd::batch<T> b) { a / b; };
+
+} // namespace
+
+TEST_CASE("is_lane_v admits exactly the supported lane types", "[simd][integer]") {
+    using namespace mtl::simd;
+    STATIC_REQUIRE(is_lane_v<float>);
+    STATIC_REQUIRE(is_lane_v<double>);
+    STATIC_REQUIRE(is_lane_v<std::int32_t>);
+    STATIC_REQUIRE(is_lane_v<std::uint32_t>);
+
+    // Not yet: 8- and 16-bit lanes are worth having only WITH the widening
+    // accumulate they exist for, and 64-bit integer multiply is emulated on x86
+    // before AVX512DQ (#451 phases 2-3).
+    STATIC_REQUIRE_FALSE(is_lane_v<std::int8_t>);
+    STATIC_REQUIRE_FALSE(is_lane_v<std::int16_t>);
+    STATIC_REQUIRE_FALSE(is_lane_v<std::int64_t>);
+    STATIC_REQUIRE_FALSE(is_lane_v<std::uint64_t>);
+    STATIC_REQUIRE_FALSE(is_lane_v<bool>);
+
+    STATIC_REQUIRE(is_integer_lane_v<std::int32_t>);
+    STATIC_REQUIRE(is_integer_lane_v<std::uint32_t>);
+    STATIC_REQUIRE_FALSE(is_integer_lane_v<double>);
+}
+
+TEST_CASE("division is available on floating lanes and absent on integer lanes",
+          "[simd][integer]") {
+    // The constrained overload, stated as the claim it is. #450 made integer
+    // division a compile error one level up (Field excludes the integers, the
+    // factorizations require FieldMatrix); this pins the same answer underneath,
+    // so generic code cannot reach a truncating quotient through batch<>.
+    STATIC_REQUIRE(has_lane_division<float>);
+    STATIC_REQUIRE(has_lane_division<double>);
+    STATIC_REQUIRE_FALSE(has_lane_division<std::int32_t>);
+    STATIC_REQUIRE_FALSE(has_lane_division<std::uint32_t>);
+}
+
+TEMPLATE_TEST_CASE("integer batch: lane count and load/store round-trip",
+                   "[simd][integer]", std::int32_t, std::uint32_t) {
+    using B = mtl::simd::batch<TestType>;
+    constexpr std::size_t N = B::size;
+    STATIC_REQUIRE(N >= 1);
+    STATIC_REQUIRE(mtl::simd::width<TestType> == N);
+
+    // Same guard the float tests carry: an -DMTL5_WITH_HIGHWAY=ON build that
+    // silently resolves to the size == 1 fallback would pass everything here
+    // while covering nothing. 32-bit integer lanes are in the SSE2 baseline.
+#if defined(MTL5_HAS_HIGHWAY) && (defined(__x86_64__) || defined(_M_X64))
+    STATIC_REQUIRE(N > 1);
+#endif
+
+    alignas(64) TestType in[64], out[64];
+    for (std::size_t i = 0; i < N; ++i) in[i] = big_a<TestType>(i);
+
+    B::load_unaligned(in).store_unaligned(out);
+    for (std::size_t i = 0; i < N; ++i) CHECK(out[i] == in[i]);
+    B::load_aligned(in).store_aligned(out);
+    for (std::size_t i = 0; i < N; ++i) CHECK(out[i] == in[i]);
+
+    B(TestType(7)).store_unaligned(out);
+    for (std::size_t i = 0; i < N; ++i) CHECK(out[i] == TestType(7));
+
+    B{}.store_unaligned(out);                      // default ctor zeroes
+    for (std::size_t i = 0; i < N; ++i) CHECK(out[i] == TestType(0));
+}
+
+TEMPLATE_TEST_CASE("integer batch arithmetic wraps mod 2^32, exactly",
+                   "[simd][integer]", std::int32_t, std::uint32_t) {
+    using B = mtl::simd::batch<TestType>;
+    constexpr std::size_t N = B::size;
+
+    alignas(64) TestType a[64], b[64], c[64], r[64];
+    for (std::size_t i = 0; i < N; ++i) {
+        a[i] = big_a<TestType>(i);                 // ~2^31 magnitudes, so every
+        b[i] = big_b<TestType>(i);                 // product below overflows
+        c[i] = static_cast<TestType>(static_cast<std::uint32_t>(0xDEADBEEFu + i));
+    }
+    const auto va = B::load_aligned(a), vb = B::load_aligned(b), vc = B::load_aligned(c);
+
+    (va + vb).store_aligned(r);
+    for (std::size_t i = 0; i < N; ++i) CHECK(bits(r[i]) == ((bits(a[i]) + bits(b[i])) & 0xFFFFFFFFu));
+    (va - vb).store_aligned(r);
+    for (std::size_t i = 0; i < N; ++i) CHECK(bits(r[i]) == ((bits(a[i]) - bits(b[i])) & 0xFFFFFFFFu));
+    (va * vb).store_aligned(r);
+    for (std::size_t i = 0; i < N; ++i) CHECK(bits(r[i]) == ((bits(a[i]) * bits(b[i])) & 0xFFFFFFFFu));
+
+    // fma on integer lanes is a multiply and an add -- nothing is fused, nothing
+    // rounds, and the result is the exact product-sum reduced mod 2^32. So it
+    // must agree with the separate operations bit for bit, which is a claim the
+    // floating-point fma cannot make.
+    fma(va, vb, vc).store_aligned(r);
+    for (std::size_t i = 0; i < N; ++i)
+        CHECK(bits(r[i]) == ((bits(a[i]) * bits(b[i]) + bits(c[i])) & 0xFFFFFFFFu));
+
+    alignas(64) TestType mul_then_add[64];
+    (va * vb + vc).store_aligned(mul_then_add);
+    for (std::size_t i = 0; i < N; ++i) CHECK(mul_then_add[i] == r[i]);
+}
+
+TEMPLATE_TEST_CASE("integer batch horizontal reductions", "[simd][integer]",
+                   std::int32_t, std::uint32_t) {
+    using B = mtl::simd::batch<TestType>;
+    constexpr std::size_t N = B::size;
+
+    alignas(64) TestType a[64];
+    std::uint64_t sum = 0;
+    TestType lo = std::numeric_limits<TestType>::max();
+    TestType hi = std::numeric_limits<TestType>::lowest();
+    for (std::size_t i = 0; i < N; ++i) {
+        // Keep magnitudes modest here: min/max are order-independent anyway, but
+        // the sum is compared against the wrapped reference, so state it plainly.
+        a[i] = static_cast<TestType>(static_cast<std::uint32_t>(i * 37u + 11u));
+        sum += bits(a[i]);
+        if (a[i] < lo) lo = a[i];
+        if (a[i] > hi) hi = a[i];
+    }
+    const auto v = B::load_aligned(a);
+    CHECK(reduce_add(v) == wrap32<TestType>(sum));
+    CHECK(reduce_min(v) == lo);
+    CHECK(reduce_max(v) == hi);
+}
+
+TEMPLATE_TEST_CASE("integer reduce_dot equals the exact mod-2^32 sum",
+                   "[simd][integer][l1]", std::int32_t, std::uint32_t) {
+    for (std::size_t n : kLengths) {
+        std::vector<TestType> a(n), b(n);
+        std::uint64_t acc = 0;
+        for (std::size_t i = 0; i < n; ++i) {
+            a[i] = big_a<TestType>(i);
+            b[i] = big_b<TestType>(i);
+            acc += bits(a[i]) * bits(b[i]);        // uint64 wrap keeps the low 32 bits
+        }
+        INFO("n=" << n);
+        CHECK(mtl::simd::reduce_dot<TestType>(a.data(), b.data(), n) == wrap32<TestType>(acc));
+    }
+}
+
+TEMPLATE_TEST_CASE("integer reduce_dot is invariant under partitioning",
+                   "[simd][integer][l1]", std::int32_t, std::uint32_t) {
+    // The property that makes integer lanes a better testbed than float ones:
+    // wrapping addition is associative, so cutting the reduction at ANY point
+    // and adding the two halves reproduces the whole exactly. Every split is
+    // checked, including ones that land mid-SIMD-body and leave both halves with
+    // different tail lengths -- which is where a grouping-sensitive kernel would
+    // disagree. The same argument is why a threaded integer reduction would be
+    // bit-identical to the serial one.
+    constexpr std::size_t n = 137;                 // prime: no split aligns nicely
+    std::vector<TestType> a(n), b(n);
+    for (std::size_t i = 0; i < n; ++i) { a[i] = big_a<TestType>(i); b[i] = big_b<TestType>(i); }
+
+    const TestType whole = mtl::simd::reduce_dot<TestType>(a.data(), b.data(), n);
+    for (std::size_t k = 0; k <= n; ++k) {
+        const TestType lo = mtl::simd::reduce_dot<TestType>(a.data(), b.data(), k);
+        const TestType hi = mtl::simd::reduce_dot<TestType>(a.data() + k, b.data() + k, n - k);
+        INFO("split at k=" << k);
+        CHECK(wrap32<TestType>(bits(lo) + bits(hi)) == whole);
+    }
+}
+
+TEMPLATE_TEST_CASE("integer reduce_sum_squares equals the exact mod-2^32 sum",
+                   "[simd][integer][l1]", std::int32_t, std::uint32_t) {
+    for (std::size_t n : kLengths) {
+        std::vector<TestType> a(n);
+        std::uint64_t acc = 0;
+        for (std::size_t i = 0; i < n; ++i) { a[i] = big_a<TestType>(i); acc += bits(a[i]) * bits(a[i]); }
+        INFO("n=" << n);
+        CHECK(mtl::simd::reduce_sum_squares<TestType>(a.data(), n) == wrap32<TestType>(acc));
+    }
+}
+
+TEMPLATE_TEST_CASE("integer axpy and scal match the wrapping reference",
+                   "[simd][integer][l1]", std::int32_t, std::uint32_t) {
+    const TestType alpha = static_cast<TestType>(static_cast<std::uint32_t>(0xC2B2AE35u));
+    for (std::size_t n : kLengths) {
+        std::vector<TestType> x(n), y(n), yref(n), xs(n), xsref(n);
+        for (std::size_t i = 0; i < n; ++i) {
+            x[i] = big_a<TestType>(i);
+            y[i] = big_b<TestType>(i);
+            yref[i]  = wrap32<TestType>(bits(alpha) * bits(x[i]) + bits(y[i]));
+            xs[i]    = x[i];
+            xsref[i] = wrap32<TestType>(bits(alpha) * bits(x[i]));
+        }
+        mtl::simd::axpy<TestType>(alpha, x.data(), y.data(), n);
+        mtl::simd::scal<TestType>(alpha, xs.data(), n);
+        INFO("n=" << n);
+        for (std::size_t i = 0; i < n; ++i) {
+            CHECK(y[i] == yref[i]);
+            CHECK(xs[i] == xsref[i]);
+        }
+    }
+}


### PR DESCRIPTION
Phase 0 of epic #451. Plumbing only — no widening accumulate, no gemm.

> **This PR also fixes a GCC 13 miscompile it uncovered.** See *The miscompile* below — the integer lanes are the first code in the tree whose reductions the compiler is allowed to reassociate, and GCC 13 gets it wrong on AVX2.

## Why only phase 0

The epic's own sequencing note blocks phases 2–3 behind the blocking-model decision, because phase 3 re-derives the register tile and `derive_blocking` is mid-decision. That decision is still open: #453 was falsified and closed, #458 was opened for the partition question. Phase 4 (benchmark arms) depends on 2–3 — measuring the scalar fallback would answer nothing. Phase 1 landed as #450.

Phase 0 is the part the issue marks independent: *"does not depend on it and can start any time."*

## What changed

`batch<T>` accepted only floating-point lanes, so `dot`/`gemv` over an integer vector fell to the generic scalar loop and every SIMD kernel was unreachable for them. `is_lane_v<T>` now admits `int32_t`/`uint32_t`, and the L1 kernels plus both GEMV orientations follow it.

**The boundary is deliberate at both ends.** 8- and 16-bit lanes are worth having only *with* the widening accumulate they exist for (`vpdpbusd`/`vpdpwssd`/SDOT), and x86 has no 8-bit vector multiply at all. 64-bit integer multiply is emulated before AVX512DQ, so a `batch<int64_t>` would advertise a vector op that is a scalar loop in disguise. 32-bit is exactly where the multiply is one native instruction on every target ISA.

**The overflow contract is stated, not inherited.** Integer arithmetic here is two's-complement wrapping — what Highway specifies (`operator*` *"truncating to the lower half for integer inputs"*) and what every target ISA does. That buys a property floating point cannot offer:

> addition mod 2³² is associative, so an integer reduction is **bit-identical** across lane counts, unroll factors, backends and thread partitions.

So the tests assert exact equality against a closed-form mod-2³² reference and never mention accumulation order — including a case that splits a 137-term dot at every one of its 138 cut points. This is the "testing win" the epic predicted for phase 3, available at phase 0. It is also what caught the miscompile.

**Signed-overflow UB is closed, not tolerated.** Scalar tails and the fallback backend route through new `wrap_add`/`wrap_sub`/`wrap_mul` helpers. Without them a tail written `s += a[i] * b[i]` over int32 is UB precisely where the SIMD body it completes wraps and defines the result.

**Division is not offered on integer lanes** — constrained out of the overload set, so generic code that divides fails to compile. Highway's integer `Div` is implementation-defined at `b==0` and at `INT_MIN/-1`, and it truncates. #450 took exactly this position one level up; offering it here would reopen that door underneath the concept. `load_widen` is likewise floating-only.

**Dispatch** moves to new `SimdDenseVector`/`SimdDenseMatrix` — `BlasDenseX` widened to every lane type. There is no external `?dot` or `?gemv` for int32, so the native path is the only one integers can take, and gating on the BLAS predicate is what kept them on the scalar loop. Float/double routing is unchanged (the Simd concepts are a strict superset) and the BLAS branches are untouched.

**One asymmetry, stated in the code:** integer `dot` is serial where the float one is parallel. `parallel_reduce` combines partials with a plain `acc + partial`, which is UB on int32. Wrapping addition is associative, so a threaded integer reduction would be bit-identical and is worth having — but making that combine wrap-safe means changing a documented plus-only contract for every `T`, which is not a phase-0 change.

## The miscompile

The first push went red on one lane: **Linux x64 FP-contract (x86-64-v3)** — gcc-13, `-O3 -march=x86-64-v3`, no Highway. `reduce_dot<int32_t>` returned `384576632` where the answer is `286176841`.

The partitioning test localised it precisely: **all 138 splits agreed with the closed form**, and only the one call whose length was a *compile-time constant* disagreed. Same function, same memory, same length — so the two could only differ if one was compiled wrong.

The emitted assembly says which, and why. On the scalar-fallback backend the four accumulators are four interleaved scalar chains. Integer addition reassociates, so the vectorizer may fuse them into one contiguous reduction — and GCC 13 does, then botches the stride: it advances the first chain 8 elements per iteration with 8-wide loads while leaving the other three advancing 4, so those three cover half the range.

```
.L2:
        movl    4(%rdi,%rax), %ecx        # a1 chain: scale 1  -> +4 elements/iter
        imull   4(%rsi,%rax), %ecx
        vmovdqu (%rdi,%rax,2), %ymm2      # a0 chain: scale 2  -> +8 elements/iter
        vpmulld (%rsi,%rax,2), %ymm2, %ymm0
        vpaddd  %ymm1, %ymm0, %ymm1
        ...
        addq    $16, %rax
        cmpq    $272, %rax
        jne     .L2
```

Reconstructing that sum by hand reproduces CI's wrong value **bit for bit**:

```
vector part (lanes 0,4 of ymm)  -> a0 chain, i = 0,4,...,132
scalar chains a1/a2/a3          -> stop at element 67 instead of 135
+ epilogue element 136
= 384576632   == exactly what CI printed
```

Scope, measured on GCC 13.3: **176 of the first 299 compile-time-constant lengths**, `int32_t` and `uint32_t` only. **float and double are never affected** — FP addition does not reassociate, so the fusion is never attempted. **Clang is unaffected** (it fully unrolls to contiguous form), which matches the green clang lanes. `gemv`, `axpy` and `scal` are structurally immune: their accumulators are never summed together, so there is no reassociation to get wrong — verified against the same assembly signature.

### The fix is not a dodge

The hand unroll exists to hide FP add/FMA latency — 3–5 cycles, enough to serialize a single-accumulator loop. An integer reduction carries a **1-cycle** add and needs two loads and a multiply per element, so it is throughput-bound long before it is latency-bound; the extra accumulators buy nothing. One accumulator on integer lanes is the right shape on its own terms, and it leaves the vectorizer nothing to un-unroll.

Guarded with `if constexpr (std::is_floating_point_v<T>)`, so the FP path is untouched — and *verified* untouched: the generated assembly for `reduce_dot<float>` and `reduce_dot<double>` at `-O3 -march=x86-64-v3` is byte-identical before and after, **0 diff lines**.

### The test gap mattered as much as the bug

Every reduction test reached the kernel through a **runtime** length — which is a different code path, and was correct throughout. The new case sweeps **23 compile-time-constant lengths** (including both that GCC got wrong) and checks each against *both* the closed form and the same call with the length made opaque. A constant-folding divergence now fails on the spot instead of surviving into a release build.

I could not reduce this to a reproducer free of MTL5 headers — the plain-C++ and cast-only forms compile correctly at every length tried; it needs the `batch<>` wrapper's inlined shape. A `#include <mtl/simd/algorithm.hpp>` reproducer is header-only and dependency-free, so it is fileable upstream as-is if you want to report it.

## Review findings

Two review passes, **five findings**, all real, all fixed. Two were pre-existing defects this PR's changes put in front of a reviewer; three were mine. A full re-review was run after the first round precisely because each fix kept turning up a defect in the one before it — and it found two more.

**Strided vectors on contiguous fast paths** (`7a53cb7`). `vec::strided_vector_ref` stores element *i* at `data()[i * stride()]` but supplies `data()` and `size()`, which is all `BlasDenseVector` asked for — so it was accepted by every operation gated on that concept, each of which then walked `data()` unit-stride. Measured before the fix: `dot_real` over a stride-2 view returned **14** where the answer is **44**. Ten operations dispatch on that concept (`dot`, `dot_real`, `two_norm`, `axpy`, `scale`, `mult`'s GEMV, `trmv`, `trsv`, `symv`, `ger`), and a column of a row-major matrix is exactly such a view — so "dot two matrix columns" was silently wrong for `float` and `double`, entirely independent of integer lanes. The new `ContiguousVector` admits a *compile-time* unit stride (which is what `dense_vector` has) and rejects runtime strides, sending them to the generic loop.

**Integer overflow UB in the generic dense loops** (`7a53cb7`). `acc += A(r, c) * x(c)` is signed-overflow UB on int32 — and that is the path an integer `mult` takes in the **default** build, since `MTL5_NATIVE_FAST_GEMM` is off. Both `mult_generic` overloads and both `dot` fallbacks now accumulate through a shared `generic_fma`.

**The wrapping helpers were not wide enough to be defined** (`fb6ad55`) — the sharpest of the three, and a defect in the fix above. Casting operands to `std::make_unsigned_t<T>` does *not* make the arithmetic defined: integral promotion runs first and promotes anything narrower than `int` to **signed** `int`, so for `int16_t`, `uint16_t(-1) * uint16_t(-1)` is `65535 * 65535` in `int`, which overflows. The cast intended to prevent UB reintroduced it. Reachable from the public API, because `generic_fma` is instantiated on the caller's element type rather than on the lane types: `dot_real` over a `dense_vector<int16_t>` of `-1`s trips it. The helpers now operate in `common_type_t<make_unsigned_t<T>, unsigned>`, and `bool` is excluded (`make_unsigned_t<bool>` is ill-formed).

Reviewing that code turned up one more, mine: `generic_fma` converted operands to the result type before multiplying, which is lossless between integers but destructive with a floating operand and an integral result — `mult(dense2D<double>, dense_vector<double>, dense_vector<int>)` turned `2.5 * 2.5` into `2 * 2`. The modular branch now requires the *operands* to be integral too.

### Second pass (full re-review)

**`long double` broke a build that previously worked** (`198fca9`) — a regression this PR introduced, not a latent issue. `is_lane_v` asked `std::is_floating_point_v`, which admits `long double`; Highway has no such vector type, and because the trait gates `SimdDenseVector`, `dot(dense_vector<long double>, ...)` was routed into `reduce_dot<long double>` and stopped compiling in any Highway build. The old `BlasDenseVector` gate is float/double only, so widening the shape check is what broke it. Verified both directions against a worktree of `main`: compiles there, failed here, compiles again now. The `static_assert` in `batch<T>` had said *"float, double, int32_t and uint32_t"* all along — the trait now agrees with it.

**A `bool` operand fell off the wrapping path** (`198fca9`). `bool` must be excluded as a *result* type (`std::make_unsigned_t<bool>` is ill-formed) but *included* as an operand — I applied one predicate to both. Excluding it as an operand pushed the expression back onto plain `acc + a * b`, reinstating exactly the signed-overflow UB the helper removes. Reachable as `dot(dense_vector<bool>, dense_vector<int32_t>)`, whose result type is `int`. After the fix: `-294967296`, i.e. 4e9 mod 2³², clean under UBSan.

Two more came out of auditing rather than the report: `mult_generic`'s **mat×mat** overload took the same `generic_fma` change as mat×vec but had **no integer coverage at all** (the only `mult(A, B, C)` test in the tree is over `double`), and one of my own test expectations was wrong — the mixed float-operand/integer-result case yields **6, not 7**, because `acc` has the result type and an integral output rounds every term as it accumulates rather than summing in `double` and rounding once. That behaviour is pre-existing and the test now pins it unchanged.

Follow-up **#461** tracks the remaining integer-overflow sites in the sparse kernels and the `axpy`/`scale`/`norms` generic branches — pre-existing, wider than this PR's contract, and deliberately not half-fixed here.

## Changes

| File | What |
|---|---|
| `include/mtl/simd/batch.hpp` | `is_lane_v` / `is_integer_lane_v`; wrapping helpers; integer `fma`; `operator/` and `load_widen` constrained to floating lanes; the contract documented at the top |
| `include/mtl/simd/algorithm.hpp` | `static_assert`s relaxed to `is_lane_v`; scalar tails made wrapping-safe; **accumulator count made a floating-point decision** with the GCC finding recorded |
| `include/mtl/detail/gemv.hpp` | both scalar tails made wrapping-safe |
| `include/mtl/interface/dispatch_traits.hpp` | `SimdDenseVector`, `SimdDenseMatrix` |
| `include/mtl/operation/dot.hpp` | integer branch (serial) in `dot`; `dot_real` gate widened |
| `include/mtl/operation/mult.hpp` | native GEMV gate widened to the Simd concepts |
| `tests/unit/simd/test_integer_lanes.cpp` | **new** — lane trait, division absence, wrapping arithmetic, `fma` ≡ mul+add, reductions, exactness, **compile-time-constant length sweep**, partition invariance, `sum_squares`/`axpy`/`scal` |
| `tests/unit/operation/test_dot.cpp` | integer dot: dispatch predicate + a deliberately overflowing 1031-term case |
| `tests/unit/operation/test_gemv.cpp` | `int32_t`/`uint32_t` arms; a direct assertion that integers satisfy the SIMD predicate and no BLAS one |
| `include/mtl/detail/wrapping_arithmetic.hpp` | **new** — `wrap_add`/`wrap_sub`/`wrap_mul`/`generic_fma`, performed wide enough to be defined at every width |
| `include/mtl/interface/dispatch_traits.hpp` | `ContiguousVector`, applied to `BlasDenseVector` and `SimdDenseVector` |
| `tests/unit/detail/test_wrapping_arithmetic.cpp` | **new** — all eight standard widths against a 64-bit reference, the promotion case, the `bool` exclusion, both `generic_fma` branches |
| `tests/unit/operation/test_strided_dispatch.cpp` | **new** — strided regression for `dot`/`dot_real`/`two_norm`/`axpy`/`scale`, incl. that gaps stay untouched |

## Test results

**CI: 43 pass, 0 fail** on `198fca9`, both tiers — including the FP-contract lane that caught the miscompile, and the Tier 2 regression suite.

Locally, full suite in four configurations:

| Compiler | Backend | Result |
|---|---|---|
| gcc 13.3 | scalar fallback | **173/173** |
| gcc 13.3 | Highway 1.4, `-march=native` | **173/173** |
| clang | scalar fallback | **173/173** |
| clang | Highway 1.4, `-march=native` | **173/173** |

Plus:
- **UBSan** (`-fsanitize=undefined,integer -fno-sanitize-recover=all`) over the simd + dot + gemv tests — clean, with a positive control confirming the sanitizer was armed
- `MTL5_HAS_BLAS` dispatch path syntax-checked for all four lane types

Both Highway targets carry `STATIC_REQUIRE(batch<int32_t>::size > 1)` on x86-64, so a build that silently resolved to the size-1 fallback would fail to compile rather than pass green.

## What this does not do

- No `gemm` — that needs the register tile re-derived for an integer accumulator (phase 3)
- No int8/int16, no `ReorderWidenMulAccumulate`, no VNNI/SDOT (phases 2–3)
- No benchmark arms (phase 4)
- `axpy`/`scale` **kernels** accept integers now, but their `operation/` dispatch is unchanged — out of phase-0 scope

## Test plan
- [x] Tier 1 CI passes (42/42)
- [x] CodeRabbit review addressed — 2 passes, 5 findings, all fixed; all 5 threads resolved
- [ ] Promote to ready

Relates to #451

Generated with [Claude Code](https://claude.com/claude-code)
