### PR TITLE
feat(simd): int16 → int32 widening dot via the hardware multiply-accumulate (#451 phase 2)

### DIFF
--- a/docs/algorithms/mixed-precision-kernels.md
+++ b/docs/algorithms/mixed-precision-kernels.md
@@ -224,6 +224,60 @@ storage cost, at SIMD speed. The same-type kernels are untouched.
 
 ---
 
+## The integer case: the same idea, a different failure mode
+
+Widening is not only a floating-point technique. `dot<int32_t>` over `int16_t`
+vectors accumulates 16-bit operands in 32 bits through the hardware's widening
+multiply-add — `vpmaddwd` on x86 (`pmaddwd` back to SSE2), `SMLAL`/`UMLAL` on
+NEON. One instruction does the widen, the multiply and the accumulate.
+
+But the reason you reach for it is the opposite of the floating-point one.
+Widening a `float` reduction into `double` buys **accuracy**: the products were
+already exact, and what you recover is the rounding lost in the sum. Widening an
+`int16` reduction into `int32` buys **range**, and only some:
+
+| | floating (`float` → `double`) | integer (`int16` → `int32`) |
+|---|---|---|
+| what a single product costs | exact either way | exact either way — 2³⁰ fits |
+| what the wide accumulator recovers | rounding error in the sum | headroom before the sum wraps |
+| what happens when you run out | gradual loss of low bits | wraps mod 2³², abruptly |
+| how much you get | ~2⁵³ terms of headroom | **~2^(31−2b) terms** at *b* bits of operand magnitude |
+
+That last row is the one to internalize. At full 16-bit range the worst case —
+every term maximal and same-signed — overflows at **k = 3**; random signed data
+random-walks rather than marches, but still only reaches k ≈ 36. The useful
+regime is **small operands, not short vectors**: 8-bit values in `int16` storage
+give ~2¹⁵ terms of headroom, 4-bit values ~2²³.
+
+This is exactly why the hardware's marquee integer dot instructions (VNNI's
+`vpdpbusd`, NEON's `SDOT`) accumulate **int8** into int32 rather than int16: an
+8-bit product needs 15 bits, leaving 16 bits of headroom — about 65 000 terms.
+`int16 → int32` is the awkward middle, useful when your data is genuinely small
+and you want the width anyway.
+
+When the sum does exceed the accumulator it **wraps** — the true sum reduced
+mod 2³², never a trap, never a saturation, never undefined. Callers needing the
+full range should widen their storage, not hope.
+
+### Why the integer kernel can use an instruction the float one cannot
+
+`ReorderWidenMulAccumulate` is free to permute which product lands in which
+accumulator lane; the ISA chooses (x86 pairs adjacent lanes, NEON splits
+low/high halves), and the only guarantee is that the *total* is right.
+
+For a floating accumulator that would be disqualifying: the sum would depend on
+which products got grouped, so the same code would give different answers on
+different ISAs. On integer lanes it costs exactly nothing, because addition mod
+2³² is associative and commutative — the permutation is unobservable.
+
+That is a concrete dividend of the integer contract: because MTL5 defines
+integer lanes as wrapping rather than leaving overflow undefined, the reduction
+is bit-identical across lane counts, unroll factors, backends and thread
+partitions, and a permuting instruction is simply free to use. The tests assert
+exact equality against a closed form and never mention lane order.
+
+---
+
 ## Designing your own mixed-precision algorithm
 
 The takeaways that generalize beyond GEMM:

--- a/include/mtl/interface/dispatch_traits.hpp
+++ b/include/mtl/interface/dispatch_traits.hpp
@@ -114,6 +114,22 @@ concept SimdDenseVector =
         { v.size() };
     };
 
+/// Concept satisfied by dense vector types whose element type is not a lane but
+/// can be WIDENED into one by a dot-product accumulate -- 16-bit integers, as of
+/// #451 phase 2.
+///
+/// Separate from `SimdDenseVector` because these types are operands, not lanes:
+/// `batch<std::int16_t>` does not exist, and the only kernel that accepts them
+/// is `reduce_dot_widen`, which never materializes one.
+template <typename V>
+concept SimdNarrowVector =
+    simd::is_widenable_v<typename V::value_type> &&
+    ContiguousVector<V> &&
+    requires(const V& v) {
+        { v.data() } -> std::convertible_to<const typename V::value_type*>;
+        { v.size() };
+    };
+
 /// Concept satisfied by dense matrix types eligible for MTL5's own SIMD
 /// kernels -- `BlasDenseMatrix` widened to every `mtl::simd` lane type, for the
 /// same reason as `SimdDenseVector`.

--- a/include/mtl/operation/dot.hpp
+++ b/include/mtl/operation/dot.hpp
@@ -22,6 +22,20 @@
 
 namespace mtl {
 
+/// Does `dot<Accumulator, Result>(v1, v2)` name the widening integer kernel?
+///
+/// Both vectors contiguous over the SAME 16-bit type, and the requested
+/// accumulator exactly that type's widened counterpart (int16 -> int32,
+/// uint16 -> uint32) with no separate delivery type. Anything else -- a wider
+/// accumulator, a mixed pair, a strided view -- falls to the generic
+/// accumulator_traits loop, which is correct for all of them.
+template <typename Accumulator, typename Result, typename V1, typename V2>
+concept widening_int_dot =
+    interface::SimdNarrowVector<V1> && interface::SimdNarrowVector<V2> &&
+    std::is_same_v<typename V1::value_type, typename V2::value_type> &&
+    std::is_same_v<Accumulator, simd::widen_accumulator_t<typename V1::value_type>> &&
+    std::is_same_v<Result, Accumulator>;
+
 /// Hermitian dot product: sum(conj(v1[i]) * v2[i]).
 ///
 /// Mixed precision: pass an explicit `Accumulator` to sum the products in a
@@ -44,6 +58,14 @@ auto dot(const V1& v1, const V2& v2) {
                       std::is_same_v<typename V2::value_type, float> &&
                       std::is_same_v<Accumulator, double> && std::is_same_v<Result, double>) {
             return simd::reduce_dot_widen<double, float>(v1.data(), v2.data(), v1.size());
+        } else if constexpr (widening_int_dot<Accumulator, Result, V1, V2>) {
+            // Widening INTEGER fast path (#451 phase 2): 16-bit operands into a
+            // 32-bit accumulator, via the hardware's widening multiply-add. conj
+            // is the identity on the integers, so this is the Hermitian product.
+            // The sum wraps mod 2^32 and does so within a few terms at full
+            // range -- see reduce_dot_widen for the contract.
+            return simd::reduce_dot_widen<Accumulator, typename V1::value_type>(
+                v1.data(), v2.data(), v1.size());
         } else {
             using Value = std::common_type_t<typename V1::value_type, typename V2::value_type>;
             using AT = math::accumulator_traits<Accumulator, Value>;
@@ -123,6 +145,9 @@ auto dot_real(const V1& v1, const V2& v2) {
                       std::is_same_v<typename V2::value_type, float> &&
                       std::is_same_v<Accumulator, double> && std::is_same_v<Result, double>) {
             return simd::reduce_dot_widen<double, float>(v1.data(), v2.data(), v1.size());
+        } else if constexpr (widening_int_dot<Accumulator, Result, V1, V2>) {
+            return simd::reduce_dot_widen<Accumulator, typename V1::value_type>(
+                v1.data(), v2.data(), v1.size());
         } else {
             using Value = std::common_type_t<typename V1::value_type, typename V2::value_type>;
             using AT = math::accumulator_traits<Accumulator, Value>;

--- a/include/mtl/simd/algorithm.hpp
+++ b/include/mtl/simd/algorithm.hpp
@@ -91,9 +91,11 @@ T reduce_dot(const T* a, const T* b, std::size_t n) {
 /// mixed-precision dot keeps the wide accumulator's accuracy at SIMD speed,
 /// instead of the scalar policy fallback. (On the scalar batch backend this is
 /// the correct scalar widening loop.)
+/// (Integer overload below; this one is the floating-point case.)
 template <typename Wide, typename Narrow>
+    requires std::is_floating_point_v<Wide>
 Wide reduce_dot_widen(const Narrow* a, const Narrow* b, std::size_t n) {
-    static_assert(std::is_floating_point_v<Wide> && std::is_floating_point_v<Narrow>);
+    static_assert(std::is_floating_point_v<Narrow>);
     static_assert(sizeof(Narrow) < sizeof(Wide), "reduce_dot_widen requires Narrow < Wide");
     using B = batch<Wide>;
     constexpr std::size_t W = B::size;
@@ -111,6 +113,71 @@ Wide reduce_dot_widen(const Narrow* a, const Narrow* b, std::size_t n) {
         a0 = fma(B::load_widen(a + i), B::load_widen(b + i), a0);
     Wide s = reduce_add((a0 + a1) + (a2 + a3));
     for (; i < n; ++i) s += static_cast<Wide>(a[i]) * static_cast<Wide>(b[i]);  // tail
+    return s;
+}
+
+/// Widening INTEGER dot product: 16-bit operands accumulated in 32 bits, via the
+/// hardware's widening multiply-accumulate (#451 phase 2).
+///
+/// `int16 -> int32` and `uint16 -> uint32`. One instruction does the widening,
+/// the multiply and the accumulate -- `vpmaddwd` on x86, `SMLAL`/`UMLAL` on
+/// NEON -- so this is the first kernel here whose ISA support is the point
+/// rather than an implementation detail.
+///
+/// THE OVERFLOW CONTRACT
+///
+/// Two separate questions, with very different answers.
+///
+///   * The PRODUCTS are always exact. |-2^15 * -2^15| = 2^30 fits an int32 with
+///     a bit to spare, so no individual term is ever lost.
+///   * The SUM wraps, and it wraps SOON. Full-range operands consume 31 of the
+///     accumulator's 32 bits per term, so the worst case (every term the same
+///     sign, both operands at the limit) overflows at k = 3. Random signed data
+///     does better -- the terms random-walk rather than march, so |sum| grows
+///     like sqrt(k) -- but only to roughly k = 36 before it is more likely than
+///     not to have exceeded 2^31.
+///
+/// So this is NOT the "accumulate 65 000 terms safely" case; that is int8 into
+/// int32 (phase 3), where a product needs 15 bits and leaves 16 of headroom, and
+/// it is why the VNNI and SDOT instructions are shaped the way they are. What
+/// makes 16-bit accumulation useful is small operands, not short vectors: at b
+/// bits of operand magnitude the headroom is about 2^(31-2b) terms, so 8-bit
+/// values in int16 storage give ~2^15 terms and 4-bit values give ~2^23.
+///
+/// When the sum does exceed the accumulator it WRAPS, exactly as everywhere else
+/// in mtl::simd -- the result is the true sum reduced mod 2^32, never a trap,
+/// never a saturation, never undefined. Callers who need the full range should
+/// widen their storage, not hope. tests/unit/simd/test_int_accumulation.cpp pins
+/// the measured envelope for the 64-bit case.
+///
+/// LANE ORDER IS UNSPECIFIED AND THAT IS FINE. The hardware instruction is free
+/// to permute which product lands in which accumulator lane, and Highway
+/// promises only that the total is right. For a floating accumulator that would
+/// make the result ISA-dependent; here it is unobservable, because addition mod
+/// 2^32 is associative and commutative. Phase 0's contract is what lets this
+/// kernel use the instruction without a caveat.
+template <typename Wide, typename Narrow>
+    requires std::is_integral_v<Wide>
+Wide reduce_dot_widen(const Narrow* a, const Narrow* b, std::size_t n) {
+    static_assert(is_widenable_v<Narrow>, "reduce_dot_widen widens 16-bit integers");
+    // Guarded: widen_accumulator has no definition for a non-widenable Narrow,
+    // so naming it unconditionally would bury the assertion above under an
+    // "incomplete type" error. A discarded if-constexpr branch is not
+    // instantiated, which leaves exactly one diagnostic.
+    if constexpr (is_widenable_v<Narrow>) {
+        static_assert(std::is_same_v<Wide, widen_accumulator_t<Narrow>>,
+                      "int16 accumulates in int32, uint16 in uint32");
+    }
+    using B = batch<Wide>;
+    constexpr std::size_t S = B::widen_step;
+    B s0{}, s1{};                            // s1 MUST start zeroed -- see batch.hpp
+    std::size_t i = 0;
+    for (; i + S <= n; i += S)
+        B::widen_dot_accumulate(a + i, b + i, s0, s1);
+    Wide s = reduce_add(s0 + s1);            // the one defined observation
+    for (; i < n; ++i)                       // scalar tail, same wrapping rules
+        s = mtl::detail::wrap_add(
+            s, mtl::detail::wrap_mul(static_cast<Wide>(a[i]), static_cast<Wide>(b[i])));
     return s;
 }
 

--- a/include/mtl/simd/batch.hpp
+++ b/include/mtl/simd/batch.hpp
@@ -102,6 +102,27 @@ inline constexpr bool is_lane_v =
 template <typename T>
 inline constexpr bool is_integer_lane_v = is_lane_v<T> && std::is_integral_v<T>;
 
+/// Narrow integer types that can be WIDENED into a lane by a dot-product
+/// accumulate (#451 phase 2). These are storage/operand types, not lanes:
+/// `batch<std::int16_t>` does not exist and is not wanted, because a 16-bit
+/// lane's value is the widening accumulate, not the plain multiply.
+template <typename T>
+inline constexpr bool is_widenable_v =
+    std::is_same_v<T, std::int16_t> || std::is_same_v<T, std::uint16_t>;
+
+/// The accumulator a narrow type widens into: 16 bits doubles to 32, keeping
+/// signedness. Products of two 16-bit values always fit the 32-bit accumulator
+/// EXACTLY (|-2^15 * -2^15| = 2^30 < 2^31); it is the running sum that can
+/// overflow, and does so quickly -- see reduce_dot_widen in simd/algorithm.hpp
+/// for the headroom this actually buys.
+template <typename Narrow>
+struct widen_accumulator;
+template <> struct widen_accumulator<std::int16_t>  { using type = std::int32_t;  };
+template <> struct widen_accumulator<std::uint16_t> { using type = std::uint32_t; };
+
+template <typename Narrow>
+using widen_accumulator_t = typename widen_accumulator<Narrow>::type;
+
 #if MTL5_SIMD_USE_HIGHWAY
 
 namespace hn = hwy::HWY_NAMESPACE;
@@ -150,6 +171,51 @@ public:
                       "load_widen widens; use load_unaligned for equal-width types");
         const hn::Rebind<Src, D> ds;
         return batch(hn::PromoteTo(d_, hn::LoadU(ds, p)));
+    }
+
+    /// Narrow values consumed by one `widen_dot_accumulate` call: a full narrow
+    /// vector, which holds twice as many 16-bit lanes as this batch holds 32-bit
+    /// ones. Compile-time, like `size`.
+    ///
+    /// Only meaningful on a 32-bit integer accumulator -- it is the loop stride
+    /// for `reduce_dot_widen`, and `widen_dot_accumulate` static_asserts the
+    /// lane/operand pairing anyway, so the constant existing on `batch<double>`
+    /// is inert rather than a second gate to keep in sync.
+    static constexpr std::size_t widen_step = 2 * size;
+
+    /// Widening dot accumulate: multiply `widen_step` pairs of NARROW values and
+    /// add the products into two wide accumulators.
+    ///
+    /// The lane assignment is deliberately UNSPECIFIED. Highway's
+    /// `ReorderWidenMulAccumulate` promises only that
+    /// `reduce_add(sum0 + sum1)` is the sum of all the products -- which lane a
+    /// given product lands in is a permutation the ISA chooses (`vpmaddwd` pairs
+    /// adjacent lanes on x86; NEON splits low/high halves). That is exactly
+    /// enough for a reduction and nothing more, so this primitive is only usable
+    /// inside one.
+    ///
+    /// For a FLOATING accumulator such a permutation would be a problem: the sum
+    /// would depend on which products got grouped, and the result would vary by
+    /// ISA. On integer lanes it costs nothing, because addition mod 2^32 is
+    /// associative and commutative -- the permutation is unobservable. The
+    /// contract established in phase 0 is what makes this instruction usable
+    /// without qualification.
+    ///
+    /// `sum1` MUST start zeroed; Highway leaves it untouched on targets that do
+    /// not need it, so a nonzero initial value would silently be counted or not
+    /// depending on the ISA.
+    template <typename Narrow>
+    static void widen_dot_accumulate(const Narrow* a, const Narrow* b,
+                                     batch& sum0, batch& sum1) {
+        static_assert(is_widenable_v<Narrow>, "widen_dot_accumulate takes 16-bit operands");
+        static_assert(std::is_same_v<T, widen_accumulator_t<Narrow>>,
+                      "the accumulator must be the widened counterpart of Narrow "
+                      "(int16 -> int32, uint16 -> uint32)");
+        const hn::Repartition<Narrow, D> dn;
+        auto s1 = sum1.v_;
+        sum0.v_ = hn::ReorderWidenMulAccumulate(d_, hn::LoadU(dn, a), hn::LoadU(dn, b),
+                                                sum0.v_, s1);
+        sum1.v_ = s1;
     }
 
     friend batch operator+(batch a, batch b) { return batch(hn::Add(a.v_, b.v_)); }
@@ -216,6 +282,29 @@ public:
         static_assert(sizeof(Src) < sizeof(T),
                       "load_widen widens; use load_unaligned for equal-width types");
         return batch(static_cast<T>(p[0]));
+    }
+
+    /// Narrow values consumed per widen_dot_accumulate call. Two rather than
+    /// one, so the fallback drives BOTH accumulators and the loop in
+    /// reduce_dot_widen is the same shape on either backend -- which also means
+    /// the fallback exercises the sum1 path that Highway may or may not use.
+    static constexpr std::size_t widen_step = 2;
+
+    /// Widening dot accumulate -- scalar fallback of the SIMD primitive; see the
+    /// Highway variant for the contract. Splitting the two products across the
+    /// two accumulators reproduces the "unspecified lane assignment, defined
+    /// total" behaviour rather than papering over it.
+    template <typename Narrow>
+    static void widen_dot_accumulate(const Narrow* a, const Narrow* b,
+                                     batch& sum0, batch& sum1) {
+        static_assert(is_widenable_v<Narrow>, "widen_dot_accumulate takes 16-bit operands");
+        static_assert(std::is_same_v<T, widen_accumulator_t<Narrow>>,
+                      "the accumulator must be the widened counterpart of Narrow "
+                      "(int16 -> int32, uint16 -> uint32)");
+        sum0.v_ = mtl::detail::wrap_add(
+            sum0.v_, mtl::detail::wrap_mul(static_cast<T>(a[0]), static_cast<T>(b[0])));
+        sum1.v_ = mtl::detail::wrap_add(
+            sum1.v_, mtl::detail::wrap_mul(static_cast<T>(a[1]), static_cast<T>(b[1])));
     }
 
     friend batch operator+(batch a, batch b) { return batch(mtl::detail::wrap_add(a.v_, b.v_)); }

--- a/tests/unit/simd/test_widening_dot.cpp
+++ b/tests/unit/simd/test_widening_dot.cpp
@@ -1,0 +1,191 @@
+// Widening integer dot: 16-bit operands accumulated in 32 bits -- #451 phase 2.
+//
+// The interesting property is what the tests DO NOT have to say. The hardware
+// instruction behind this (`vpmaddwd` on x86, `SMLAL` on NEON) is free to permute
+// which product lands in which accumulator lane; Highway promises only that the
+// total is right. A floating-point kernel could not use it without qualifying
+// every result by ISA, because the grouping would change the rounding. Here the
+// permutation is unobservable -- addition mod 2^32 is associative and
+// commutative -- so every case below asserts exact equality against a closed form
+// and never mentions lane order, backend or vector width.
+//
+// The reference is computed in 64-bit and truncated. Products of two 16-bit
+// values are exact in 32 bits, so only the running sum can wrap, and reduction
+// mod 2^32 commutes with the 64-bit accumulation.
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+
+#include <mtl/interface/dispatch_traits.hpp>
+#include <mtl/operation/dot.hpp>
+#include <mtl/simd/algorithm.hpp>
+#include <mtl/simd/batch.hpp>
+#include <mtl/vec/dense_vector.hpp>
+#include <mtl/vec/strided_vector_ref.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+#include <vector>
+
+namespace {
+
+template <typename Narrow>
+using Wide = mtl::simd::widen_accumulator_t<Narrow>;
+
+/// Exact sum of products, reduced to the accumulator width.
+template <typename Narrow>
+Wide<Narrow> ref_widen_dot(const Narrow* a, const Narrow* b, std::size_t n) {
+    std::uint64_t acc = 0;
+    for (std::size_t i = 0; i < n; ++i)
+        acc += static_cast<std::uint64_t>(static_cast<std::uint32_t>(static_cast<Wide<Narrow>>(a[i]))) *
+               static_cast<std::uint32_t>(static_cast<Wide<Narrow>>(b[i]));
+    return static_cast<Wide<Narrow>>(static_cast<std::uint32_t>(acc));
+}
+
+/// Full-range 16-bit data: every product is near 2^30, so the sum leaves the
+/// accumulator within a handful of terms. That is the regime the contract has to
+/// define rather than avoid.
+template <typename Narrow>
+Narrow gen_a(std::size_t i) { return static_cast<Narrow>(static_cast<std::uint16_t>(0x9E37u * (i + 1) + 0x1234u)); }
+template <typename Narrow>
+Narrow gen_b(std::size_t i) { return static_cast<Narrow>(static_cast<std::uint16_t>(0x85EBu * (i + 3) + 0x5678u)); }
+
+const std::size_t kLengths[] = {0, 1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 23, 31,
+                                32, 33, 63, 64, 65, 100, 127, 128, 129, 257, 1031};
+
+} // namespace
+
+TEST_CASE("the widenable types and their accumulators", "[simd][widen]") {
+    using namespace mtl::simd;
+    STATIC_REQUIRE(is_widenable_v<std::int16_t>);
+    STATIC_REQUIRE(is_widenable_v<std::uint16_t>);
+    STATIC_REQUIRE_FALSE(is_widenable_v<std::int8_t>);      // phase 3
+    STATIC_REQUIRE_FALSE(is_widenable_v<std::int32_t>);     // already a lane
+    STATIC_REQUIRE_FALSE(is_widenable_v<float>);
+
+    STATIC_REQUIRE(std::is_same_v<widen_accumulator_t<std::int16_t>,  std::int32_t>);
+    STATIC_REQUIRE(std::is_same_v<widen_accumulator_t<std::uint16_t>, std::uint32_t>);
+
+    // 16-bit types are operands, NOT lanes: batch<int16_t> is deliberately absent,
+    // because a 16-bit lane's value is this accumulate, not a plain multiply.
+    STATIC_REQUIRE_FALSE(is_lane_v<std::int16_t>);
+    STATIC_REQUIRE_FALSE(is_lane_v<std::uint16_t>);
+
+    // widen_step is a compile-time constant, like size, and consumes a full
+    // narrow vector -- twice as many 16-bit lanes as the batch has 32-bit ones.
+    STATIC_REQUIRE(batch<std::int32_t>::widen_step == 2 * batch<std::int32_t>::size);
+}
+
+TEMPLATE_TEST_CASE("widening dot is exact mod 2^32 at every length", "[simd][widen]",
+                   std::int16_t, std::uint16_t) {
+    using N = TestType;
+    using W = Wide<N>;
+    for (std::size_t n : kLengths) {
+        std::vector<N> a(n), b(n);
+        for (std::size_t i = 0; i < n; ++i) { a[i] = gen_a<N>(i); b[i] = gen_b<N>(i); }
+        INFO("n=" << n);
+        CHECK(mtl::simd::reduce_dot_widen<W, N>(a.data(), b.data(), n) ==
+              ref_widen_dot<N>(a.data(), b.data(), n));
+    }
+}
+
+TEMPLATE_TEST_CASE("widening dot is invariant under partitioning", "[simd][widen]",
+                   std::int16_t, std::uint16_t) {
+    // The same associativity argument as the plain integer dot, and the reason
+    // the hardware's lane permutation is harmless: cut the reduction anywhere,
+    // add the two halves, get the whole back exactly.
+    using N = TestType;
+    using W = Wide<N>;
+    constexpr std::size_t n = 137;                     // prime: no split aligns
+    std::vector<N> a(n), b(n);
+    for (std::size_t i = 0; i < n; ++i) { a[i] = gen_a<N>(i); b[i] = gen_b<N>(i); }
+
+    const W whole = mtl::simd::reduce_dot_widen<W, N>(a.data(), b.data(), n);
+    for (std::size_t k = 0; k <= n; ++k) {
+        const W lo = mtl::simd::reduce_dot_widen<W, N>(a.data(), b.data(), k);
+        const W hi = mtl::simd::reduce_dot_widen<W, N>(a.data() + k, b.data() + k, n - k);
+        INFO("split at k=" << k);
+        CHECK(static_cast<W>(static_cast<std::uint32_t>(
+                  static_cast<std::uint32_t>(lo) + static_cast<std::uint32_t>(hi))) == whole);
+    }
+}
+
+TEST_CASE("products are exact even at the extremes; only the sum wraps",
+          "[simd][widen]") {
+    // -2^15 * -2^15 = 2^30, which fits an int32 with a bit to spare. A single
+    // term is therefore never lost, however extreme the operands.
+    constexpr auto lo = std::numeric_limits<std::int16_t>::lowest();   // -32768
+    std::vector<std::int16_t> a{lo}, b{lo};
+    CHECK(mtl::simd::reduce_dot_widen<std::int32_t, std::int16_t>(a.data(), b.data(), 1)
+          == 1073741824);                                              // 2^30, exact
+
+    // Two of them still fit (2^31 does not, but 2^30 + 2^30 wraps to exactly
+    // INT32_MIN, which is the defined answer rather than an accident).
+    a.push_back(lo); b.push_back(lo);
+    CHECK(mtl::simd::reduce_dot_widen<std::int32_t, std::int16_t>(a.data(), b.data(), 2)
+          == std::numeric_limits<std::int32_t>::lowest());
+
+    // Three overflows -- the worst case the contract names -- and the result is
+    // the true sum 3 * 2^30 reduced mod 2^32, not a trap or a saturation.
+    a.push_back(lo); b.push_back(lo);
+    CHECK(mtl::simd::reduce_dot_widen<std::int32_t, std::int16_t>(a.data(), b.data(), 3)
+          == static_cast<std::int32_t>(static_cast<std::uint32_t>(3ull * (1ull << 30))));
+}
+
+TEST_CASE("small operands have the headroom the contract claims", "[simd][widen]") {
+    // The useful regime is small operands, not short vectors: at b bits of
+    // magnitude the headroom is about 2^(31-2b) terms. With 8-bit operands
+    // (b = 8) that is ~2^15, so 20 000 terms of the worst case -- every term
+    // maximal and same-signed -- must still be exact.
+    constexpr std::size_t n = 20000;
+    std::vector<std::int16_t> a(n, 127), b(n, 127);
+    const auto got = mtl::simd::reduce_dot_widen<std::int32_t, std::int16_t>(a.data(), b.data(), n);
+    CHECK(got == static_cast<std::int32_t>(n * 127 * 127));            // 322 580 000 < 2^31
+    CHECK(got > 0);                                                    // i.e. it did not wrap
+}
+
+// ---------------------------------------------------------------------------
+// Reachability from the public API. The kernel above is only useful if the
+// mixed-precision dot() spelling selects it, so assert the predicate directly
+// rather than inferring it from a value that the generic loop would also get
+// right.
+
+TEST_CASE("dot<int32_t> over int16 vectors selects the widening kernel",
+          "[simd][widen][operation][dot]") {
+    using v16 = mtl::vec::dense_vector<std::int16_t>;
+    using u16 = mtl::vec::dense_vector<std::uint16_t>;
+
+    STATIC_REQUIRE(mtl::interface::SimdNarrowVector<v16>);
+    STATIC_REQUIRE(mtl::widening_int_dot<std::int32_t, std::int32_t, v16, v16>);
+    STATIC_REQUIRE(mtl::widening_int_dot<std::uint32_t, std::uint32_t, u16, u16>);
+
+    // Everything else keeps the generic accumulator_traits loop, which is
+    // correct for all of these: a wider accumulator than the kernel implements,
+    // a mismatched operand pair, and a view whose stride the kernel cannot see.
+    STATIC_REQUIRE_FALSE(mtl::widening_int_dot<std::int64_t, std::int64_t, v16, v16>);
+    STATIC_REQUIRE_FALSE(mtl::widening_int_dot<std::int32_t, std::int32_t, v16, u16>);
+    STATIC_REQUIRE_FALSE((mtl::widening_int_dot<std::int32_t, std::int32_t,
+                          mtl::vec::strided_vector_ref<std::int16_t>,
+                          mtl::vec::strided_vector_ref<std::int16_t>>));
+    // 16-bit operands are not lanes, so the PLAIN dot path must still reject them.
+    STATIC_REQUIRE_FALSE(mtl::interface::SimdDenseVector<v16>);
+}
+
+TEST_CASE("dot<int32_t> over int16 vectors agrees with the generic loop",
+          "[simd][widen][operation][dot]") {
+    constexpr std::size_t n = 259;
+    mtl::vec::dense_vector<std::int16_t> a(n), b(n);
+    for (std::size_t i = 0; i < n; ++i) { a(i) = gen_a<std::int16_t>(i); b(i) = gen_b<std::int16_t>(i); }
+
+    const auto expected = ref_widen_dot<std::int16_t>(&a(0), &b(0), n);
+    CHECK(mtl::dot<std::int32_t>(a, b) == expected);
+    CHECK(mtl::dot_real<std::int32_t>(a, b) == expected);
+
+    // A wider accumulator does NOT wrap: int64 has room for every one of these
+    // terms, so it must differ from the 32-bit answer and match the true sum.
+    std::int64_t exact = 0;
+    for (std::size_t i = 0; i < n; ++i) exact += std::int64_t(a(i)) * b(i);
+    CHECK(mtl::dot_real<std::int64_t>(a, b) == exact);
+    CHECK(exact != std::int64_t(expected));          // i.e. the 32-bit path really wrapped
+}


### PR DESCRIPTION
Phase 2 of epic #451: the first widening accumulate. `dot<int32_t>` over `int16_t` vectors now goes through the ISA's widening multiply-add instead of the generic accumulator loop.

## What landed

One instruction does the widen, the multiply and the accumulate — **`vpmaddwd`** on x86, degrading to **`pmaddwd`** at `-march=x86-64-v2`, `SMLAL`/`UMLAL` on NEON. Verified at the instruction level rather than only by value:

```
-march=x86-64-v3   ->  vpmaddwd
-march=x86-64-v2   ->  pmaddwd        (the remaining imull are the scalar tail)
```

**16-bit types are operands, not lanes.** `batch<int16_t>` deliberately does not exist: a 16-bit lane's value *is* this accumulate, not a plain multiply. So `is_widenable_v` and `widen_accumulator_t` sit beside `is_lane_v` rather than extending it, and `SimdNarrowVector` gates dispatch separately from `SimdDenseVector`.

## The overflow contract

The other half of what this phase owes, and it is less generous than the floating-point case it superficially resembles. Widening `float`→`double` buys **accuracy** — the products were already exact, and you recover rounding lost in the sum. Widening `int16`→`int32` buys **range**, and not much:

| | `float` → `double` | `int16` → `int32` |
|---|---|---|
| a single product | exact either way | exact either way — 2³⁰ fits |
| what the wide accumulator recovers | rounding error in the sum | headroom before the sum wraps |
| running out | gradual loss of low bits | wraps mod 2³², abruptly |
| how much you get | ~2⁵³ terms | **~2^(31−2b) terms** at *b* bits of operand magnitude |

At full 16-bit range the worst case — every term maximal and same-signed — overflows at **k = 3**. Random signed data random-walks rather than marches, and still only reaches k ≈ 36. The useful regime is **small operands, not short vectors**: 8-bit values in `int16` storage give ~2¹⁵ terms, 4-bit values ~2²³.

This is exactly why VNNI's `vpdpbusd` and NEON's `SDOT` accumulate **int8** into int32 — an 8-bit product needs 15 bits and leaves 16 of headroom, about 65 000 terms. `int16 → int32` is the awkward middle. When the sum does exceed the accumulator it **wraps**: the true sum mod 2³², never a trap, never a saturation, never undefined.

## Why this kernel may use an instruction the float one may not

`ReorderWidenMulAccumulate` is free to permute which product lands in which accumulator lane — x86 pairs adjacent lanes, NEON splits low/high halves — and Highway guarantees only that the **total** is right.

For a floating accumulator that is disqualifying: the grouping changes the rounding, so identical source would give different answers per ISA. On integer lanes it costs exactly nothing, because addition mod 2³² is associative and commutative and the permutation is unobservable.

That is the real dependency between phases 0 and 2 — **phase 0's wrapping contract is what lets this kernel use a permuting instruction without a caveat**, and why every test here asserts exact equality against a closed form and never mentions lane order, backend or vector width.

## A note on sequencing

The epic groups phases 2–3 behind the blocking-model decision (#458), but the stated reason is *phase 3's* register-tile re-derivation. This phase is lane-level and touches no part of `derive_blocking`, so it is unaffected. **Phase 3 genuinely is still blocked** and is not attempted here.

## Changes

| File | What |
|---|---|
| `include/mtl/simd/batch.hpp` | `is_widenable_v`, `widen_accumulator_t`, `widen_step`, and `widen_dot_accumulate` on both backends |
| `include/mtl/simd/algorithm.hpp` | integer `reduce_dot_widen` overload, with the overflow contract written down |
| `include/mtl/interface/dispatch_traits.hpp` | `SimdNarrowVector` |
| `include/mtl/operation/dot.hpp` | `widening_int_dot` predicate; `dot` and `dot_real` select the kernel |
| `tests/unit/simd/test_widening_dot.cpp` | **new** — 9 cases, 352 assertions |
| `docs/algorithms/mixed-precision-kernels.md` | the integer case, contrasted against the floating one |

## Tests

- 25 lengths straddling the widen step, both signedness arms, against a closed form
- **Partition invariance** at all 138 cut points of a prime length — the same associativity argument that makes the lane permutation harmless
- The extremes pinned: one `-2^15` squared is exact (2³⁰), two wrap to exactly `INT32_MIN`, three wrap to a stated value
- The claimed headroom verified: 20 000 worst-case 8-bit terms summed without wrapping
- Dispatch asserted **directly**, not inferred from a value the generic loop would also get right — including that a wider accumulator, a mismatched pair and a strided view all correctly fall back
- A misuse (`int8_t` operands) produces exactly one diagnostic, not a cascade

| Compiler | Backend | Result |
|---|---|---|
| gcc 13.3 | scalar fallback | **174/174** |
| gcc 13.3 | Highway 1.4, `-march=native` | **174/174** |
| clang | scalar fallback | **174/174** |
| clang | Highway 1.4, `-march=native` | **174/174** |

Plus UBSan (`-fsanitize=undefined,integer`) over the integer kernels.

## What this does not do

- No int8 / VNNI / SDOT — phase 3, blocked on #458
- No widening `gemv` or `gemm` — the per-row accumulator structure is a different shape, and phase 3 territory
- No benchmarks — phase 4, and deliberately last

## Test plan
- [ ] Tier 1 CI passes
- [ ] CodeRabbit review addressed
- [ ] Merge

Relates to #451

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SIMD-optimized widening dot products for signed and unsigned 16-bit integers with 32-bit accumulation.
  * Added support for contiguous narrow-integer vectors and automatic accumulator type mapping.
  * Preserved existing fallback behavior for unsupported types, layouts, and accumulator sizes.
  * Documented integer mixed-precision dot products, overflow behavior, and deterministic wrapping arithmetic.

* **Bug Fixes**
  * Improved handling of integer overflow and scalar tails using consistent modulo-2³² arithmetic.

* **Tests**
  * Added comprehensive coverage for supported types, extreme values, vector lengths, dispatch behavior, and fallback paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->