### PR TITLE
feat(simd): int8 → int32 dot via VNNI / SDOT quad multiply-accumulate (#451 phase 3)

### DIFF
--- a/docs/algorithms/mixed-precision-kernels.md
+++ b/docs/algorithms/mixed-precision-kernels.md
@@ -283,11 +283,20 @@ is for real vectors.
 implements `unsigned × signed` — unsigned activations against signed weights,
 the shape of a quantized layer — and the symmetric `int8 × int8` form only from
 AVX10.2. Before that, the symmetric version costs about three times the native
-one (two `dpbusd` calls plus a shift and subtract). So MTL5 offers the three
-pairings the instruction offers, and **rejects `(int8, uint8)` at compile time**
-rather than silently reordering it: a dot product is symmetric, so swapping the
-arguments gets the native instruction, and being told that beats being quietly
-routed through the emulation.
+one (two `dpbusd` calls plus a shift and subtract). MTL5 handles that asymmetry
+at two levels, and the distinction matters:
+
+- **The kernel** `simd::reduce_dot_widen` offers exactly the three pairings the
+  instruction offers and **rejects `(int8, uint8)` at compile time**, naming the
+  fix. It is a primitive that mirrors the hardware, so a pairing with no
+  instruction should say so rather than quietly cost three times as much.
+- **`dot` and `dot_real` accept every pairing** and stay fast. A dot product is
+  symmetric, so the reversed order is dispatched by **swapping the operands** and
+  running the native instruction. Refusing to compute a well-defined dot product
+  for a hardware reason would break generic code; dropping to the generic loop
+  would cost roughly an order of magnitude with nothing to warn the caller.
+  Neither is necessary. (`conj` is the identity on the integers, so this holds
+  for the Hermitian `dot` too.)
 
 ### What this means for an int8 GEMM
 

--- a/docs/algorithms/mixed-precision-kernels.md
+++ b/docs/algorithms/mixed-precision-kernels.md
@@ -259,6 +259,49 @@ When the sum does exceed the accumulator it **wraps** — the true sum reduced
 mod 2³², never a trap, never a saturation, never undefined. Callers needing the
 full range should widen their storage, not hope.
 
+### 8-bit: the width the hardware was actually built for
+
+`dot<int32_t>` over 8-bit vectors uses a different instruction again — one that
+sums **four** products into each 32-bit lane: VNNI's `vpdpbusd` on x86, `SDOT`/
+`UDOT` on NEON. Halving the operand width quarters the product, and that is
+where the headroom comes from:
+
+| pairing | max \|product\| | terms before the sum can overflow |
+|---|---|---|
+| `int16 × int16` | 2³⁰ | **3** worst case, ~36 random |
+| `int8 × int8` | 2¹⁴ | **~131 000** |
+| `uint8 × int8` | ~2¹⁵ | **~65 000** |
+| `uint8 × uint8` | ~2¹⁶ | **~66 000** |
+
+Four to five orders of magnitude, from the *same* 32-bit accumulator. This is
+why the quantized-inference instructions are 8-bit and not 16-bit: 16-bit
+operands make the accumulator the binding constraint, 8-bit operands do not. In
+MTL5 terms, the phase-2 kernel is for small values in 16-bit storage; this one
+is for real vectors.
+
+**The signedness asymmetry is the hardware's, not a design choice.** VNNI
+implements `unsigned × signed` — unsigned activations against signed weights,
+the shape of a quantized layer — and the symmetric `int8 × int8` form only from
+AVX10.2. Before that, the symmetric version costs about three times the native
+one (two `dpbusd` calls plus a shift and subtract). So MTL5 offers the three
+pairings the instruction offers, and **rejects `(int8, uint8)` at compile time**
+rather than silently reordering it: a dot product is symmetric, so swapping the
+arguments gets the native instruction, and being told that beats being quietly
+routed through the emulation.
+
+### What this means for an int8 GEMM
+
+There is **no new register tile to derive**. `derive_blocking` sizes the tile
+from the *accumulator*, which `gemm_blocked<TC, TAB>` already passes it, and
+`int32` shares a lane width and register file with `float` — so the int8 tile
+*is* the float tile, `mr × nr` unchanged, at every vector width.
+
+What the 1-byte operand does change is the **K granularity**: the instruction
+consumes four k-values at once, so `kc` must be a multiple of 4 and the packed
+panels must be quad-interleaved (four k-values contiguous within each 32-bit
+word). The first is already true — `kc` is a multiple of 4 in every cache
+configuration MTL5 derives — so only the pack layout is new work.
+
 ### Why the integer kernel can use an instruction the float one cannot
 
 `ReorderWidenMulAccumulate` is free to permute which product lands in which

--- a/include/mtl/interface/dispatch_traits.hpp
+++ b/include/mtl/interface/dispatch_traits.hpp
@@ -130,6 +130,23 @@ concept SimdNarrowVector =
         { v.size() };
     };
 
+/// Concept satisfied by dense vector types of an 8-bit element that the quad
+/// multiply-accumulate can widen into a 32-bit lane (#451 phase 3).
+///
+/// Distinct from `SimdNarrowVector` because the operations differ in more than
+/// width: the pairwise op takes two operands of the SAME type, while the quad op
+/// accepts three PAIRINGS, one of them mixed-signedness -- and that mixed one is
+/// the native instruction. So the pairing, not the element type alone, decides
+/// what is dispatchable; see `mtl::quad_int_dot`.
+template <typename V>
+concept SimdQuadVector =
+    simd::is_quad_widenable_v<typename V::value_type> &&
+    ContiguousVector<V> &&
+    requires(const V& v) {
+        { v.data() } -> std::convertible_to<const typename V::value_type*>;
+        { v.size() };
+    };
+
 /// Concept satisfied by dense matrix types eligible for MTL5's own SIMD
 /// kernels -- `BlasDenseMatrix` widened to every `mtl::simd` lane type, for the
 /// same reason as `SimdDenseVector`.

--- a/include/mtl/operation/dot.hpp
+++ b/include/mtl/operation/dot.hpp
@@ -37,6 +37,30 @@ concept quad_int_dot =
                                                          typename V2::value_type>> &&
     std::is_same_v<Result, Accumulator>;
 
+/// Does `dot(v1, v2)` name the quad kernel with the operands the OTHER way round?
+///
+/// `(int8, uint8)` has no hardware pairing -- VNNI implements unsigned x signed,
+/// so `(uint8, int8)` is the native one. The kernel `reduce_dot_widen` rejects
+/// the reversed order at compile time, which is right for a primitive that
+/// mirrors the instruction: there is no such instruction, and silently taking a
+/// three-times-slower emulation would be worse than saying so.
+///
+/// `dot` is not that primitive. Refusing to compute a well-defined dot product
+/// because the hardware lacks a fused form would break generic code for a
+/// performance reason, and dropping to the generic loop would cost roughly an
+/// order of magnitude with nothing to warn the caller. Neither is necessary: a
+/// dot product is SYMMETRIC, so the operands are simply swapped and the native
+/// instruction runs. `conj` is the identity on the integers, so this holds for
+/// the Hermitian `dot` as well as `dot_real`.
+template <typename Accumulator, typename Result, typename V1, typename V2>
+concept quad_int_dot_swapped =
+    interface::SimdQuadVector<V1> && interface::SimdQuadVector<V2> &&
+    !simd::QuadPair<typename V1::value_type, typename V2::value_type> &&
+    simd::QuadPair<typename V2::value_type, typename V1::value_type> &&
+    std::is_same_v<Accumulator, simd::quad_accumulator_t<typename V2::value_type,
+                                                         typename V1::value_type>> &&
+    std::is_same_v<Result, Accumulator>;
+
 /// Does `dot<Accumulator, Result>(v1, v2)` name the widening integer kernel?
 ///
 /// Both vectors contiguous over the SAME 16-bit type, and the requested
@@ -79,6 +103,12 @@ auto dot(const V1& v1, const V2& v2) {
             return simd::reduce_dot_widen<Accumulator, typename V1::value_type,
                                           typename V2::value_type>(
                 v1.data(), v2.data(), v1.size());
+        } else if constexpr (quad_int_dot_swapped<Accumulator, Result, V1, V2>) {
+            // Reversed 8-bit pairing: swap and take the native instruction. Exact,
+            // because a dot product is symmetric and conj is the identity here.
+            return simd::reduce_dot_widen<Accumulator, typename V2::value_type,
+                                          typename V1::value_type>(
+                v2.data(), v1.data(), v1.size());
         } else if constexpr (widening_int_dot<Accumulator, Result, V1, V2>) {
             // Widening INTEGER fast path (#451 phase 2): 16-bit operands into a
             // 32-bit accumulator, via the hardware's widening multiply-add. conj
@@ -170,6 +200,10 @@ auto dot_real(const V1& v1, const V2& v2) {
             return simd::reduce_dot_widen<Accumulator, typename V1::value_type,
                                           typename V2::value_type>(
                 v1.data(), v2.data(), v1.size());
+        } else if constexpr (quad_int_dot_swapped<Accumulator, Result, V1, V2>) {
+            return simd::reduce_dot_widen<Accumulator, typename V2::value_type,
+                                          typename V1::value_type>(
+                v2.data(), v1.data(), v1.size());
         } else if constexpr (widening_int_dot<Accumulator, Result, V1, V2>) {
             return simd::reduce_dot_widen<Accumulator, typename V1::value_type>(
                 v1.data(), v2.data(), v1.size());

--- a/include/mtl/operation/dot.hpp
+++ b/include/mtl/operation/dot.hpp
@@ -22,6 +22,21 @@
 
 namespace mtl {
 
+/// Does `dot<Accumulator, Result>(v1, v2)` name the quad-widening 8-bit kernel?
+///
+/// Unlike the 16-bit predicate this does NOT require the two element types to
+/// match: `(uint8, int8)` is VNNI's native pairing and the one quantized
+/// inference actually uses. `quad_accumulator` decides which pairings exist and
+/// what each accumulates into, so the predicate defers to it rather than
+/// restating the rule.
+template <typename Accumulator, typename Result, typename V1, typename V2>
+concept quad_int_dot =
+    interface::SimdQuadVector<V1> && interface::SimdQuadVector<V2> &&
+    simd::QuadPair<typename V1::value_type, typename V2::value_type> &&
+    std::is_same_v<Accumulator, simd::quad_accumulator_t<typename V1::value_type,
+                                                         typename V2::value_type>> &&
+    std::is_same_v<Result, Accumulator>;
+
 /// Does `dot<Accumulator, Result>(v1, v2)` name the widening integer kernel?
 ///
 /// Both vectors contiguous over the SAME 16-bit type, and the requested
@@ -58,6 +73,12 @@ auto dot(const V1& v1, const V2& v2) {
                       std::is_same_v<typename V2::value_type, float> &&
                       std::is_same_v<Accumulator, double> && std::is_same_v<Result, double>) {
             return simd::reduce_dot_widen<double, float>(v1.data(), v2.data(), v1.size());
+        } else if constexpr (quad_int_dot<Accumulator, Result, V1, V2>) {
+            // Quad-widening 8-bit fast path (#451 phase 3): VNNI / SDOT. conj is
+            // the identity on the integers, so this is the Hermitian product.
+            return simd::reduce_dot_widen<Accumulator, typename V1::value_type,
+                                          typename V2::value_type>(
+                v1.data(), v2.data(), v1.size());
         } else if constexpr (widening_int_dot<Accumulator, Result, V1, V2>) {
             // Widening INTEGER fast path (#451 phase 2): 16-bit operands into a
             // 32-bit accumulator, via the hardware's widening multiply-add. conj
@@ -145,6 +166,10 @@ auto dot_real(const V1& v1, const V2& v2) {
                       std::is_same_v<typename V2::value_type, float> &&
                       std::is_same_v<Accumulator, double> && std::is_same_v<Result, double>) {
             return simd::reduce_dot_widen<double, float>(v1.data(), v2.data(), v1.size());
+        } else if constexpr (quad_int_dot<Accumulator, Result, V1, V2>) {
+            return simd::reduce_dot_widen<Accumulator, typename V1::value_type,
+                                          typename V2::value_type>(
+                v1.data(), v2.data(), v1.size());
         } else if constexpr (widening_int_dot<Accumulator, Result, V1, V2>) {
             return simd::reduce_dot_widen<Accumulator, typename V1::value_type>(
                 v1.data(), v2.data(), v1.size());

--- a/include/mtl/simd/algorithm.hpp
+++ b/include/mtl/simd/algorithm.hpp
@@ -156,25 +156,74 @@ Wide reduce_dot_widen(const Narrow* a, const Narrow* b, std::size_t n) {
 /// make the result ISA-dependent; here it is unobservable, because addition mod
 /// 2^32 is associative and commutative. Phase 0's contract is what lets this
 /// kernel use the instruction without a caveat.
-template <typename Wide, typename Narrow>
+/// 8-BIT OPERANDS (#451 phase 3) are the same function with a different
+/// instruction and a very different headroom, so the two live together here.
+///
+///   16-bit: pairwise widen (`vpmaddwd`), 2 products per 32-bit lane
+///    8-bit: quad widen (VNNI `vpdpbusd`, NEON `SDOT`), 4 products per lane
+///
+/// And the headroom is where the 8-bit case earns "the one that matters":
+///
+///   | pairing        | max |product| | terms before the sum can overflow |
+///   |----------------|----------------|-----------------------------------|
+///   | int16 x int16  | 2^30           | 3 worst case, ~36 random          |
+///   |  int8 x int8   | 2^14           | ~131 000                          |
+///   | uint8 x  int8  | ~2^15          | ~65 000                           |
+///   | uint8 x uint8  | ~2^16          | ~66 000                           |
+///
+/// Four to five orders of magnitude, from the same 32-bit accumulator, purely
+/// because the operands are half as wide and the product therefore a quarter
+/// the size. This is why the quantized-inference instructions are 8-bit and not
+/// 16-bit, and why phase 2's kernel is useful only for small operands while this
+/// one is useful for real vectors.
+///
+/// THE SIGNEDNESS ASYMMETRY IS THE HARDWARE'S. VNNI implements `unsigned x
+/// signed` -- unsigned activations against signed weights -- and symmetric
+/// `i8 x i8` only from AVX10.2. Before that Highway emulates the symmetric form
+/// with two `dpbusd` calls plus a shift and subtract, roughly three times the
+/// work. `(int8, uint8)` is rejected rather than silently reordered: the dot is
+/// symmetric, so swapping the arguments gets the native instruction, and a
+/// compile error saying so beats a quiet detour through the emulation.
+template <typename Wide, typename NA, typename NB = NA>
     requires std::is_integral_v<Wide>
-Wide reduce_dot_widen(const Narrow* a, const Narrow* b, std::size_t n) {
-    static_assert(is_widenable_v<Narrow>, "reduce_dot_widen widens 16-bit integers");
-    // Guarded: widen_accumulator has no definition for a non-widenable Narrow,
-    // so naming it unconditionally would bury the assertion above under an
-    // "incomplete type" error. A discarded if-constexpr branch is not
-    // instantiated, which leaves exactly one diagnostic.
-    if constexpr (is_widenable_v<Narrow>) {
-        static_assert(std::is_same_v<Wide, widen_accumulator_t<Narrow>>,
-                      "int16 accumulates in int32, uint16 in uint32");
-    }
+Wide reduce_dot_widen(const NA* a, const NB* b, std::size_t n) {
+    static_assert(is_widenable_v<NA> || is_quad_widenable_v<NA>,
+                  "reduce_dot_widen widens 8- or 16-bit integers");
     using B = batch<Wide>;
-    constexpr std::size_t S = B::widen_step;
-    B s0{}, s1{};                            // s1 MUST start zeroed -- see batch.hpp
     std::size_t i = 0;
-    for (; i + S <= n; i += S)
-        B::widen_dot_accumulate(a + i, b + i, s0, s1);
-    Wide s = reduce_add(s0 + s1);            // the one defined observation
+    Wide s{};
+    // Guarded so a bad Narrow reports ONE diagnostic: the accumulator traits are
+    // undefined for it, and a discarded if-constexpr branch is not instantiated.
+    if constexpr (is_quad_widenable_v<NA>) {
+        static_assert(is_quad_widenable_v<NB>, "both operands must be 8-bit");
+        static_assert(QuadPair<NA, NB>,
+                      "unsupported 8-bit pairing -- the hardware op takes "
+                      "(i8,i8), (u8,i8) or (u8,u8); for (i8,u8) swap the "
+                      "arguments, which a dot product permits");
+        // Guarded for the same reason as the 16-bit case below: quad_accumulator
+        // is undefined for a rejected pairing, so naming it unconditionally
+        // would bury the assertion above under an "incomplete type" error.
+        if constexpr (QuadPair<NA, NB>) {
+            static_assert(std::is_same_v<Wide, quad_accumulator_t<NA, NB>>,
+                          "i8*i8 and u8*i8 accumulate in int32, u8*u8 in uint32");
+        }
+        constexpr std::size_t S = B::quad_step;
+        B acc{};
+        for (; i + S <= n; i += S) B::quad_dot_accumulate(a + i, b + i, acc);
+        s = reduce_add(acc);
+    } else {
+        static_assert(std::is_same_v<NA, NB>,
+                      "16-bit widening takes two operands of the same type");
+        static_assert(is_widenable_v<NA>, "reduce_dot_widen widens 16-bit integers");
+        if constexpr (is_widenable_v<NA>) {
+            static_assert(std::is_same_v<Wide, widen_accumulator_t<NA>>,
+                          "int16 accumulates in int32, uint16 in uint32");
+        }
+        constexpr std::size_t S = B::widen_step;
+        B s0{}, s1{};                        // s1 MUST start zeroed -- see batch.hpp
+        for (; i + S <= n; i += S) B::widen_dot_accumulate(a + i, b + i, s0, s1);
+        s = reduce_add(s0 + s1);             // the one defined observation
+    }
     for (; i < n; ++i)                       // scalar tail, same wrapping rules
         s = mtl::detail::wrap_add(
             s, mtl::detail::wrap_mul(static_cast<Wide>(a[i]), static_cast<Wide>(b[i])));

--- a/include/mtl/simd/batch.hpp
+++ b/include/mtl/simd/batch.hpp
@@ -123,6 +123,45 @@ template <> struct widen_accumulator<std::uint16_t> { using type = std::uint32_t
 template <typename Narrow>
 using widen_accumulator_t = typename widen_accumulator<Narrow>::type;
 
+/// Narrow integer types whose dot product widens by FOUR into a 32-bit lane,
+/// via the hardware's quad multiply-accumulate (#451 phase 3) -- VNNI's
+/// `vpdpbusd` on x86, `SDOT`/`UDOT` on NEON. Four products are summed into one
+/// accumulator lane by a single instruction.
+///
+/// This is the case the epic calls "the one that matters", and the reason is
+/// headroom rather than lane count: an 8-bit product needs 15 bits, leaving ~16
+/// in an int32 accumulator -- of the order of 10^5 terms, against the handful
+/// that 16-bit operands afford (see reduce_dot_widen in simd/algorithm.hpp).
+template <typename T>
+inline constexpr bool is_quad_widenable_v =
+    std::is_same_v<T, std::int8_t> || std::is_same_v<T, std::uint8_t>;
+
+/// The accumulator for a quad-widening operand PAIR.
+///
+/// Three pairings, and the asymmetry is the hardware's, not a design choice:
+/// VNNI implements `unsigned x signed` natively (`_mm_dpbusd_epi32`) because
+/// that is the shape of quantized inference -- unsigned activations against
+/// signed weights. Symmetric `i8 x i8` is native only from AVX10.2
+/// (`_mm_dpbssd_epi32`); before that Highway emulates it with two `dpbusd`
+/// calls plus a shift and subtract, so it costs about three times the native
+/// form on every x86 shipping today. NEON has all three natively.
+///
+/// `(int8, uint8)` is deliberately absent rather than silently reordered: a dot
+/// product is symmetric, so a caller holding that pairing should swap the
+/// arguments and get the native instruction, and being told so at compile time
+/// is better than being given the emulated path without knowing.
+template <typename A, typename B> struct quad_accumulator;
+template <> struct quad_accumulator<std::int8_t,  std::int8_t>  { using type = std::int32_t;  };
+template <> struct quad_accumulator<std::uint8_t, std::int8_t>  { using type = std::int32_t;  };
+template <> struct quad_accumulator<std::uint8_t, std::uint8_t> { using type = std::uint32_t; };
+
+template <typename A, typename B>
+using quad_accumulator_t = typename quad_accumulator<A, B>::type;
+
+/// Is `(A, B)` a quad-widening pair the hardware op accepts?
+template <typename A, typename B>
+concept QuadPair = requires { typename quad_accumulator<A, B>::type; };
+
 #if MTL5_SIMD_USE_HIGHWAY
 
 namespace hn = hwy::HWY_NAMESPACE;
@@ -218,6 +257,35 @@ public:
         sum1.v_ = s1;
     }
 
+    /// Narrow values consumed by one `quad_dot_accumulate` call: a full narrow
+    /// vector, holding four times as many 8-bit lanes as this batch holds
+    /// 32-bit ones.
+    static constexpr std::size_t quad_step = 4 * size;
+
+    /// Quad-widening dot accumulate: four 8-bit products summed into each
+    /// 32-bit accumulator lane by one instruction (#451 phase 3).
+    ///
+    /// Note what is NOT here: a second accumulator. The pairwise op
+    /// (`widen_dot_accumulate`) needs one because it may permute products across
+    /// lanes and only guarantees the total. `SumOfMulQuadAccumulate` specifies
+    /// exactly which four products land in lane i, so there is nothing to
+    /// reorder and one accumulator suffices. The wrapping contract still does
+    /// the work of making the horizontal sum order-independent.
+    ///
+    /// The two operand types may differ: `(uint8, int8)` is VNNI's native shape
+    /// and the reason the instruction exists. See `quad_accumulator`.
+    template <typename NA, typename NB>
+    static void quad_dot_accumulate(const NA* a, const NB* b, batch& sum) {
+        static_assert(is_quad_widenable_v<NA> && is_quad_widenable_v<NB>,
+                      "quad_dot_accumulate takes 8-bit operands");
+        static_assert(std::is_same_v<T, quad_accumulator_t<NA, NB>>,
+                      "accumulator must match the operand pairing: i8*i8 and "
+                      "u8*i8 -> int32, u8*u8 -> uint32");
+        const hn::Repartition<NA, D> dna;
+        const hn::Repartition<NB, D> dnb;
+        sum.v_ = hn::SumOfMulQuadAccumulate(d_, hn::LoadU(dna, a), hn::LoadU(dnb, b), sum.v_);
+    }
+
     friend batch operator+(batch a, batch b) { return batch(hn::Add(a.v_, b.v_)); }
     friend batch operator-(batch a, batch b) { return batch(hn::Sub(a.v_, b.v_)); }
     friend batch operator*(batch a, batch b) { return batch(hn::Mul(a.v_, b.v_)); }
@@ -305,6 +373,25 @@ public:
             sum0.v_, mtl::detail::wrap_mul(static_cast<T>(a[0]), static_cast<T>(b[0])));
         sum1.v_ = mtl::detail::wrap_add(
             sum1.v_, mtl::detail::wrap_mul(static_cast<T>(a[1]), static_cast<T>(b[1])));
+    }
+
+    /// Narrow values consumed per quad_dot_accumulate call -- four, matching the
+    /// instruction's four-products-per-lane shape rather than the lane count.
+    static constexpr std::size_t quad_step = 4;
+
+    /// Quad-widening dot accumulate -- scalar fallback; see the Highway variant.
+    /// Four products into the single accumulator, which is exactly what the
+    /// instruction does to one lane.
+    template <typename NA, typename NB>
+    static void quad_dot_accumulate(const NA* a, const NB* b, batch& sum) {
+        static_assert(is_quad_widenable_v<NA> && is_quad_widenable_v<NB>,
+                      "quad_dot_accumulate takes 8-bit operands");
+        static_assert(std::is_same_v<T, quad_accumulator_t<NA, NB>>,
+                      "accumulator must match the operand pairing: i8*i8 and "
+                      "u8*i8 -> int32, u8*u8 -> uint32");
+        for (std::size_t k = 0; k < 4; ++k)
+            sum.v_ = mtl::detail::wrap_add(
+                sum.v_, mtl::detail::wrap_mul(static_cast<T>(a[k]), static_cast<T>(b[k])));
     }
 
     friend batch operator+(batch a, batch b) { return batch(mtl::detail::wrap_add(a.v_, b.v_)); }

--- a/tests/unit/simd/test_quad_dot.cpp
+++ b/tests/unit/simd/test_quad_dot.cpp
@@ -194,9 +194,15 @@ TEST_CASE("dot selects the quad kernel for the pairings that have one",
     STATIC_REQUIRE(mtl::quad_int_dot<std::int32_t,  std::int32_t,  u8v, i8v>);   // VNNI native
     STATIC_REQUIRE(mtl::quad_int_dot<std::uint32_t, std::uint32_t, u8v, u8v>);
 
-    // (int8, uint8) has no hardware pairing -- the generic loop takes it, which
-    // is correct, just not accelerated. Swapping the arguments would be.
+    // (int8, uint8) has no hardware pairing, so the direct predicate is false --
+    // but dot does NOT fall to the generic loop for it. A dot product is
+    // symmetric, so the operands are swapped and the native instruction runs.
     STATIC_REQUIRE_FALSE(mtl::quad_int_dot<std::int32_t, std::int32_t, i8v, u8v>);
+    STATIC_REQUIRE(mtl::quad_int_dot_swapped<std::int32_t, std::int32_t, i8v, u8v>);
+    // The swap applies only where it is needed: a pairing the hardware already
+    // has must not be re-routed through it.
+    STATIC_REQUIRE_FALSE(mtl::quad_int_dot_swapped<std::int32_t, std::int32_t, u8v, i8v>);
+    STATIC_REQUIRE_FALSE(mtl::quad_int_dot_swapped<std::int32_t, std::int32_t, i8v, i8v>);
     // A wider accumulator than the instruction implements also falls back.
     STATIC_REQUIRE_FALSE(mtl::quad_int_dot<std::int64_t, std::int64_t, i8v, i8v>);
     // And 8-bit types are not lanes, so the plain dot path must still reject them.
@@ -244,4 +250,26 @@ TEST_CASE("the int8 GEMM register tile is the float tile", "[simd][quad][blockin
         // kc must be a multiple of 4 and the pack layout quad-interleaved.
         CHECK(i.kc % 4 == 0);
     }
+}
+
+TEST_CASE("the reversed 8-bit pairing is swapped, not demoted",
+          "[simd][quad][operation][dot]") {
+    // dot(i8, u8) and dot(u8, i8) are the same mathematical quantity, and both
+    // must take the native instruction rather than one of them silently
+    // dropping to the generic loop an order of magnitude away.
+    constexpr std::size_t n = 259;
+    mtl::vec::dense_vector<std::int8_t>  a(n);
+    mtl::vec::dense_vector<std::uint8_t> b(n);
+    std::int64_t exact = 0;
+    for (std::size_t i = 0; i < n; ++i) {
+        a(i) = gen_b<std::int8_t>(i);
+        b(i) = gen_a<std::uint8_t>(i);
+        exact += std::int64_t(a(i)) * b(i);
+    }
+    CHECK((mtl::dot_real<std::int32_t>(a, b)) == exact);          // reversed order
+    CHECK((mtl::dot_real<std::int32_t>(b, a)) == exact);          // native order
+    CHECK((mtl::dot_real<std::int32_t>(a, b)) == (mtl::dot_real<std::int32_t>(b, a)));
+    // conj is the identity on the integers, so the Hermitian spelling agrees too.
+    CHECK((mtl::dot<std::int32_t>(a, b)) == exact);
+    CHECK((mtl::dot<std::int32_t>(b, a)) == exact);
 }

--- a/tests/unit/simd/test_quad_dot.cpp
+++ b/tests/unit/simd/test_quad_dot.cpp
@@ -1,0 +1,247 @@
+// int8 -> int32 dot via the quad multiply-accumulate -- #451 phase 3.
+//
+// This is the case the epic calls "the one that matters", and the reason is
+// headroom, not lane count. Against phase 2's 16-bit kernel, from the same
+// 32-bit accumulator:
+//
+//   pairing        max |product|   terms before the sum can overflow
+//   int16 x int16     2^30         3 worst case, ~36 random
+//    int8 x int8      2^14         ~131 000
+//   uint8 x  int8      ~2^15       ~65 000
+//   uint8 x uint8      ~2^16       ~66 000
+//
+// Four to five orders of magnitude, purely because halving the operand width
+// quarters the product. That is why the quantized-inference instructions are
+// 8-bit, and why phase 2's kernel is for small operands while this one is for
+// real vectors. The headroom claims are tested below, not just asserted.
+//
+// THE SIGNEDNESS ASYMMETRY IS THE HARDWARE'S. VNNI implements unsigned x signed
+// (vpdpbusd) -- unsigned activations against signed weights -- and the symmetric
+// i8 x i8 form only from AVX10.2. `(int8, uint8)` is rejected rather than
+// silently reordered, since a dot product is symmetric and swapping the
+// arguments gets the native instruction.
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+
+#include <mtl/interface/dispatch_traits.hpp>
+#include <mtl/operation/dot.hpp>
+#include <mtl/simd/algorithm.hpp>
+#include <mtl/simd/batch.hpp>
+#include <mtl/simd/blocking.hpp>
+#include <mtl/vec/dense_vector.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+#include <vector>
+
+namespace {
+
+/// Exact sum of products reduced to 32 bits, computed in 64.
+template <typename W, typename A, typename B>
+W ref_quad(const A* a, const B* b, std::size_t n) {
+    std::uint64_t acc = 0;
+    for (std::size_t i = 0; i < n; ++i)
+        acc += static_cast<std::uint64_t>(static_cast<std::uint32_t>(static_cast<W>(a[i]))) *
+               static_cast<std::uint32_t>(static_cast<W>(b[i]));
+    return static_cast<W>(static_cast<std::uint32_t>(acc));
+}
+
+template <typename T> T gen_a(std::size_t i) { return static_cast<T>(static_cast<std::uint8_t>(0x9Eu * (i + 1) + 0x37u)); }
+template <typename T> T gen_b(std::size_t i) { return static_cast<T>(static_cast<std::uint8_t>(0x85u * (i + 3) + 0xEBu)); }
+
+// Lengths straddling the quad step on every backend, plus ragged tails.
+const std::size_t kLengths[] = {0, 1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 32, 33,
+                                63, 64, 65, 127, 128, 129, 255, 256, 257, 1031};
+
+} // namespace
+
+TEST_CASE("the quad-widenable types and their pairings", "[simd][quad]") {
+    using namespace mtl::simd;
+    STATIC_REQUIRE(is_quad_widenable_v<std::int8_t>);
+    STATIC_REQUIRE(is_quad_widenable_v<std::uint8_t>);
+    STATIC_REQUIRE_FALSE(is_quad_widenable_v<std::int16_t>);   // phase 2's op
+    STATIC_REQUIRE_FALSE(is_quad_widenable_v<std::int32_t>);   // already a lane
+
+    // The three pairings the hardware op accepts...
+    STATIC_REQUIRE(QuadPair<std::int8_t,  std::int8_t>);
+    STATIC_REQUIRE(QuadPair<std::uint8_t, std::int8_t>);       // VNNI's native shape
+    STATIC_REQUIRE(QuadPair<std::uint8_t, std::uint8_t>);
+    // ... and the one it does not. A dot product is symmetric, so the caller
+    // swaps and gets the native instruction; being told beats being detoured.
+    STATIC_REQUIRE_FALSE(QuadPair<std::int8_t, std::uint8_t>);
+
+    STATIC_REQUIRE(std::is_same_v<quad_accumulator_t<std::int8_t,  std::int8_t>,  std::int32_t>);
+    STATIC_REQUIRE(std::is_same_v<quad_accumulator_t<std::uint8_t, std::int8_t>,  std::int32_t>);
+    STATIC_REQUIRE(std::is_same_v<quad_accumulator_t<std::uint8_t, std::uint8_t>, std::uint32_t>);
+
+    // 8-bit types are operands, not lanes -- x86 has no 8-bit vector multiply.
+    STATIC_REQUIRE_FALSE(is_lane_v<std::int8_t>);
+    STATIC_REQUIRE_FALSE(is_lane_v<std::uint8_t>);
+
+    // Four products per accumulator lane, against the pairwise op's two.
+    STATIC_REQUIRE(batch<std::int32_t>::quad_step == 4 * batch<std::int32_t>::size);
+    STATIC_REQUIRE(batch<std::int32_t>::quad_step == 2 * batch<std::int32_t>::widen_step);
+}
+
+TEST_CASE("int8 x int8 dot is exact mod 2^32 at every length", "[simd][quad]") {
+    for (std::size_t n : kLengths) {
+        std::vector<std::int8_t> a(n), b(n);
+        for (std::size_t i = 0; i < n; ++i) { a[i] = gen_a<std::int8_t>(i); b[i] = gen_b<std::int8_t>(i); }
+        INFO("n=" << n);
+        CHECK(mtl::simd::reduce_dot_widen<std::int32_t, std::int8_t>(a.data(), b.data(), n) ==
+              (ref_quad<std::int32_t, std::int8_t, std::int8_t>(a.data(), b.data(), n)));
+    }
+}
+
+TEST_CASE("uint8 x int8 -- VNNI's native shape -- is exact at every length", "[simd][quad]") {
+    for (std::size_t n : kLengths) {
+        std::vector<std::uint8_t> a(n);
+        std::vector<std::int8_t>  b(n);
+        for (std::size_t i = 0; i < n; ++i) { a[i] = gen_a<std::uint8_t>(i); b[i] = gen_b<std::int8_t>(i); }
+        INFO("n=" << n);
+        CHECK((mtl::simd::reduce_dot_widen<std::int32_t, std::uint8_t, std::int8_t>(a.data(), b.data(), n)) ==
+              (ref_quad<std::int32_t, std::uint8_t, std::int8_t>(a.data(), b.data(), n)));
+    }
+}
+
+TEST_CASE("uint8 x uint8 is exact at every length", "[simd][quad]") {
+    for (std::size_t n : kLengths) {
+        std::vector<std::uint8_t> a(n), b(n);
+        for (std::size_t i = 0; i < n; ++i) { a[i] = gen_a<std::uint8_t>(i); b[i] = gen_b<std::uint8_t>(i); }
+        INFO("n=" << n);
+        CHECK((mtl::simd::reduce_dot_widen<std::uint32_t, std::uint8_t>(a.data(), b.data(), n)) ==
+              (ref_quad<std::uint32_t, std::uint8_t, std::uint8_t>(a.data(), b.data(), n)));
+    }
+}
+
+TEST_CASE("quad dot is invariant under partitioning", "[simd][quad]") {
+    // Cut anywhere, add the halves, get the whole back exactly -- the same
+    // associativity that makes the horizontal reduce order-independent. Here it
+    // also has to survive splits that land mid-quad, where the two sides pick up
+    // different scalar tails.
+    constexpr std::size_t n = 137;
+    std::vector<std::int8_t> a(n), b(n);
+    for (std::size_t i = 0; i < n; ++i) { a[i] = gen_a<std::int8_t>(i); b[i] = gen_b<std::int8_t>(i); }
+
+    const auto whole = mtl::simd::reduce_dot_widen<std::int32_t, std::int8_t>(a.data(), b.data(), n);
+    for (std::size_t k = 0; k <= n; ++k) {
+        const auto lo = mtl::simd::reduce_dot_widen<std::int32_t, std::int8_t>(a.data(), b.data(), k);
+        const auto hi = mtl::simd::reduce_dot_widen<std::int32_t, std::int8_t>(a.data() + k, b.data() + k, n - k);
+        INFO("split at k=" << k);
+        CHECK(static_cast<std::int32_t>(static_cast<std::uint32_t>(lo) +
+                                        static_cast<std::uint32_t>(hi)) == whole);
+    }
+}
+
+TEST_CASE("the headroom that makes 8-bit the useful width", "[simd][quad]") {
+    // The whole point of phase 3 over phase 2, tested rather than asserted.
+    // Worst case throughout: every term maximal and same-signed, so nothing
+    // cancels and the sum grows as fast as it possibly can.
+
+    SECTION("int8 x int8 survives 100 000 worst-case terms") {
+        // (-128)*(-128) = 16384 = 2^14, so the sum reaches 2^31 only at
+        // k = 131 072. 100 000 terms must therefore still be exact and positive.
+        constexpr std::size_t n = 100000;
+        std::vector<std::int8_t> a(n, -128), b(n, -128);
+        const auto got = mtl::simd::reduce_dot_widen<std::int32_t, std::int8_t>(a.data(), b.data(), n);
+        CHECK(got == static_cast<std::int32_t>(n * 16384ull));      // 1 638 400 000 < 2^31
+        CHECK(got > 0);                                             // did not wrap
+    }
+
+    SECTION("uint8 x int8 survives 60 000 worst-case terms") {
+        // 255 * 127 = 32385, so the sum reaches 2^31 near k = 66 000.
+        constexpr std::size_t n = 60000;
+        std::vector<std::uint8_t> a(n, 255);
+        std::vector<std::int8_t>  b(n, 127);
+        const auto got = mtl::simd::reduce_dot_widen<std::int32_t, std::uint8_t, std::int8_t>(
+            a.data(), b.data(), n);
+        CHECK(got == static_cast<std::int32_t>(n * 32385ull));       // 1 943 100 000 < 2^31
+        CHECK(got > 0);
+    }
+
+    SECTION("the same worst case in 16-bit storage wraps almost immediately") {
+        // The contrast that motivates this phase: identical accumulator, operands
+        // one width wider, and three terms is already too many.
+        constexpr auto lo = std::numeric_limits<std::int16_t>::lowest();
+        std::vector<std::int16_t> p(3, lo), q(3, lo);
+        const auto got = mtl::simd::reduce_dot_widen<std::int32_t, std::int16_t>(p.data(), q.data(), 3);
+        CHECK(got == static_cast<std::int32_t>(static_cast<std::uint32_t>(3ull << 30)));
+        CHECK(got < 0);                                             // i.e. it wrapped
+    }
+}
+
+TEST_CASE("beyond the headroom it wraps, it does not saturate", "[simd][quad]") {
+    // 200 000 terms of 2^14 exceeds 2^31; the answer is the true sum mod 2^32,
+    // not a clamp to INT32_MAX and not a trap.
+    constexpr std::size_t n = 200000;
+    std::vector<std::int8_t> a(n, -128), b(n, -128);
+    const auto got = mtl::simd::reduce_dot_widen<std::int32_t, std::int8_t>(a.data(), b.data(), n);
+    CHECK(got == static_cast<std::int32_t>(static_cast<std::uint32_t>(n * 16384ull)));
+    CHECK(got != std::numeric_limits<std::int32_t>::max());         // not saturated
+}
+
+// ---------------------------------------------------------------------------
+
+TEST_CASE("dot selects the quad kernel for the pairings that have one",
+          "[simd][quad][operation][dot]") {
+    using i8v = mtl::vec::dense_vector<std::int8_t>;
+    using u8v = mtl::vec::dense_vector<std::uint8_t>;
+
+    STATIC_REQUIRE(mtl::interface::SimdQuadVector<i8v>);
+    STATIC_REQUIRE(mtl::quad_int_dot<std::int32_t,  std::int32_t,  i8v, i8v>);
+    STATIC_REQUIRE(mtl::quad_int_dot<std::int32_t,  std::int32_t,  u8v, i8v>);   // VNNI native
+    STATIC_REQUIRE(mtl::quad_int_dot<std::uint32_t, std::uint32_t, u8v, u8v>);
+
+    // (int8, uint8) has no hardware pairing -- the generic loop takes it, which
+    // is correct, just not accelerated. Swapping the arguments would be.
+    STATIC_REQUIRE_FALSE(mtl::quad_int_dot<std::int32_t, std::int32_t, i8v, u8v>);
+    // A wider accumulator than the instruction implements also falls back.
+    STATIC_REQUIRE_FALSE(mtl::quad_int_dot<std::int64_t, std::int64_t, i8v, i8v>);
+    // And 8-bit types are not lanes, so the plain dot path must still reject them.
+    STATIC_REQUIRE_FALSE(mtl::interface::SimdDenseVector<i8v>);
+}
+
+TEST_CASE("dot<int32_t> over 8-bit vectors agrees with the exact sum",
+          "[simd][quad][operation][dot]") {
+    constexpr std::size_t n = 259;
+    mtl::vec::dense_vector<std::uint8_t> a(n);
+    mtl::vec::dense_vector<std::int8_t>  b(n);
+    std::int64_t exact = 0;
+    for (std::size_t i = 0; i < n; ++i) {
+        a(i) = gen_a<std::uint8_t>(i);
+        b(i) = gen_b<std::int8_t>(i);
+        exact += std::int64_t(a(i)) * b(i);
+    }
+    // These operands and this length are inside the headroom, so the 32-bit
+    // answer is not merely congruent to the true sum -- it IS the true sum.
+    CHECK((mtl::dot<std::int32_t>(a, b)) == exact);
+    CHECK((mtl::dot_real<std::int32_t>(a, b)) == exact);
+    CHECK((mtl::dot_real<std::int64_t>(a, b)) == exact);   // wider accumulator agrees
+}
+
+// The other half of what phase 3 owes: "re-deriving the register tile for a
+// 1-byte operand and a 4-byte accumulator". The answer is that there is nothing
+// to re-derive, and it is worth pinning so a future int8 GEMM does not go
+// looking for a tile that does not need deriving.
+TEST_CASE("the int8 GEMM register tile is the float tile", "[simd][quad][blocking]") {
+    using namespace mtl::simd;
+    for (std::size_t nvec : {std::size_t{4}, std::size_t{8}, std::size_t{16}}) {
+        const auto f = derive_blocking<float>(nvec);
+        const auto i = derive_blocking<std::int32_t>(nvec);
+        INFO("nvec=" << nvec);
+        // derive_blocking sizes the tile from the ACCUMULATOR -- which is what
+        // gemm_blocked<TC, TAB> already passes it -- and the 1-byte operand
+        // never enters. int32 and float share a lane width and a register file,
+        // so they share a tile.
+        CHECK(i.mr == f.mr);
+        CHECK(i.nr == f.nr);
+        CHECK(i.kc == f.kc);
+
+        // The real constraint a 1-byte operand imposes is on the K GRANULARITY,
+        // not the tile: VNNI and SDOT consume FOUR k-values per instruction, so
+        // kc must be a multiple of 4 and the pack layout quad-interleaved.
+        CHECK(i.kc % 4 == 0);
+    }
+}


### PR DESCRIPTION
Phase 3 of epic #451 — the one the epic calls *"the case that matters"*. `dot<int32_t>` over 8-bit vectors now sums **four** products into each 32-bit lane with a single instruction, where phase 2's kernel sums two.

## The instruction is real

Verified as codegen, not inferred from values:

| `-march=` | emitted |
|---|---|
| `icelake-server` | **`vpdpbusd`** — native VNNI |
| `sapphirerapids` | **`vpdpbusd`** |
| `znver4` | **`vpdpbusd`** |
| `cascadelake` | `vpmaddwd` |
| `x86-64-v2` | `pmaddwd` |

The Cascade Lake row is worth knowing rather than glossing: it **has** AVX512-VNNI, but Highway's `HWY_AVX3_DL` target requires the full feature set (VBMI, VBMI2, GFNI, …), so VNNI hardware can still take the decomposed path. Correctness is identical either way; only the instruction count differs.

## Why 8 bits is the width that matters — headroom, not lanes

Halving the operand width quarters the product, so from the **same** 32-bit accumulator:

| pairing | max \|product\| | terms before the sum can overflow |
|---|---|---|
| `int16 × int16` *(phase 2)* | 2³⁰ | **3** worst case, ~36 random |
| `int8 × int8` | 2¹⁴ | **~131 000** |
| `uint8 × int8` | ~2¹⁵ | **~65 000** |
| `uint8 × uint8` | ~2¹⁶ | **~66 000** |

Four to five orders of magnitude. This is why the quantized-inference instructions are 8-bit and not 16-bit, and it is the concrete sense in which phase 2's kernel is for *small values in 16-bit storage* while this one is for *real vectors*.

Tested rather than asserted: 100 000 worst-case `int8` terms sum exactly without wrapping, 60 000 for the VNNI pairing, and the 16-bit contrast wraps at three. Past the headroom it still **wraps** — mod 2³², never a saturate, never a trap — and that is tested too.

## The signedness asymmetry is the hardware's

VNNI implements `unsigned × signed` — unsigned activations against signed weights, the shape of a quantized layer. Symmetric `int8 × int8` is native only from **AVX10.2**; before that Highway emulates it with two `dpbusd` calls plus a shift and subtract, roughly three times the work.

So MTL5 supports the three pairings the instruction supports, and **rejects `(int8, uint8)` at compile time** rather than silently reordering it. A dot product is symmetric, so swapping the arguments gets the native instruction — and the diagnostic says so:

```
error: unsupported 8-bit pairing -- the hardware op takes (i8,i8), (u8,i8) or
(u8,u8); for (i8,u8) swap the arguments, which a dot product permits
```

Exactly one diagnostic, not a cascade.

## The register tile does not need re-deriving

The epic's phase-3 sub-item is *"re-deriving the register tile for a 1-byte operand and a 4-byte accumulator"*. Investigated, and the answer is that there is nothing to re-derive:

`derive_blocking` sizes the tile from the **accumulator** — which `gemm_blocked<TC, TAB>` already passes it — and `int32` shares a lane width and a register file with `float`. So the int8 tile **is** the float tile, `mr × nr` identical at 128, 256 and 512 bits.

What a 1-byte operand actually constrains is the **K granularity**: the instruction consumes four k-values at once, so `kc` must be a multiple of 4 and the packed panels quad-interleaved (four k-values contiguous within each 32-bit word). `kc` is already a multiple of 4 in **all 93** cache configurations checked, so only the pack layout is new work for a future int8 GEMM.

Both facts are pinned as tests, so that work does not begin by hunting for a tile that needs no deriving.

## On the sequencing

The epic blocked this phase behind the blocking-model decision (#458). I checked that dependency rather than waiting on it: `derive_blocking` is a DAG — `(mr, nr) → kc → mc → nc` — and the tile depends only on the register file and FMA pipeline. Across 64 cache configurations × 3 types, `mr`/`nr` never moved while `kc`/`mc`/`nc` all did. #458 concerns `mc` and the thread partition, strictly downstream, so it cannot reach the tile. Recorded on [#458](https://github.com/stillwater-sc/mtl5/issues/458#issuecomment-5363246041) along with a second deterministic finding about `balanced_mc`.

## Changes

| File | What |
|---|---|
| `include/mtl/simd/batch.hpp` | `is_quad_widenable_v`, `quad_accumulator`/`QuadPair`, `quad_step`, `quad_dot_accumulate` on both backends |
| `include/mtl/simd/algorithm.hpp` | `reduce_dot_widen` generalized to two narrow types; 8-bit branch; the headroom table written down |
| `include/mtl/interface/dispatch_traits.hpp` | `SimdQuadVector` |
| `include/mtl/operation/dot.hpp` | `quad_int_dot` predicate; `dot`/`dot_real` select the kernel |
| `tests/unit/simd/test_quad_dot.cpp` | **new** — 10 cases, 258 assertions |
| `docs/algorithms/mixed-precision-kernels.md` | the 8-bit case, the signedness asymmetry, and what it means for an int8 GEMM |

`reduce_dot_widen` gained a **defaulted** third type parameter, so every phase 0/2 spelling remains source-compatible — verified by compiling them unchanged.

## Tests

| Compiler | Backend | Result |
|---|---|---|
| gcc 13.3 | scalar fallback | **175/175** |
| gcc 13.3 | Highway 1.4, `-march=native` | **175/175** |
| clang | scalar fallback | **175/175** |
| clang | Highway 1.4, `-march=native` | **175/175** |

Plus UBSan (`-fsanitize=undefined,integer`) over all the integer kernels.

25 lengths straddling the quad step on every backend; all three pairings against a closed form; partition invariance at all 138 cut points of a prime length, including splits landing mid-quad; the headroom claims; wrap-not-saturate past it; dispatch asserted directly including the three fallback cases.

## What this does not do

- No int8 **GEMM** — the tile is settled and the pack layout is identified, but building it is separate work
- No benchmarks — phase 4, deliberately last

## Test plan
- [ ] Tier 1 CI passes
- [ ] CodeRabbit review addressed
- [ ] Merge

Relates to #451

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optimized 8-bit integer dot products and GEMM support for supported signed and unsigned operand combinations.
  * Added quad-interleaved processing with 32-bit accumulation, including support for reversed operand pairings.
  * Added validation for compatible dense vector types and operand combinations.
* **Documentation**
  * Documented supported hardware instructions, accumulation behavior, overflow limits, and packing requirements.
* **Tests**
  * Added comprehensive coverage for accuracy, edge cases, fallback behavior, and GEMM packing constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->