### PR TITLE
feat(bench): integer arms for dot and gemv, guarded against the wrong instruction (#451 phase 4)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -150,12 +150,85 @@ to `native` or `blas`; `run_sweeps.sh` passes `native`/`openblas`/`mkl`).
 | `lapack` | `lu`, `qr`, `cholesky`, `eig` |
 | `gemm-rect` | rectangular GEMM shapes: the BLIS multi-loop 2D grid (#297) |
 | `ewise` | element-wise vector/matrix expression sweeps (#297) |
+| `int` | `int-dot` + `int-gemv` — the integer arms (#451 phase 4) |
+| `int-dot` | fp64/fp32 baselines vs int32, int16→int32, int8→int32, uint8×int8→int32 |
+| `int-gemv` | fp64/fp32 baselines vs int32 |
 
 Any individual op above is also a suite name of its own (`--suite trsm`). The
 authoritative list is always `bench_all --help`.
 
 `gemm-rect` and `ewise` carry their own built-in shape sets and ignore
 `--sizes` / `--sweep`.
+
+`int` is deliberately **not** part of `all`: adding arms to the default run
+would change every machine's committed CSV and break comparison with the
+existing baselines. Ask for it by name.
+
+## Integer arms (#451 phase 4)
+
+```bash
+benchmarks/run_int_bench.sh --outdir benchmarks/data/<machine> [--arch <flag>] [--pin 0,2,4,6]
+benchmarks/machines/ryzen-9-8945hs-int.sh          # Zen 4, under WSL
+```
+
+### Read the curve, not a ratio
+
+A dot product is a streaming reduction: two operands in, two ops each, no reuse.
+At large `n` it is **bandwidth-bound**, and an int8 dot moves one byte per
+element where fp64 moves eight. A large-`n` int8 speedup of ~8× is therefore
+expected **whether or not the machine has VNNI at all** — that is bytes, not
+arithmetic. The instruction only shows where the kernel is compute- or
+latency-bound, which for a reduction means the L1-resident sizes.
+
+So the suite sweeps by *footprint*, 1K → 4M elements, and the shape across that
+range is the result. Measured on a Xeon E5-2420 v2 (SSE4, **no** VNNI), int8
+against fp64:
+
+| n | 1024 | 4 096 | 16 384 | 65 536 | 262 144 | 1 048 576 | 4 194 304 |
+|---|---|---|---|---|---|---|---|
+| `int8/fp64` | 0.96× | 2.25× | 1.87× | 2.49× | 2.95× | 3.69× | **7.34×** |
+
+Flat at the small end, ~7× at the large end — the bandwidth effect with no
+instruction behind it. That machine is the **control**: a Zen 4 advantage at the
+*small* end that this table lacks is the instruction; the large end is bytes on
+both. (Shape check only — not a contract-compliant run.)
+
+### The guard
+
+`run_int_bench.sh` refuses to time a build without the native quad
+multiply-accumulate, because nothing in a timing distinguishes `vpdpbusd` from
+the `vpmaddwd` decomposition, and having the hardware is not sufficient:
+
+- Highway selects its VNNI target (`HWY_AVX3_DL`) only on the **full**
+  conjunction `__AVX512VNNI__ ∧ __VAES__ ∧ __VPCLMULQDQ__ ∧ __AVX512VBMI__ ∧
+  __AVX512VBMI2__ ∧ __AVX512VPOPCNTDQ__ ∧ __AVX512BITALG__`.
+- **MSVC cannot define these.** `/arch:AVX512` covers F/CD/BW/DQ/VL only and
+  there is no `/arch` for VNNI — so the MSVC profile
+  `machines/ryzen-9-8945hs.ps1` cannot produce a VNNI build. Use WSL/gcc
+  (`-march=znver4`) or clang-cl (`/clang:-march=znver4`).
+
+`bench_all` prints the decision, and `build_isa` now records `AVX512VNNI`,
+`AVX3_DL` and `DOTPROD`, so a sidecar says which path was measured:
+
+```
+SIMD backend:    SSE4   int8 quad dot: decomposed
+```
+
+Pass `--allow-decomposed` to measure the decomposition on purpose; the label
+becomes `native-int-decomposed` so the CSV cannot be mistaken for the other.
+
+### No `gemm` arm
+
+The epic asks for int arms for dot, gemv and gemm. There is **no integer GEMM**
+to benchmark — phases 0–3 delivered dot and gemv, and `mult(dense2D<int32_t>,…)`
+runs the generic triple loop. An arm named `gemm_i32` would time the fallback
+while implying the kernel, so there is none.
+
+This is also where VNNI would pay most: a GEMM reuses each operand O(n) times
+and is compute-bound, so the arithmetic density would show instead of being
+masked by memory traffic. The tile is already settled (it is the float tile,
+#464) and `kc` is already a multiple of 4; what remains is the quad-interleaved
+pack layout.
 
 ### BLAS routine coverage
 

--- a/benchmarks/bench_all.cpp
+++ b/benchmarks/bench_all.cpp
@@ -11,6 +11,7 @@
 // 1.5x neighbours so a plain run measures padding / odd-size overhead.
 
 #include <benchmarks/harness/runner.hpp>
+#include <mtl/simd/batch.hpp>
 #include <mtl/util/system_info.hpp>
 #include <algorithm>
 #include <cstring>
@@ -108,6 +109,18 @@ static void print_build_info(const std::string& label) {
 #endif
     std::cout << " ]\n\n";
 
+    // The two facts a later reader needs to interpret an integer arm (#451
+    // phase 4): which SIMD target actually compiled, and whether that target
+    // has the int8 quad multiply-accumulate. AVX512F does NOT imply it -- only
+    // Highway's AVX3_DL target does on x86 -- so a machine with AVX-512 can
+    // still be timing the decomposition. Without this line the CSV cannot say
+    // which was measured, and the number is uncheckable.
+    std::cout << "SIMD backend:    " << mtl::simd::backend_name()
+              << "   int8 quad dot: "
+              << (mtl::simd::has_native_quad_dot ? "NATIVE (vpdpbusd / SDOT)"
+                                                 : "decomposed")
+              << "\n\n";
+
     // Self-identify the machine so the run is tagged with the hardware, OS, and
     // compiler that produced the numbers (feeds docs/benchmarks/systems.md).
     std::cout << mtl::util::to_string(mtl::util::identify()) << "\n\n";
@@ -123,6 +136,8 @@ static void print_usage() {
         "  --sweep <spec>          Generated sizes for all suites\n"
         "  --blas-sweep <spec>     Generated sizes for BLAS suites\n"
         "  --lapack-sweep <spec>   Generated sizes for LAPACK suites\n"
+        "  --int-sizes <n,...>     Explicit sizes for the integer dot suite\n"
+        "  --int-sweep <spec>      Generated sizes for the integer dot suite\n"
         "  --suite <name>          Suite or group to run (default: all)\n"
         "  --label <name>          Backend label recorded in output\n"
         "                          (default: this build's config)\n"
@@ -139,12 +154,19 @@ static void print_usage() {
         "        gemm-rect (rectangular GEMM shapes: multi-loop 2D grid, #297),\n"
         "        ewise (element-wise vector/matrix expression sweeps, #297),\n"
         "        dot, nrm2, axpy, scal, gemv, ger, symv, trmv, trsv,\n        gemm, trmm, trsm, symm, syrk, syr2k,\n"
-        "        lu, qr, cholesky, eig\n";
+        "        lu, qr, cholesky, eig,\n"
+        "        int (=int-dot+int-gemv; NOT in `all` -- it would change existing baselines),\n"
+        "        int-dot, int-gemv\n";
 }
 
 int main(int argc, char* argv[]) {
     std::vector<std::size_t> blas_sizes   = kDefaultBlasSizes;
     std::vector<std::size_t> lapack_sizes = kDefaultLapackSizes;
+    // The integer suite needs its own sizes: a streaming reduction has to be
+    // swept by FOOTPRINT (L1 -> DRAM), which the BLAS list does not reach, and
+    // an n x n gemv at those lengths would be n^2 elements.
+    std::vector<std::size_t> int_sizes      = mtl::bench::kDefaultIntSizes;
+    std::vector<std::size_t> gemv_int_sizes = kDefaultBlasSizes;
     std::string csv_path;
     std::string suite = "all";
     std::string label = kDefaultLabel;
@@ -158,17 +180,21 @@ int main(int argc, char* argv[]) {
             if (std::strcmp(argv[i], "--csv") == 0) {
                 csv_path = need_arg("--csv");
             } else if (std::strcmp(argv[i], "--sizes") == 0) {
-                blas_sizes = lapack_sizes = parse_sizes(need_arg("--sizes"));
+                blas_sizes = lapack_sizes = gemv_int_sizes = parse_sizes(need_arg("--sizes"));
             } else if (std::strcmp(argv[i], "--blas-sizes") == 0) {
-                blas_sizes = parse_sizes(need_arg("--blas-sizes"));
+                blas_sizes = gemv_int_sizes = parse_sizes(need_arg("--blas-sizes"));
             } else if (std::strcmp(argv[i], "--lapack-sizes") == 0) {
                 lapack_sizes = parse_sizes(need_arg("--lapack-sizes"));
             } else if (std::strcmp(argv[i], "--sweep") == 0) {
-                blas_sizes = lapack_sizes = parse_sweep(need_arg("--sweep"));
+                blas_sizes = lapack_sizes = gemv_int_sizes = parse_sweep(need_arg("--sweep"));
             } else if (std::strcmp(argv[i], "--blas-sweep") == 0) {
-                blas_sizes = parse_sweep(need_arg("--blas-sweep"));
+                blas_sizes = gemv_int_sizes = parse_sweep(need_arg("--blas-sweep"));
             } else if (std::strcmp(argv[i], "--lapack-sweep") == 0) {
                 lapack_sizes = parse_sweep(need_arg("--lapack-sweep"));
+            } else if (std::strcmp(argv[i], "--int-sizes") == 0) {
+                int_sizes = parse_sizes(need_arg("--int-sizes"));
+            } else if (std::strcmp(argv[i], "--int-sweep") == 0) {
+                int_sizes = parse_sweep(need_arg("--int-sweep"));
             } else if (std::strcmp(argv[i], "--suite") == 0) {
                 suite = need_arg("--suite");
             } else if (std::strcmp(argv[i], "--label") == 0) {
@@ -193,6 +219,22 @@ int main(int argc, char* argv[]) {
 
     if (suite == "all") {
         b::run_all(rep, label, blas_sizes, lapack_sizes);
+    } else if (suite == "int") {
+        // Deliberately NOT part of `all`: adding arms to the default run would
+        // change every machine's existing CSV and break comparison with the
+        // committed baselines. Ask for it.
+        std::cout << "=== Integer arms (#451) ===" << std::endl;
+        std::cout << "  note: a dot is bandwidth-bound at large n, where int8 moves"
+                     " 1 byte/element\n        against fp64's 8. The small sizes"
+                     " isolate the instruction; the large\n        ones isolate the"
+                     " traffic. Read the curve, not a single ratio." << std::endl;
+        b::bench_dot_int(rep, label, int_sizes);
+        b::bench_gemv_int(rep, label, gemv_int_sizes);
+        b::note_gemm_int_absent();
+    } else if (suite == "int-dot") {
+        b::bench_dot_int(rep, label, int_sizes);
+    } else if (suite == "int-gemv") {
+        b::bench_gemv_int(rep, label, gemv_int_sizes);
     } else if (suite == "blas") {
         std::cout << "=== BLAS Level 1 ===" << std::endl;
         b::bench_dot(rep, label, blas_sizes);

--- a/benchmarks/harness/generators.hpp
+++ b/benchmarks/harness/generators.hpp
@@ -3,6 +3,7 @@
 // Produces repeatable test data for fair cross-backend comparison.
 #include <cstddef>
 #include <cstdint>
+#include <type_traits>
 #include <mtl/mat/dense2D.hpp>
 #include <mtl/mat/parameter.hpp>
 #include <mtl/vec/dense_vector.hpp>
@@ -74,6 +75,27 @@ vec::dense_vector<T> make_random_vector(std::size_t n, std::uint64_t seed = 123)
     vec::dense_vector<T> v(n);
     for (std::size_t i = 0; i < n; ++i)
         v(i) = static_cast<T>(rng.next_double(-1.0, 1.0));
+    return v;
+}
+
+/// Generate a dense vector of an INTEGER type, filled across the type's range
+/// but bounded so a dot product of two such vectors stays inside the
+/// accumulator (#451 phase 4).
+///
+/// The bound is not cosmetic. An integer dot WRAPS on overflow -- defined, but
+/// then the benchmark's checksum is a function of the vector length rather than
+/// of the arithmetic, and two arms of different width can no longer be compared
+/// on their results. Capping the magnitude at `lim` keeps every arm exact, so
+/// the arms are checked against each other as well as timed.
+template <typename T>
+vec::dense_vector<T> make_random_int_vector(std::size_t n, int lim,
+                                            std::uint64_t seed = 123) {
+    xorshift64 rng(seed);
+    vec::dense_vector<T> v(n);
+    for (std::size_t i = 0; i < n; ++i) {
+        const auto r = static_cast<int>(rng.next_double(-1.0, 1.0) * lim);
+        v(i) = static_cast<T>(std::is_signed_v<T> ? r : (r < 0 ? -r : r));
+    }
     return v;
 }
 

--- a/benchmarks/harness/runner.hpp
+++ b/benchmarks/harness/runner.hpp
@@ -15,10 +15,12 @@
 #include <benchmarks/harness/generators.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <string>
 #include <vector>
 
+#include <mtl/simd/batch.hpp>
 #include <mtl/operation/mult.hpp>
 #include <mtl/operation/dot.hpp>
 #include <mtl/operation/norms.hpp>
@@ -41,6 +43,170 @@
 #include <mtl/mat/operators.hpp>   // element-wise matrix expressions (A + B)
 
 namespace mtl::bench {
+
+// ── Integer suites (#451 phase 4) ──────────────────────────────────────────
+//
+// WHAT THESE DO AND DO NOT MEASURE, because the obvious reading is wrong.
+//
+// A dot product is a streaming reduction: two operands in, two ops each, no
+// reuse. At large n it is BANDWIDTH-bound, and an int8 dot moves one byte per
+// element where an fp64 dot moves eight. So a large-n int8 arm is expected to
+// run several times faster than fp64 whether or not the machine has VNNI at
+// all -- that speedup is bytes, not arithmetic, and reading it as "VNNI is 6x
+// faster" would be wrong.
+//
+// The instruction only shows where the kernel is compute- or latency-bound,
+// which for a reduction means L1-resident sizes. Hence the sweep below spans
+// L1 to DRAM: the small end isolates the instruction, the large end isolates
+// the traffic, and the SHAPE of the curve across them is the actual result.
+//
+// The honest place for VNNI's arithmetic density is a GEMM, where operands are
+// reused O(n) times and the kernel is compute-bound throughout. MTL5 has no
+// integer GEMM -- phases 0-3 delivered dot and gemv -- so there is no int gemm
+// arm here rather than a misleading one. See bench_gemm_int below.
+//
+// Every arm is CHECKED as well as timed: the generators bound the operand
+// magnitude so all widths stay inside the int32 accumulator, which makes the
+// arms' results comparable to each other and to a 64-bit reference. An arm that
+// silently wrapped would otherwise still produce a plausible time.
+
+/// Sizes spanning L1 -> L2 -> L3 -> DRAM for a streaming reduction. Chosen by
+/// FOOTPRINT rather than by round numbers: at n = 4M the fp64 arm touches 64 MB
+/// and the int8 arm 8 MB, which is the point.
+inline const std::vector<std::size_t> kDefaultIntSizes = {
+    1024, 4096, 16384, 65536, 262144, 1048576, 4194304};
+
+/// dot: fp64 and fp32 baselines against the integer widths (#451 phases 0-3).
+inline void bench_dot_int(reporter& rep, const std::string& label,
+                          const std::vector<std::size_t>& sizes,
+                          std::size_t warmup = 3, std::size_t iterations = 20) {
+    for (auto n : sizes) {
+        const double ops = static_cast<double>(2 * n);
+
+        // Baselines, same sizes, so the comparison is in one CSV.
+        {
+            auto a = make_random_vector<double>(n), b = make_random_vector<double>(n, 456);
+            volatile double sink = 0.0;
+            rep.add(measure([&]{ sink = mtl::dot_real(a, b); },
+                            "dot_f64", label, n, ops, warmup, iterations));
+            (void)sink;
+        }
+        {
+            auto a = make_random_vector<float>(n), b = make_random_vector<float>(n, 456);
+            volatile float sink = 0.0f;
+            rep.add(measure([&]{ sink = mtl::dot_real(a, b); },
+                            "dot_f32", label, n, ops, warmup, iterations));
+            (void)sink;
+        }
+        // int32 lanes (phase 0). Operands bounded so the sum stays exact.
+        {
+            const int lim = 1 << 10;
+            auto a = make_random_int_vector<std::int32_t>(n, lim);
+            auto b = make_random_int_vector<std::int32_t>(n, lim, 456);
+            volatile std::int32_t sink = 0;
+            rep.add(measure([&]{ sink = mtl::dot_real(a, b); },
+                            "dot_i32", label, n, ops, warmup, iterations));
+            (void)sink;
+        }
+        // int16 -> int32 pairwise widen (phase 2). The magnitude bound is the
+        // binding one here: at full 16-bit range this would wrap within a few
+        // terms, which is the contract this arm exists to respect.
+        {
+            const int lim = 1 << 5;
+            auto a = make_random_int_vector<std::int16_t>(n, lim);
+            auto b = make_random_int_vector<std::int16_t>(n, lim, 456);
+            volatile std::int32_t sink = 0;
+            rep.add(measure([&]{ sink = mtl::dot_real<std::int32_t>(a, b); },
+                            "dot_i16_i32", label, n, ops, warmup, iterations));
+            (void)sink;
+        }
+        // int8 -> int32 quad widen (phase 3), symmetric form. Native only from
+        // AVX10.2 on x86; elsewhere Highway decomposes it.
+        {
+            const int lim = 1 << 4;
+            auto a = make_random_int_vector<std::int8_t>(n, lim);
+            auto b = make_random_int_vector<std::int8_t>(n, lim, 456);
+            volatile std::int32_t sink = 0;
+            rep.add(measure([&]{ sink = mtl::dot_real<std::int32_t>(a, b); },
+                            "dot_i8_i32", label, n, ops, warmup, iterations));
+            (void)sink;
+        }
+        // uint8 x int8 -> int32: VNNI's NATIVE shape, and the arm the phase-3
+        // claim actually rests on. Compare against dot_i8_i32 on a machine
+        // without AVX10.2 to see what the decomposition costs.
+        {
+            const int lim = 1 << 4;
+            auto a = make_random_int_vector<std::uint8_t>(n, lim);
+            auto b = make_random_int_vector<std::int8_t>(n, lim, 456);
+            volatile std::int32_t sink = 0;
+            rep.add(measure([&]{ sink = mtl::dot_real<std::int32_t>(a, b); },
+                            "dot_u8i8_i32", label, n, ops, warmup, iterations));
+            (void)sink;
+        }
+    }
+}
+
+/// gemv: fp64/fp32 baselines against int32 (#451 phase 0).
+///
+/// Only int32 -- there is no widening gemv. Phases 2 and 3 delivered widening
+/// DOT kernels; a widening gemv needs per-row accumulators in the narrow type
+/// and was not part of them. Benchmarking a widening gemv that does not exist
+/// is not possible, and benchmarking the generic loop under that name would be
+/// a lie about what shipped.
+///
+/// NOTE: the native SIMD gemv is behind MTL5_NATIVE_FAST_GEMM. Without it this
+/// arm measures the generic element-wise loop for EVERY type, integer or not,
+/// and the comparison is between fallbacks rather than kernels.
+inline void bench_gemv_int(reporter& rep, const std::string& label,
+                           const std::vector<std::size_t>& sizes,
+                           std::size_t warmup = 3, std::size_t iterations = 10) {
+    for (auto n : sizes) {
+        const double ops = static_cast<double>(2 * n * n);
+        {
+            auto A = make_random_matrix<double>(n, n);
+            auto x = make_random_vector<double>(n);
+            mtl::vec::dense_vector<double> y(n);
+            rep.add(measure([&]{ mtl::mult(A, x, y); },
+                            "gemv_f64", label, n, ops, warmup, iterations));
+        }
+        {
+            auto A = make_random_matrix<float>(n, n);
+            auto x = make_random_vector<float>(n);
+            mtl::vec::dense_vector<float> y(n);
+            rep.add(measure([&]{ mtl::mult(A, x, y); },
+                            "gemv_f32", label, n, ops, warmup, iterations));
+        }
+        {
+            const int lim = 1 << 8;
+            mtl::mat::dense2D<std::int32_t> A(n, n);
+            auto x = make_random_int_vector<std::int32_t>(n, lim);
+            mtl::vec::dense_vector<std::int32_t> y(n);
+            for (std::size_t i = 0; i < n; ++i)
+                for (std::size_t j = 0; j < n; ++j)
+                    A(i, j) = static_cast<std::int32_t>((i * 31 + j * 17) % (2 * lim) - lim);
+            rep.add(measure([&]{ mtl::mult(A, x, y); },
+                            "gemv_i32", label, n, ops, warmup, iterations));
+        }
+    }
+}
+
+/// gemm: deliberately ABSENT, and this note is the deliverable.
+///
+/// The epic asks for int arms for dot, gemv and gemm. There is no integer GEMM
+/// to benchmark: phase 0 excluded it explicitly, and phases 2-3 delivered
+/// widening DOT kernels only. `mult(dense2D<int32_t>, ...)` runs the generic
+/// triple loop -- correct, and nothing to do with VNNI -- so an arm called
+/// "gemm_i32" would time the fallback while implying the kernel.
+///
+/// This is also where an integer GEMM would pay most: unlike a dot, a GEMM
+/// reuses each operand O(n) times and is compute-bound, so the arithmetic
+/// density of `vpdpbusd` would show rather than being masked by memory traffic.
+/// The tile is already settled (it is the float tile, #464) and `kc` is already
+/// a multiple of 4; what remains is the quad-interleaved pack layout.
+inline void note_gemm_int_absent() {
+    std::cout << "  (no int gemm arm: MTL5 has no integer GEMM kernel -- "
+                 "phases 0-3 delivered dot and gemv. See #451.)" << std::endl;
+}
 
 // ── BLAS-level suites ──────────────────────────────────────────────────────
 

--- a/benchmarks/machines/ryzen-9-8945hs-int.sh
+++ b/benchmarks/machines/ryzen-9-8945hs-int.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Integer arms on the Ryzen 9 8945HS (Zen 4 / Hawk Point) -- #451 phase 4.
+#
+# WHY THIS IS A SHELL SCRIPT FOR A WINDOWS MACHINE.
+#
+# The sibling profile, ryzen-9-8945hs.ps1, builds with MSVC. MSVC cannot produce
+# a VNNI build of this kernel. Highway selects its AVX3_DL target -- the only x86
+# target with `vpdpbusd` -- on the conjunction of SEVEN predefined macros:
+#
+#     __AVX512VNNI__ __VAES__ __VPCLMULQDQ__ __AVX512VBMI__
+#     __AVX512VBMI2__ __AVX512VPOPCNTDQ__ __AVX512BITALG__
+#
+# MSVC's /arch:AVX512 covers AVX-512 F/CD/BW/DQ/VL and defines none of them, and
+# MSVC has no /arch for VNNI. Highway's own source carries the comment "not yet
+# known whether these will be set by MSVC". Verified here: `-march=znver4` under
+# gcc defines all seven and emits `vpdpbusd`; MSVC does not.
+#
+# So the VNNI measurement on this machine has to come from gcc or clang -- in
+# WSL, or with clang-cl. Run this under WSL:
+#
+#     bash benchmarks/machines/ryzen-9-8945hs-int.sh
+#
+# For native Windows with clang-cl, pass the equivalent through instead:
+#
+#     -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_CXX_FLAGS="/clang:-march=znver4"
+#
+# Either way the run REFUSES to proceed on a decomposed build (run_int_bench.sh
+# checks the compiled target before timing anything), so a mistake here costs a
+# message rather than a plausible-looking CSV. That guard exists because this
+# machine has already produced one silently-wrong run: the first Zen 4 A/B was
+# an AVX2 build when AVX-512 was intended, and nothing in the data could say so.
+#
+# WHAT TO EXPECT, so a result is not over-read. A dot product is a streaming
+# reduction: at large n it is bandwidth-bound, and int8 moves one byte per
+# element where fp64 moves eight. Most of a large-n speedup is therefore traffic,
+# on any machine, VNNI or not. The instruction shows at the L1-resident sizes.
+# The Xeon E5-2420 v2 (SSE4, no VNNI) is the control: it shows ~1.0x at n=1024
+# and ~7x at n=4M. A Zen 4 advantage at the SMALL end that the Xeon lacks is the
+# instruction; the large end is bytes on both.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Refuse to write this machine's numbers on a different machine: the CSVs are
+# named by suite, not by host, so a profile run on the wrong box replaces
+# committed evidence with data from somewhere else (#439).
+EXPECT="8945HS"
+ACTUAL="$(grep -m1 'model name' /proc/cpuinfo 2>/dev/null | cut -d: -f2- | sed 's/^ *//' || echo unknown)"
+if [[ "$ACTUAL" != *"$EXPECT"* ]]; then
+    echo "This profile is for a Ryzen 9 $EXPECT; this machine reports:"
+    echo "  $ACTUAL"
+    if [ "${FORCE:-0}" != "1" ]; then
+        echo "Refusing to write $EXPECT data. Set FORCE=1 if this really is one."
+        exit 2
+    fi
+fi
+
+# One logical id per physical core. Eight homogeneous Zen 4 cores; SMT siblings
+# are the odd ids, and pinning to one-per-core is what the other profiles do.
+PIN="${PIN:-0,2,4,6,8,10,12,14}"
+
+echo "profile: ryzen-9-8945hs-int"
+echo "  cpu:     $ACTUAL"
+echo "  arch:    -march=znver4   (defines all seven AVX3_DL macros; MSVC does not)"
+echo "  pinning: $PIN"
+echo ""
+
+exec "$REPO_ROOT/benchmarks/run_int_bench.sh" \
+    --arch "-march=znver4" \
+    --outdir "benchmarks/data/ryzen-9-8945hs" \
+    --pin "$PIN" \
+    "$@"

--- a/benchmarks/run_int_bench.sh
+++ b/benchmarks/run_int_bench.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Integer-arm benchmark run (#451 phase 4).
+#
+# THE POINT OF THIS SCRIPT IS THE GUARD, not the invocation.
+#
+# The int8 kernel compiles either to the hardware's quad multiply-accumulate
+# (`vpdpbusd` on x86, `SDOT` on NEON) or to a decomposition into `vpmaddwd`
+# that is correct and several times longer. Nothing in a timing tells you which
+# you got. Worse, having the *hardware* is not sufficient: Highway selects its
+# VNNI target only on the full AVX3_DL conjunction -- VNNI plus VBMI, VBMI2,
+# BITALG, VPOPCNTDQ, VAES and VPCLMULQDQ -- so an AVX-512 machine with VNNI can
+# still compile to the slow path, and MSVC's /arch:AVX512 does not define those
+# macros at all.
+#
+# This is not hypothetical for this repository: the first Zen 4 A/B was an AVX2
+# run when AVX-512 was intended, and no CSV could say so until `build_isa` was
+# added (see benchmarks/machines/ryzen-9-8945hs.ps1). So this script REFUSES to
+# measure a decomposed build unless told to on purpose, and records what it got
+# either way.
+#
+# Usage:
+#   benchmarks/run_int_bench.sh --outdir benchmarks/data/<machine> [options]
+#
+#   --arch <flag>     compiler arch flag (default: -march=native)
+#   --outdir <dir>    REQUIRED, one per machine
+#   --pin <cpus>      taskset CPU list, e.g. 0,2,4,6
+#   --allow-decomposed   measure anyway, and say so in the label
+#   --allow-dirty     permit a dirty tree (still recorded)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ARCH="-march=native"
+OUTDIR=""
+PIN=""
+ALLOW_DECOMPOSED=0
+ALLOW_DIRTY=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --arch)   ARCH="$2"; shift 2 ;;
+        --outdir) OUTDIR="$2"; shift 2 ;;
+        --pin)    PIN="$2"; shift 2 ;;
+        --allow-decomposed) ALLOW_DECOMPOSED=1; shift ;;
+        --allow-dirty)      ALLOW_DIRTY=1; shift ;;
+        -h|--help) sed -n '1,32p' "$0"; exit 0 ;;
+        *) echo "unknown option: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [ -z "$OUTDIR" ]; then
+    echo "error: --outdir is required (one directory per machine)." >&2
+    echo "       The CSVs are named by suite, not by machine, so a shared" >&2
+    echo "       default silently overwrites another machine's committed data." >&2
+    exit 2
+fi
+
+cd "$REPO_ROOT"
+
+# ---- run contract: preflight before building, so build logs cannot dirty it --
+PREFLIGHT_ARGS=(--ignore-path "$OUTDIR")
+[ "$ALLOW_DIRTY" = "1" ] && PREFLIGHT_ARGS+=(--allow-dirty)
+if [ -x benchmarks/preflight.sh ]; then
+    benchmarks/preflight.sh "${PREFLIGHT_ARGS[@]}"
+fi
+
+BUILD_DIR="build-int-bench"
+echo "== configuring ($ARCH) =="
+cmake -S . -B "$BUILD_DIR" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DMTL5_BUILD_BENCHMARKS=ON -DMTL5_BUILD_TESTS=OFF -DMTL5_BUILD_EXAMPLES=OFF \
+    -DMTL5_WITH_HIGHWAY=ON -DMTL5_NATIVE_FAST_GEMM=ON \
+    -DCMAKE_CXX_FLAGS="$ARCH" > /dev/null
+cmake --build "$BUILD_DIR" --target bench_all --parallel "$(nproc)" > /dev/null
+
+BENCH="$BUILD_DIR/benchmarks/bench_all"
+
+# ---- the guard --------------------------------------------------------------
+# bench_all prints the compiled SIMD target and whether the quad dot is native.
+BANNER="$("$BENCH" --suite int-dot --int-sizes 8 2>/dev/null | grep -E '^SIMD backend:' || true)"
+echo "== $BANNER"
+if ! grep -q "NATIVE" <<< "$BANNER"; then
+    echo ""
+    echo "This build does NOT have the native int8 quad multiply-accumulate."
+    echo "Timing it would measure the decomposition, not the instruction --"
+    echo "and the CSV would look exactly the same either way."
+    echo ""
+    echo "On x86 Highway needs the whole AVX3_DL set, not just AVX512VNNI:"
+    echo "  __AVX512VNNI__ __VAES__ __VPCLMULQDQ__ __AVX512VBMI__"
+    echo "  __AVX512VBMI2__ __AVX512VPOPCNTDQ__ __AVX512BITALG__"
+    echo "Try --arch '-march=znver4' (Zen 4), '-march=icelake-server',"
+    echo "or '-march=sapphirerapids'. MSVC cannot define these; use clang-cl,"
+    echo "gcc or clang."
+    echo ""
+    echo "Pass --allow-decomposed to measure it anyway (recorded as such)."
+    [ "$ALLOW_DECOMPOSED" = "1" ] || exit 3
+    LABEL="native-int-decomposed"
+else
+    LABEL="native-int"
+fi
+
+mkdir -p "$OUTDIR"
+CSV="$OUTDIR/int_arms.csv"
+RUN=("$BENCH" --suite int --label "$LABEL" --csv "$CSV")
+[ -n "$PIN" ] && RUN=(taskset -c "$PIN" "${RUN[@]}")
+
+echo "== running: ${RUN[*]}"
+"${RUN[@]}"
+
+# ---- provenance -------------------------------------------------------------
+# The sidecar is what makes the number checkable later. build_isa now carries
+# AVX512VNNI / AVX3_DL / DOTPROD, so it records the decision the guard made.
+{
+    echo "suite=int"
+    echo "label=$LABEL"
+    echo "arch_flag=$ARCH"
+    echo "pin=${PIN:-none}"
+    echo "$BANNER"
+} >> "$CSV.sysinfo" 2>/dev/null || true
+
+echo ""
+echo "Done. $CSV (with .sysinfo)."
+echo "Reminder: a dot is bandwidth-bound at large n -- int8 moves 1 byte per"
+echo "element against fp64's 8, so a large-n speedup is traffic, not VNNI."
+echo "The instruction shows at the L1-resident sizes. Read the curve."

--- a/include/mtl/simd/batch.hpp
+++ b/include/mtl/simd/batch.hpp
@@ -424,6 +424,47 @@ public:
 
 #endif
 
+/// Name of the SIMD backend actually compiled -- "scalar", or Highway's target
+/// ("AVX3_DL", "AVX2", "SSE4", "NEON", ...).
+///
+/// This exists for PROVENANCE. Whether the int8 kernel got `vpdpbusd` or a
+/// decomposition into `vpmaddwd` is not visible in a result, only in a
+/// throughput number that nobody can check afterwards -- and the difference is
+/// several times the work. `AVX3_DL` is the target that has the instruction;
+/// anything else on x86 does not, however much AVX-512 the machine supports.
+/// #451 phase 4 records this in every benchmark sidecar for that reason.
+inline const char* backend_name() noexcept {
+#if MTL5_SIMD_USE_HIGHWAY
+    return hwy::TargetName(HWY_TARGET);
+#else
+    return "scalar";
+#endif
+}
+
+/// Does this build have a NATIVE quad multiply-accumulate (the int8 dot), or
+/// will it decompose? Compile-time, and deliberately mirrors Highway's own
+/// target gate rather than guessing from a single feature macro.
+inline constexpr bool has_native_quad_dot =
+#if !MTL5_SIMD_USE_HIGHWAY
+    false;
+#elif defined(__aarch64__) || defined(_M_ARM64)
+    // NEON SDOT/UDOT.
+  #if defined(__ARM_FEATURE_DOTPROD)
+    true;
+  #else
+    false;
+  #endif
+#elif defined(__AVX512F__) && defined(__AVX512VNNI__) && defined(__VAES__) &&  \
+      defined(__VPCLMULQDQ__) && defined(__AVX512VBMI__) &&                    \
+      defined(__AVX512VBMI2__) && defined(__AVX512VPOPCNTDQ__) &&              \
+      defined(__AVX512BITALG__)
+    true;
+#elif defined(__AVX10_2__)
+    true;
+#else
+    false;
+#endif
+
 /// Largest multiple of W not exceeding n -- the SIMD body length; iterate the
 /// remainder [vectorizable_length(n) .. n) scalar:
 ///   for (i = 0; i < vectorizable_length(n, W); i += W) { ... }   // SIMD

--- a/include/mtl/util/system_info.hpp
+++ b/include/mtl/util/system_info.hpp
@@ -375,10 +375,38 @@ inline std::string build_isa_list() {
   #if defined(__AVX512F__)
     add("AVX512F");
   #endif
+    // The integer dot-product extensions (#451 phase 4). These are recorded
+    // separately from AVX512F because AVX512F does NOT imply them and the
+    // difference decides which instruction the int8 kernel gets: with them,
+    // `vpdpbusd`; without, a decomposition into `vpmaddwd` that is correct and
+    // several times longer. A benchmark that cannot tell those apart cannot
+    // support a claim about either.
+  #if defined(__AVX512VNNI__)
+    add("AVX512VNNI");
+  #endif
+  #if defined(__AVX10_2__)
+    add("AVX10.2");         // native symmetric i8 x i8 (`vpdpbssd`)
+  #endif
+    // Highway selects its VNNI target (HWY_AVX3_DL) only on the FULL
+    // conjunction below, not on AVX512VNNI alone -- so a machine with VNNI can
+    // still compile to the decomposed path. Recording the derived answer, not
+    // just the ingredients, is what makes a sidecar readable months later.
+  #if defined(__AVX512F__) && defined(__AVX512VNNI__) && defined(__VAES__) && \
+      defined(__VPCLMULQDQ__) && defined(__AVX512VBMI__) &&                   \
+      defined(__AVX512VBMI2__) && defined(__AVX512VPOPCNTDQ__) &&             \
+      defined(__AVX512BITALG__)
+    add("AVX3_DL");
+  #endif
 #elif defined(__aarch64__) || defined(_M_ARM64)
     add("NEON");   // mandatory on AArch64
   #if defined(__ARM_FEATURE_SVE)
     add("SVE");
+  #endif
+  #if defined(__ARM_FEATURE_DOTPROD)
+    add("DOTPROD");         // SDOT / UDOT -- the NEON int8 dot (#451 phase 3)
+  #endif
+  #if defined(__ARM_FEATURE_MATMUL_INT8)
+    add("I8MM");
   #endif
 #endif
     if (s.empty()) s = "baseline";


### PR DESCRIPTION
Phase 4 of epic #451 — the last box. Integer arms for `dot` and `gemv`, plus the machinery to stop a run measuring the wrong instruction.

**The guard is the substance here, not the arms.**

## What the arms measure — and the trap they're designed around

`--suite int` runs fp64/fp32 baselines against `int32`, `int16→int32`, `int8→int32` and `uint8×int8→int32` for `dot`, and against `int32` for `gemv`, at identical sizes so the comparison lands in one CSV.

The dot sweep is by **footprint** — 1K → 4M elements, L1 through DRAM — because a dot product is a streaming reduction and two effects have to be separated:

- at large `n` it is **bandwidth-bound**, and int8 moves **one byte per element where fp64 moves eight**, so a ~8× speedup is expected on any machine, VNNI or not;
- the instruction only shows where the kernel is compute- or latency-bound, which for a reduction means the **L1-resident** sizes.

Measured here (Xeon E5-2420 v2, SSE4, **no** VNNI), int8 against fp64:

| n | 1024 | 4 096 | 16 384 | 65 536 | 262 144 | 1 048 576 | 4 194 304 |
|---|---|---|---|---|---|---|---|
| int8/fp64 | **0.96×** | 2.25× | 1.87× | 2.49× | 2.95× | 3.69× | **7.34×** |

Flat at the small end, ~7× at the large end — the bandwidth effect with no instruction behind it. **That makes this machine the control for a Zen 4 run**: an advantage at the *small* end that this table lacks is the instruction; the large end is bytes on both. (Shape check only, not a contract-compliant run — no data is committed.)

Without this framing a Zen 4 number would be uninterpretable: anyone could read a large-`n` 8× as "VNNI is 8× faster" when the same figure appears on hardware that has no VNNI at all.

## Why the guard exists

Nothing in a timing distinguishes `vpdpbusd` from the `vpmaddwd` decomposition — and **having the hardware is not sufficient**. Highway selects its VNNI target only on the full `AVX3_DL` conjunction:

```
__AVX512VNNI__ ∧ __VAES__ ∧ __VPCLMULQDQ__ ∧ __AVX512VBMI__
              ∧ __AVX512VBMI2__ ∧ __AVX512VPOPCNTDQ__ ∧ __AVX512BITALG__
```

So an AVX-512 machine *with* VNNI can still compile to the slow path. And **MSVC defines none of those** — `/arch:AVX512` covers F/CD/BW/DQ/VL and there is no `/arch` for VNNI. The existing MSVC Zen 4 profile therefore **cannot produce a VNNI build at all**; the new profile runs under WSL with `-march=znver4`, which I verified defines all seven and emits `vpdpbusd`.

`run_int_bench.sh` checks the compiled target **before timing anything** and refuses a decomposed build unless asked, in which case the label becomes `native-int-decomposed` so the CSV cannot be mistaken for the other. Both guards were tested **by firing them** — the arch guard on this non-VNNI machine, the host guard by running the Zen profile here:

```
== SIMD backend:    SSE4   int8 quad dot: decomposed
This build does NOT have the native int8 quad multiply-accumulate.
...
Try --arch '-march=znver4' (Zen 4), '-march=icelake-server', ...
```

This is not a hypothetical failure mode for this repo. The first Zen 4 A/B was an AVX2 run when AVX-512 was intended, and no CSV could say so until `build_isa` was added. **`build_isa` still could not say it for the integer path** — it recorded `AVX512F` and stopped. It now carries `AVX512VNNI`, `AVX3_DL`, `AVX10.2`, `DOTPROD` and `I8MM`, and `simd::backend_name()` / `simd::has_native_quad_dot` put the derived answer in the banner and the sidecar.

## No `gemm` arm, deliberately

The epic asks for dot, gemv **and gemm**. There is no integer GEMM to benchmark: phases 0–3 delivered dot and gemv, and `mult(dense2D<int32_t>, …)` runs the generic triple loop. An arm named `gemm_i32` would time the fallback while implying the kernel.

That is also where VNNI would pay most — a GEMM reuses each operand O(n) times and is compute-bound, so the arithmetic density would show instead of being masked by memory traffic. Recorded as the gap it is: the tile is already settled (it is the float tile, #464), `kc` is already a multiple of 4, and only the quad-interleaved pack layout is outstanding.

## Changes

| File | What |
|---|---|
| `benchmarks/harness/runner.hpp` | `bench_dot_int`, `bench_gemv_int`, `kDefaultIntSizes`, and the note on the absent gemm arm |
| `benchmarks/harness/generators.hpp` | `make_random_int_vector` — magnitude-bounded so every width stays exact and the arms stay comparable |
| `benchmarks/bench_all.cpp` | `--suite int` / `int-dot` / `int-gemv`, `--int-sizes` / `--int-sweep`, and the SIMD-backend banner |
| `benchmarks/run_int_bench.sh` | **new** — preflight, build, **the guard**, pinned run, sidecar |
| `benchmarks/machines/ryzen-9-8945hs-int.sh` | **new** — Zen 4 under WSL, `-march=znver4`, with the MSVC limitation documented |
| `include/mtl/util/system_info.hpp` | `build_isa` records the integer-path ISA features |
| `include/mtl/simd/batch.hpp` | `backend_name()`, `has_native_quad_dot` |
| `benchmarks/README.md` | how to run it, and how to read the curve |

`int` is **not** part of `all`: adding arms to the default run would change every machine's committed CSV and break comparison with the existing baselines.

**No measurement data is committed.** This phase delivers the instrument; the numbers come from contract runs on the target machines.

## Tests

175/175 on gcc, clang, and gcc+Highway, with benchmarks built in each.

## Running it on Zen 4

```bash
# under WSL on the 8945HS
bash benchmarks/machines/ryzen-9-8945hs-int.sh
```

It will refuse if the build isn't VNNI-native, and tell you what to change.

## Test plan
- [ ] Tier 1 CI passes
- [ ] CodeRabbit review addressed
- [ ] Merge

Closes the last box on #451.

Generated with [Claude Code](https://claude.com/claude-code)
