### PR TITLE
fix(build): add a .gitattributes so shell scripts check out with LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,32 @@
+# Line-ending policy. CLAUDE.md requires one; there was none, and the gap was
+# not theoretical: with Git for Windows' default core.autocrlf=true, every
+# tracked .sh checks out with CRLF, and running one under WSL fails with
+#
+#     /usr/bin/env: 'bash\r': No such file or directory
+#
+# because the carriage return becomes part of the interpreter name. All 15 shell
+# scripts in this repository were affected -- preflight.sh, the run_* harnesses
+# and the machine profiles alike -- so a Windows machine could not execute any
+# part of the benchmark contract under WSL.
+
+# Normalize text in the repository to LF; convert on checkout per platform.
+* text=auto
+
+# Files whose interpreter cannot tolerate CRLF, wherever they are checked out.
+*.sh    text eol=lf
+*.bash  text eol=lf
+
+# Windows-native scripts keep CRLF so they are not mangled by editors there.
+# PowerShell itself accepts either, but these are only ever run on Windows.
+*.ps1   text eol=crlf
+*.bat   text eol=crlf
+*.cmd   text eol=crlf
+
+# Binary: never touch, never diff as text. Matrix Market files are text but are
+# fixtures compared byte-for-byte by the IO tests, so pin them to LF explicitly
+# rather than leaving them to content detection.
+*.png   binary
+*.pdf   binary
+*.gz    binary
+*.mtx   text eol=lf
+*.csv   text eol=lf

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -193,6 +193,35 @@ instruction behind it. That machine is the **control**: a Zen 4 advantage at the
 *small* end that this table lacks is the instruction; the large end is bytes on
 both. (Shape check only — not a contract-compliant run.)
 
+### Troubleshooting: `/usr/bin/env: 'bash\r': No such file or directory`
+
+The script was checked out with **CRLF** line endings, so the shebang names an
+interpreter called `bash\r`. This happens on Windows, where Git's default
+`core.autocrlf=true` converts on checkout — and it affects **every** `.sh` in
+this repository, not just this one, so it will bite the moment any part of the
+benchmark contract is run under WSL.
+
+The repository now carries a `.gitattributes` pinning `*.sh` to `eol=lf`, which
+prevents it. An **already-checked-out** tree still has the old endings, though;
+attributes only apply at checkout. To repair the two scripts you need:
+
+```bash
+rm benchmarks/run_int_bench.sh benchmarks/machines/ryzen-9-8945hs-int.sh
+git checkout -- benchmarks/run_int_bench.sh benchmarks/machines/ryzen-9-8945hs-int.sh
+```
+
+Or to renormalize the whole working tree at once (**commit or stash first** —
+this discards uncommitted changes):
+
+```bash
+git rm --cached -r . && git reset --hard
+```
+
+Do **not** fix it with `sed -i 's/\r$//' …`: that leaves the tree dirty, and
+`preflight` then refuses to run — correctly, since a benchmark on a modified
+tree cannot be attributed to a commit. Re-checkout instead, which leaves the
+tree clean.
+
 ### The guard
 
 `run_int_bench.sh` refuses to time a build without the native quad

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -203,24 +203,38 @@ benchmark contract is run under WSL.
 
 The repository now carries a `.gitattributes` pinning `*.sh` to `eol=lf`, which
 prevents it. An **already-checked-out** tree still has the old endings, though;
-attributes only apply at checkout. To repair the two scripts you need:
+attributes only apply at checkout.
+
+Both repairs below **discard uncommitted changes to the files they touch** —
+commit or stash first.
 
 ```bash
+# just the two scripts
 rm benchmarks/run_int_bench.sh benchmarks/machines/ryzen-9-8945hs-int.sh
 git checkout -- benchmarks/run_int_bench.sh benchmarks/machines/ryzen-9-8945hs-int.sh
-```
 
-Or to renormalize the whole working tree at once (**commit or stash first** —
-this discards uncommitted changes):
-
-```bash
+# or the whole working tree
 git rm --cached -r . && git reset --hard
 ```
 
-Do **not** fix it with `sed -i 's/\r$//' …`: that leaves the tree dirty, and
-`preflight` then refuses to run — correctly, since a benchmark on a modified
-tree cannot be attributed to a commit. Re-checkout instead, which leaves the
-tree clean.
+Do **not** reach for `sed -i 's/\r$//' …` instead. It fixes the line endings and
+leaves the tree looking modified, so `preflight` refuses the run. That is worth
+stating precisely, because `git diff` will tell you the file is unchanged:
+
+```console
+$ sed -i 's/\r$//' s.sh
+$ git diff --numstat s.sh          # empty -- no content change
+$ git status --porcelain s.sh
+ M s.sh                            # ... but modified, and it stays that way
+warning: in the working copy of 's.sh', LF will be replaced by CRLF the next time Git touches it
+```
+
+Under `core.autocrlf=true` — the setting that produced the CRLF in the first
+place — Git reports the file modified because the working tree no longer matches
+what a checkout *would* write, not because the content differs. `preflight` tests
+exactly `git status --porcelain`, so it rejects, and correctly: a benchmark run
+on a tree Git considers modified cannot be attributed to a commit. Re-checkout
+instead, which leaves the tree genuinely clean.
 
 ### The guard
 


### PR DESCRIPTION
## The symptom

```
/usr/bin/env: 'bash\r': No such file or directory
```

The tree was checked out on Windows, where Git's default `core.autocrlf=true` rewrites text files to CRLF. The carriage return becomes part of the interpreter name, so `env` looks for a command called `bash\r`.

## The actual scope

There was **no `.gitattributes` at all** — which CLAUDE.md's cross-platform rules already require (*"Use `.gitattributes` to handle CRLF/LF"*).

So this is not specific to the script that hit it. **All fifteen tracked shell scripts were affected** — `preflight.sh`, every `run_*` harness, every machine profile — meaning no part of the benchmark contract could be executed from a Windows checkout under WSL. The new Zen 4 profile is simply the first `.sh` anyone tried to run there.

## The fix

| pattern | policy | why |
|---|---|---|
| `*.sh`, `*.bash` | `eol=lf` | the interpreter cannot tolerate CRLF, wherever it lands |
| `*.ps1`, `*.bat`, `*.cmd` | `eol=crlf` | only ever run on Windows; editors there mangle mixed endings |
| `*.png`, `*.pdf`, `*.gz` | `binary` | never converted, never diffed as text |
| `*.mtx`, `*.csv` | `eol=lf` | fixtures the IO tests compare byte-for-byte — pinned rather than left to content detection |

**Nothing changes in the repository's content.** `git add --renormalize .` stages no modification, because everything was authored LF:

```
$ git add --renormalize .
$ git status --short
A  .gitattributes          # and nothing else
```

Only checkout behaviour changes, which is the whole defect.

## Recovery for an existing checkout

Attributes apply *at checkout*, so a tree that already has CRLF keeps it. The README now carries this:

```bash
# targeted
rm benchmarks/run_int_bench.sh benchmarks/machines/ryzen-9-8945hs-int.sh
git checkout -- benchmarks/run_int_bench.sh benchmarks/machines/ryzen-9-8945hs-int.sh

# whole tree (commit or stash first — discards uncommitted changes)
git rm --cached -r . && git reset --hard
```

It also says explicitly **not** to repair this with `sed -i 's/\r$//' …`. That leaves the working tree dirty, and `preflight` then refuses to run — correctly, since a benchmark on a modified tree cannot be attributed to a commit. Re-checkout instead, which leaves the tree clean and the run attributable.

## Test plan
- [ ] Tier 1 CI passes
- [ ] Merge, then re-checkout on the Windows box and run the Zen 4 profile

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded troubleshooting guidance for shell script failures caused by Windows-style line endings.
  - Added warnings that repair commands may discard uncommitted changes.
  - Documented targeted and repository-wide file refresh options.
  - Clarified why direct text replacement can leave the working tree inconsistent.

- **Chores**
  - Standardized text file line endings across supported platforms.
  - Preserved required Windows line endings for native scripts.
  - Marked binary file formats appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->