### PR TITLE
feat(simd): the VNNI micro-kernel, and the claim it falsifies

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -282,15 +282,57 @@ memory saving it was built for is irrelevant once operands are reused. Integer
 multiply is also simply slower than float FMA on this ISA — there is no integer
 FMA, so it is a separate multiply and add.
 
-The consequence is worth stating plainly, because it decides what hardware is
-worth buying: **on a machine without VNNI there is no int8 GEMM win at all.**
-Everything an int8 GEMM can offer over fp32 has to come from the instruction —
-which makes a VNNI or AMX machine's measurement almost purely a measurement of
-the instruction, cleanly separated from bandwidth. That is the opposite of the
-dot suite, where the instruction was ~1.2× against ~18× of traffic.
-
 `gemm_i8_i32` is the **widen-on-load** path: narrow operands promoted to int32
 lanes, then an ordinary multiply-add. It is *not* `vpdpbusd`, which consumes
 four k-values per instruction and needs a quad-interleaved pack layout and a
-different micro-kernel. That remains unbuilt, and this arm is what it would be
-measured against.
+different micro-kernel.
+
+### The quad arms, and what they revise
+
+That micro-kernel now exists, and it changes the conclusion above. The two new
+arms run the **quad multiply-accumulate** itself — four k-values per
+instruction, from quad-interleaved panels — against the same operands:
+
+| arm | GOP/s | vs `gemm_i8_i32` |
+|---|---|---|
+| `gemm_f32` | 19.7 | 1.49× |
+| `gemm_i32` | 14.0 | 1.06× |
+| `gemm_i16_i32` | 12.8 | 0.97× |
+| `gemm_i8_i32` (widen-on-load) | 13.2 | 1.00× |
+| `gemm_i8_i32_quad` | **16.6** | **1.26×** |
+| `gemm_u8i8_i32_quad` | **21.7** | **1.64×** |
+
+Same Xeon E5-2420 v2, SSE4, n=512, `int8 quad dot: decomposed` — **this machine
+still has no VNNI.** Best of 8 interleaved rounds; the box is noisy and
+individual arms occasionally lose a scheduling slot, though the two quad arms
+were the *most* stable of the six. A committed figure should come from
+`run_int_bench.sh` on a quiet machine.
+
+**The claim this replaces** was that on a machine without VNNI there is no int8
+GEMM win at all. That was true of the *widen-on-load* kernel and does not
+survive changing the kernel: the quad path beats it by 1.26× symmetric and
+1.64× in VNNI's native `u8 × i8` shape — the latter also beating fp32, on a
+2013 part with no VNNI silicon anywhere in it.
+
+The reason is visible in the disassembly rather than inferred. Highway's
+*decomposition* of the quad accumulate is a pair of `vpmaddwd` plus
+sign-extension shifts, which still folds four products per accumulator lane in a
+handful of instructions — where widen-on-load runs four independent
+promote-multiply-add chains. And the symmetric `i8 × i8` form carries visibly
+more of that shift work than `u8 × i8` (4 `vpsraw` + 2 `vpsllw` against 2 + 1
+plus a mask), which is exactly the 16.6-against-21.7 gap.
+
+So the operand width still contributes nothing, and the earlier reading of that
+— "everything an int8 GEMM offers must come from the instruction" — stands. What
+was wrong was equating *the instruction* with *having VNNI silicon*: most of the
+win here is the four-products-per-lane **kernel shape**, which a machine without
+the instruction can still partly express. A VNNI or AMX machine's GEMM number
+therefore remains an almost pure measurement of arithmetic rather than
+bandwidth, but its baseline is now `gemm_i8_i32_quad` on the same machine, not
+the widening arm.
+
+Both int8 arms are compiled into the same binary on purpose. They compute
+bit-identical results — integer addition is associative — so nothing in an
+*answer* distinguishes them, and comparing a quad number on one machine against
+a widen number on another is precisely the missing-control error that cost this
+programme 20% on the dot headline once already.

--- a/benchmarks/harness/runner.hpp
+++ b/benchmarks/harness/runner.hpp
@@ -61,9 +61,10 @@ namespace mtl::bench {
 // the traffic, and the SHAPE of the curve across them is the actual result.
 //
 // The honest place for VNNI's arithmetic density is a GEMM, where operands are
-// reused O(n) times and the kernel is compute-bound throughout. MTL5 has no
-// integer GEMM -- phases 0-3 delivered dot and gemv -- so there is no int gemm
-// arm here rather than a misleading one. See bench_gemm_int below.
+// reused O(n) times and the kernel is compute-bound throughout. That is
+// bench_gemm_int below, which since phase 5 runs the quad multiply-accumulate
+// itself -- not merely narrow operands widened on load -- against the
+// widen-on-load arm as its within-machine control.
 //
 // Every arm is CHECKED as well as timed: the generators bound the operand
 // magnitude so all widths stay inside the int32 accumulator, which makes the
@@ -199,11 +200,31 @@ inline void bench_gemv_int(reporter& rep, const std::string& label,
 /// fewer bytes" and "does arithmetic faster" is genuinely different here -- and
 /// measuring that difference is the point.
 ///
-/// What is measured is the WIDEN-ON-LOAD path: narrow operands promoted into
-/// int32 lanes, then an ordinary multiply-add. Not `vpdpbusd`, which needs a
-/// quad-interleaved pack layout and a different micro-kernel. So the int8 arm
-/// here shows what the OPERAND WIDTH is worth in a compute-bound kernel, with
-/// the instruction's contribution still to come.
+/// TWO INT8 KERNELS RUN HERE, and comparing them IS the experiment (#451 phase
+/// 5). Both compute the same thing, bit for bit -- integer addition is
+/// associative, so a different summation grouping is unobservable in the result:
+///
+///   gemm_i8_i32        widen-on-load: int8 promoted into int32 lanes, one k
+///                      value per multiply-add
+///   gemm_i8_i32_quad   the quad multiply-accumulate: four k values per
+///                      instruction, from quad-interleaved panels
+///
+/// The pair is a WITHIN-MACHINE control, which is the whole reason both are
+/// compiled into one binary. The programme has already paid for the absence of
+/// one: the instruction's share of the dot speedup looked like 1.42x from a
+/// single Zen 4 run and came out at ~1.2x once an i7 could run both arms
+/// decomposed. Comparing a quad number on one machine against a widen number on
+/// another would repeat that mistake with more decimal places.
+///
+/// `gemm_u8i8_i32_quad` is VNNI's NATIVE pairing -- unsigned activations against
+/// signed weights -- and has no widen-on-load counterpart at all: the widening
+/// load requires matching signedness, so before this kernel that pair fell to
+/// the generic scalar loop. Its baseline is the symmetric arm, which every x86
+/// below AVX10.2 emulates with two `vpdpbusd` plus a shift and subtract.
+///
+/// Read `int8 quad dot:` in the header before trusting any of it. On a build
+/// without the instruction these arms measure Highway's decomposition, which is
+/// several times the work and looks like nothing in particular in a timing.
 inline void bench_gemm_int(reporter& rep, const std::string& label,
                            const std::vector<std::size_t>& sizes,
                            std::size_t warmup = 2, std::size_t iterations = 5) {
@@ -251,6 +272,25 @@ inline void bench_gemm_int(reporter& rep, const std::string& label,
                 }
             rep.add(measure([&]{ mtl::mult<std::int32_t>(A, B, C); },
                             "gemm_i8_i32", label, n, ops, warmup, iterations));
+            // The SAME operands through the quad micro-kernel -- the arm the
+            // widen-on-load number above is the control for.
+            rep.add(measure([&]{ mtl::mult_quad<std::int32_t>(A, B, C); },
+                            "gemm_i8_i32_quad", label, n, ops, warmup, iterations));
+        }
+        // VNNI's native pairing. No widen-on-load counterpart exists (the
+        // widening load requires matching signedness), so its baseline is the
+        // symmetric quad arm above, which x86 below AVX10.2 emulates.
+        {
+            mtl::mat::dense2D<std::uint8_t> A(n, n);
+            mtl::mat::dense2D<std::int8_t> B(n, n);
+            mtl::mat::dense2D<std::int32_t> C(n, n);
+            for (std::size_t i = 0; i < n; ++i)
+                for (std::size_t j = 0; j < n; ++j) {
+                    A(i, j) = static_cast<std::uint8_t>((i * 31 + j * 17) % 32);
+                    B(i, j) = static_cast<std::int8_t>((i * 13 + j * 7) % 32 - 16);
+                }
+            rep.add(measure([&]{ mtl::mult_quad<std::int32_t>(A, B, C); },
+                            "gemm_u8i8_i32_quad", label, n, ops, warmup, iterations));
         }
     }
 }

--- a/docs/performance/blocking-and-scheduling-assessment.md
+++ b/docs/performance/blocking-and-scheduling-assessment.md
@@ -169,10 +169,50 @@ multiply has no FMA on this ISA.
 So the prediction was right in direction and wrong in magnitude. The balance
 does not merely *move* toward the instruction in a GEMM; at this point the
 operand width contributes **zero** and the instruction is the only thing left.
-Which means: **on a machine without VNNI there is no int8 GEMM win at all**, and
-a VNNI or AMX machine's GEMM number is almost purely a measurement of the
-instruction — the cleanest separation of the two effects the programme can
-construct, and the opposite end of the axis from the dot.
+
+#### 6a. The quad micro-kernel, and the part of that which was wrong
+
+The paragraph that used to close this section said: *on a machine without VNNI
+there is no int8 GEMM win at all.* That was a statement about the
+**widen-on-load** kernel, which was the only int8 GEMM that existed when it was
+written, and it does not survive building the other one.
+
+`vpdpbusd` consumes four k-values per instruction, so it needs a
+quad-interleaved pack layout (`Ap[…][i*4+q] == A(i, 4g+q)`, and the same for B)
+and a micro-kernel whose left operand is a **broadcast quad** rather than a
+broadcast scalar. Both now exist. Measured on the same Xeon, same n=512, still
+`int8 quad dot: decomposed`:
+
+| `gemm_f32` | `gemm_i8_i32` | `gemm_i8_i32_quad` | `gemm_u8i8_i32_quad` |
+|---|---|---|---|
+| 19.7 | 13.2 | **16.6** | **21.7** GOP/s |
+
+1.26× over widen-on-load for the symmetric pairing, **1.64×** for `u8 × i8` —
+VNNI's native shape, which the widening path cannot express at all because
+`load_widen` requires matching signedness. The native-shape arm also beats fp32,
+on a 2013 part with no VNNI silicon in it.
+
+The mechanism is checkable in the disassembly, and was checked: Highway's
+decomposition of the quad accumulate is a pair of `vpmaddwd` plus
+sign-extension shifts, which still folds four products into each accumulator
+lane in a handful of instructions, where widen-on-load runs four independent
+promote-multiply-add chains. The symmetric form carries more of that shift work
+than the mixed one, which is the gap between the two quad arms.
+
+**What survives and what does not.** The operand *width* still contributes
+nothing in a GEMM — that finding is untouched. What was wrong was equating "the
+instruction" with "VNNI silicon": most of the win measured here is the
+four-products-per-lane **kernel shape**, which a machine without the instruction
+can partly express anyway. A VNNI or AMX machine's GEMM number is still an
+almost pure measurement of arithmetic rather than bandwidth — the opposite end
+of the axis from the dot — but its baseline is now `gemm_i8_i32_quad` on the
+same machine, not the widening arm, and the increment attributable to the
+silicon is correspondingly smaller than this section previously implied.
+
+This is the second time a claim in this document has been narrowed by supplying
+the control it lacked, and the pattern is the same both times: the original
+statement was true of everything that had been measured, and false of the thing
+that had not been built yet.
 
 ### 7. Hardware you own is not hardware you can reach
 

--- a/docs/performance/hardware-expansion-plan.md
+++ b/docs/performance/hardware-expansion-plan.md
@@ -42,6 +42,19 @@ table:
   once operands are packed and reused their width in memory stops mattering. So
   the *only* thing an int8 GEMM can offer over fp32 is the instruction — which
   makes a VNNI or AMX machine's GEMM number an almost pure measurement of it.
+- **The quad micro-kernel exists too, and it moves the baseline.** `vpdpbusd`
+  needs a quad-interleaved pack and a broadcast-quad micro-kernel; both are now
+  built (`gemm_kernel::quad`), so the int8 GEMM arms are `gemm_i8_i32_quad` and
+  `gemm_u8i8_i32_quad` alongside the widening one. **This changes what a VNNI
+  machine has left to prove.** On the Xeon, with the instruction *decomposed*,
+  the quad kernel already returns 1.26× (symmetric) and 1.64× (`u8 × i8`) over
+  widen-on-load — so a large fraction of the win is the kernel *shape*, not the
+  silicon, and a purchase justified by "int8 GEMM is much faster" would be
+  buying something we already have. The question a VNNI part now answers is
+  narrower and better posed: **what does the native instruction add on top of
+  the quad kernel, measured against that same kernel decomposed on the same
+  machine?** The i7 is the ideal control for exactly this and cannot run it
+  (§7); a Zen 4 or Zen 5 part can run both by build flag.
 
 ## Selection criteria
 

--- a/include/mtl/detail/gemm_blocked.hpp
+++ b/include/mtl/detail/gemm_blocked.hpp
@@ -53,6 +53,8 @@
 #include <mtl/detail/aligned_allocator.hpp>
 #include <mtl/detail/gemm_microkernel.hpp>
 #include <mtl/detail/gemm_pack.hpp>
+#include <mtl/detail/gemm_quad_microkernel.hpp>
+#include <mtl/detail/gemm_quad_pack.hpp>
 #include <mtl/detail/thread_pool.hpp>
 #include <mtl/simd/blocking.hpp>
 
@@ -323,23 +325,46 @@ private:
 
 /// C[m x n] (row-major, leading dim ldc) := beta*C + alpha * A[m x k] * B[k x n].
 /// A,B addressed by generic strides (see file header). ldc must be >= n.
-// TC = accumulator / C element type; TAB = A,B (operand) element type. With the
-// default TAB == TC this is the original same-type blocked GEMM. When TAB is
-// narrower (e.g. TAB=float, TC=double) the operands are packed in TAB and the
-// micro-kernel widens them into TC accumulators -- the mixed-precision fast path
-// (#176). Blocking is chosen for TC so the C microtile maps to TC registers.
-template <typename TC, typename TAB = TC>
-    requires (mtl::Scalar<TC> && mtl::Scalar<TAB>)
+// TC = accumulator / C element type; TA and TB = the A and B operand element
+// types. With the defaults TA == TB == TC this is the original same-type blocked
+// GEMM. When the operands are narrower (e.g. float operands, TC=double) they are
+// packed narrow and the micro-kernel widens them into TC accumulators -- the
+// mixed-precision fast path (#176). Blocking is chosen for TC so the C microtile
+// maps to TC registers.
+//
+// THREE KERNELS, ONE NEST. `TA` and `TB` are separate parameters because the
+// quad kernel needs them to differ: `(u8,i8)` -- unsigned activations against
+// signed weights -- is VNNI's native shape (#451 phase 5). Everything around the
+// micro-kernel -- the five loops, the cache blocks, the thread grid, the
+// cooperative B pack, the exception handling across the barrier -- is shared,
+// because none of it depends on which one runs.
+//
+// `Kern` SELECTS, AND IT IS NOT INFERRED FROM THE TYPES. An (i8, i8) pair is
+// valid input to BOTH kernels, so inferring would silently reroute the existing
+// widen-on-load path the moment the quad kernel appeared -- which is precisely
+// what happened when this parameter did not exist: `gemm_i8_i32` and
+// `gemm_i8_i32_quad` benchmarked identically because they had become the same
+// kernel, and the arm that was supposed to be the control had stopped being one.
+// The default is therefore `widening`, every existing caller keeps the code it
+// had, and asking for the quad kernel is something a call site does out loud.
+template <typename TC, typename TA = TC, typename TB = TA,
+          gemm_kernel Kern = gemm_kernel::widening>
+    requires (mtl::Scalar<TC> && mtl::Scalar<TA> && mtl::Scalar<TB>)
 void gemm_blocked(std::size_t m, std::size_t n, std::size_t k,
                   TC alpha,
-                  const TAB* A, std::ptrdiff_t a_rs, std::ptrdiff_t a_cs,
-                  const TAB* B, std::ptrdiff_t b_rs, std::ptrdiff_t b_cs,
+                  const TA* A, std::ptrdiff_t a_rs, std::ptrdiff_t a_cs,
+                  const TB* B, std::ptrdiff_t b_rs, std::ptrdiff_t b_cs,
                   TC beta,
                   TC* C, std::size_t ldc,
                   unsigned nthreads = 1) {
     constexpr simd::blocking_params bp = simd::default_blocking<TC>;
     constexpr std::size_t MR = bp.mr;   // register tile: must match the compiled
     constexpr std::size_t NR = bp.nr;   // micro-kernel, so compile-time only
+    constexpr bool QUAD = (Kern == gemm_kernel::quad);
+    static_assert(!QUAD || is_quad_gemm<TC, TA, TB>(),
+                  "the quad kernel takes an 8-bit operand pair the hardware op "
+                  "accepts -- (i8,i8), (u8,i8) or (u8,u8) -- accumulated in its "
+                  "matching 32-bit type");
     // L1/L2-sized blocks from the detected hierarchy (#222). rbp.mr/rbp.nr equal
     // MR/NR by construction -- detection overrides only cache fields, never the
     // register-file or FMA terms the tile is derived from.
@@ -376,29 +401,46 @@ void gemm_blocked(std::size_t m, std::size_t n, std::size_t k,
     // and `Bpack` are caller-owned so each thread/team passes its own buffers.
     auto do_ic_block = [&](std::size_t ic, std::size_t jc, std::size_t nci,
                            std::size_t npanels, std::size_t kci, std::size_t pc,
-                           const TAB* Bpack, TAB* Acbuf) {
+                           const TB* Bpack, TA* Acbuf) {
         const std::size_t mci = std::min(MC_eff, m - ic);
-        pack_A<TAB, MR>(A + static_cast<std::ptrdiff_t>(ic) * a_rs
-                          + static_cast<std::ptrdiff_t>(pc) * a_cs,
-                        a_rs, a_cs, mci, kci, Acbuf);
-        if (!(alpha == TC(1))) {                          // fold alpha into A panel (operand precision)
-            const std::size_t na = packed_A_size(mci, kci, MR);
-            for (std::size_t t = 0; t < na; ++t)
-                Acbuf[t] = static_cast<TAB>(alpha * static_cast<TC>(Acbuf[t]));
+        const TA* Ablock = A + static_cast<std::ptrdiff_t>(ic) * a_rs
+                             + static_cast<std::ptrdiff_t>(pc) * a_cs;
+        if constexpr (QUAD) {
+            pack_A_quad<TA, MR>(Ablock, a_rs, a_cs, mci, kci, Acbuf);
+            // alpha is NOT folded into the panel here -- it would be truncated
+            // back into a byte. gemm_quad_microkernel applies it to the int32
+            // tile on the way out instead; see there.
+        } else {
+            pack_A<TA, MR>(Ablock, a_rs, a_cs, mci, kci, Acbuf);
+            if (!(alpha == TC(1))) {                      // fold alpha into A panel (operand precision)
+                const std::size_t na = packed_A_size(mci, kci, MR);
+                for (std::size_t t = 0; t < na; ++t)
+                    Acbuf[t] = static_cast<TA>(alpha * static_cast<TC>(Acbuf[t]));
+            }
         }
+
+        // Panel depth: the quad layout stores k rounded up to a whole number of
+        // 4-value groups, so it is also the panel STRIDE.
+        const std::size_t kp = QUAD ? quad_depth(kci) : kci;
+        auto run_kernel = [&](const TA* Apanel, const TB* Bpanel, TC* Cd, std::size_t ld) {
+            if constexpr (QUAD)
+                gemm_quad_microkernel<TC, TA, TB, MR, NR>(kp, Apanel, Bpanel, Cd, ld, alpha);
+            else
+                gemm_microkernel<TC, TA, MR, NR>(kci, Apanel, Bpanel, Cd, ld);
+        };
 
         const std::size_t mpanels = (mci + MR - 1) / MR;
         TC* Cmacro = C + static_cast<std::ptrdiff_t>(ic) * static_cast<std::ptrdiff_t>(ldc)
                        + static_cast<std::ptrdiff_t>(jc);
         for (std::size_t jr = 0; jr < npanels; ++jr) {
             const std::size_t nr_eff = std::min(NR, nci - jr * NR);
-            const TAB* Bpanel = Bpack + jr * (NR * kci);
+            const TB* Bpanel = Bpack + jr * (NR * kp);
             for (std::size_t ir = 0; ir < mpanels; ++ir) {
                 const std::size_t mr_eff = std::min(MR, mci - ir * MR);
-                const TAB* Apanel = Acbuf + ir * (MR * kci);
+                const TA* Apanel = Acbuf + ir * (MR * kp);
                 TC* Cblock = Cmacro + (ir * MR) * ldc + jr * NR;
                 if (mr_eff == MR && nr_eff == NR) {
-                    gemm_microkernel<TC, TAB, MR, NR>(kci, Apanel, Bpanel, Cblock, ldc);
+                    run_kernel(Apanel, Bpanel, Cblock, ldc);
                 } else {
                     // Edge: accumulate through a zeroed full mr x nr tile so the
                     // micro-kernel's full-tile load/store stays in bounds.
@@ -407,7 +449,7 @@ void gemm_blocked(std::size_t m, std::size_t n, std::size_t k,
                     for (std::size_t i = 0; i < mr_eff; ++i)
                         for (std::size_t j = 0; j < nr_eff; ++j)
                             tile[i * NR + j] = Cblock[i * ldc + j];
-                    gemm_microkernel<TC, TAB, MR, NR>(kci, Apanel, Bpanel, tile, NR);
+                    run_kernel(Apanel, Bpanel, tile, NR);
                     for (std::size_t i = 0; i < mr_eff; ++i)
                         for (std::size_t j = 0; j < nr_eff; ++j)
                             Cblock[i * ldc + j] = tile[i * NR + j];
@@ -419,16 +461,19 @@ void gemm_blocked(std::size_t m, std::size_t n, std::size_t k,
     // Serial nest (also the fallback when the grid degenerates to one worker):
     // shared Ac/Bc buffers, jc -> pc -> ic exactly as the classic 5-loop order.
     auto serial_nest = [&]() {
-        packed_buffer<TAB> Ac(packed_A_size(mc_max, kc_max, MR));
-        packed_buffer<TAB> Bc(packed_B_size(kc_max, nc_max, NR));
+        packed_buffer<TA> Ac(packed_A_size_for<QUAD>(mc_max, kc_max, MR));
+        packed_buffer<TB> Bc(packed_B_size_for<QUAD>(kc_max, nc_max, NR));
         for (std::size_t jc = 0; jc < n; jc += NC) {
             const std::size_t nci = std::min(NC, n - jc);
             const std::size_t npanels = (nci + NR - 1) / NR;
             for (std::size_t pc = 0; pc < k; pc += KC) {
                 const std::size_t kci = std::min(KC, k - pc);
-                pack_B<TAB, NR>(B + static_cast<std::ptrdiff_t>(pc) * b_rs
-                                  + static_cast<std::ptrdiff_t>(jc) * b_cs,
-                                b_rs, b_cs, kci, nci, Bc.data());
+                const TB* Bblock = B + static_cast<std::ptrdiff_t>(pc) * b_rs
+                                     + static_cast<std::ptrdiff_t>(jc) * b_cs;
+                if constexpr (QUAD)
+                    pack_B_quad<TB, NR>(Bblock, b_rs, b_cs, kci, nci, Bc.data());
+                else
+                    pack_B<TB, NR>(Bblock, b_rs, b_cs, kci, nci, Bc.data());
                 // MUST step by MC_eff, not MC: do_ic_block sizes its block as
                 // min(MC_eff, m - ic), so stepping by the larger cache bound
                 // would skip (MC - MC_eff) rows per block and silently drop
@@ -479,10 +524,12 @@ void gemm_blocked(std::size_t m, std::size_t n, std::size_t k,
     // barrier per team. Doing every allocation here means the region itself
     // never allocates -- so for the float/double fast path it cannot throw, and
     // a thread can never miss a barrier (which would deadlock the team).
-    std::vector<packed_buffer<TAB>> team_B;   team_B.reserve(jc_nt);
-    for (unsigned j = 0; j < jc_nt; ++j) team_B.emplace_back(packed_B_size(kc_max, nc_max, NR));
-    std::vector<packed_buffer<TAB>> thr_A;    thr_A.reserve(grid);
-    for (unsigned t = 0; t < grid; ++t) thr_A.emplace_back(packed_A_size(mc_max, kc_max, MR));
+    std::vector<packed_buffer<TB>> team_B;   team_B.reserve(jc_nt);
+    for (unsigned j = 0; j < jc_nt; ++j)
+        team_B.emplace_back(packed_B_size_for<QUAD>(kc_max, nc_max, NR));
+    std::vector<packed_buffer<TA>> thr_A;    thr_A.reserve(grid);
+    for (unsigned t = 0; t < grid; ++t)
+        thr_A.emplace_back(packed_A_size_for<QUAD>(mc_max, kc_max, MR));
     std::vector<std::unique_ptr<gemm_barrier>> team_bar(jc_nt);
     for (unsigned j = 0; j < jc_nt; ++j) team_bar[j] = std::make_unique<gemm_barrier>(ic_nt);
 
@@ -510,8 +557,8 @@ void gemm_blocked(std::size_t m, std::size_t n, std::size_t k,
     pool.run(grid, [&](unsigned tid) {
         const unsigned jc_id = tid / ic_nt;
         const unsigned ic_id = tid % ic_nt;
-        TAB* Aloc = thr_A[tid].data();
-        TAB* Bteam = team_B[jc_id].data();
+        TA* Aloc = thr_A[tid].data();
+        TB* Bteam = team_B[jc_id].data();
         gemm_barrier& bar = *team_bar[jc_id];
         for (std::size_t jb = jc_id; jb < njb; jb += jc_nt) {
             const std::size_t jc = jc_starts[jb];
@@ -536,10 +583,16 @@ void gemm_blocked(std::size_t m, std::size_t n, std::size_t k,
                         const std::size_t per = (npanels + ic_nt - 1) / ic_nt;
                         const std::size_t q0  = std::min<std::size_t>(npanels, ic_id * per);
                         const std::size_t q1  = std::min<std::size_t>(npanels, q0 + per);
-                        if (q0 < q1)
-                            pack_B_panels<TAB, NR>(B + static_cast<std::ptrdiff_t>(pc) * b_rs
-                                                     + static_cast<std::ptrdiff_t>(jc) * b_cs,
-                                                   b_rs, b_cs, kci, nci, Bteam, q0, q1);
+                        const TB* Bblock = B + static_cast<std::ptrdiff_t>(pc) * b_rs
+                                             + static_cast<std::ptrdiff_t>(jc) * b_cs;
+                        if (q0 < q1) {
+                            if constexpr (QUAD)
+                                pack_B_quad_panels<TB, NR>(Bblock, b_rs, b_cs, kci, nci,
+                                                           Bteam, q0, q1);
+                            else
+                                pack_B_panels<TB, NR>(Bblock, b_rs, b_cs, kci, nci,
+                                                      Bteam, q0, q1);
+                        }
                     } catch (...) { record_failure(std::current_exception()); }
                 }
                 bar.wait();                                       // publish B to the team

--- a/include/mtl/detail/gemm_quad_microkernel.hpp
+++ b/include/mtl/detail/gemm_quad_microkernel.hpp
@@ -1,0 +1,150 @@
+#pragma once
+// MTL5 -- GEMM micro-kernel built on the QUAD MULTIPLY-ACCUMULATE (#451 phase 5).
+//
+// VNNI's `vpdpbusd` and NEON's `SDOT`/`UDOT` fold four 8-bit products into one
+// 32-bit accumulator lane per instruction. Every kernel in MTL5 up to now used
+// them the way a DOT product does -- two vectors walked in step -- and the
+// integer GEMM (#468) did not use them at all: it promoted narrow operands into
+// int32 lanes and did an ordinary multiply-add, one k value at a time.
+//
+// That measurement is what motivated this kernel. On a machine without the
+// instruction, narrowing the operand of a GEMM buys exactly nothing (Xeon
+// E5-2420 v2, n=512: gemm_i8_i32 13.3 GOP/s against gemm_i32's 13.5 and fp32's
+// 18.8), because a GEMM packs each operand once and then reads it from cache
+// O(n) times -- its width in memory stops mattering. So everything an int8 GEMM
+// can offer over fp32 has to come from the instruction, and using the
+// instruction requires this kernel.
+//
+// WHAT CHANGES, relative to gemm_microkernel:
+//
+//   * FOUR k VALUES PER INSTRUCTION instead of one. The kc loop steps by 4.
+//   * The A operand is a BROADCAST QUAD, not a broadcast scalar: the four bytes
+//     A(i, p..p+3) splatted across the register, so lane j of the result gets
+//     sum_{q<4} A(i,p+q) * B(p+q, j).
+//   * The panels are quad-interleaved (gemm_quad_pack.hpp), which is what puts
+//     those four bytes adjacent in the first place.
+//   * The operand types may DIFFER. `(uint8, int8)` is VNNI's native shape --
+//     unsigned activations against signed weights -- and the reason the
+//     instruction exists; symmetric `i8 x i8` is native only from AVX10.2 and is
+//     emulated below it. See simd::quad_accumulator.
+//
+// WHAT DOES NOT CHANGE: the C microtile is still MR x NR int32 accumulators held
+// in registers across the whole kc panel, MR and NR still come from
+// simd::default_blocking<TC>, and the arithmetic is still exact mod 2^32 -- so a
+// quad GEMM is bit-identical across lane counts, backends and thread partitions,
+// which no floating-point GEMM can claim.
+//
+// The instruction-per-load ratio is the practical win. Per MR x NR tile the
+// pairwise kernel issues MR broadcasts and NR/W loads for ONE k step; this one
+// issues the same MR broadcasts and NR/W loads for FOUR, so the same
+// multiply-accumulate throughput arrives with a quarter of the operand traffic
+// into the register file.
+//
+// A KNOWN, UNMEASURED LEVER: kc is still derived for a TC-wide B micro-panel.
+// derive_blocking sizes it so `kc x nr` fills about half of L1 at
+// sizeof(TC) bytes per element, but the panel this kernel reads holds 8-bit
+// operands -- a QUARTER of that, so the real occupancy is ~1/8 of L1 rather than
+// ~1/2. kc could therefore be several times larger before the panel stops
+// fitting. The same mismatch already applies to the widen-on-load int8 path, and
+// it is left alone deliberately: #430 and #453 both found that moving a
+// cache-derived parameter moves BLOCK COUNTS the thread partition is sensitive
+// to, and that the analytical sizing lost to the shipped constants on real
+// hardware more often than it won. So this gets its own measurement, on a
+// machine with the instruction, rather than riding along with the kernel.
+
+#include <cstddef>
+#include <type_traits>
+
+#include <mtl/simd/batch.hpp>
+
+namespace mtl::detail {
+
+/// Which micro-kernel the blocked nest drives.
+///
+/// An EXPLICIT choice, never inferred from the element types, because an
+/// (i8, i8) pair is valid input to both and inference would silently replace the
+/// widen-on-load path the moment this kernel existed. Both are correct; they
+/// differ only in speed, and which one a build measured is not recoverable from
+/// a timing afterwards. So the caller says which, and the default is the one
+/// that was already there.
+enum class gemm_kernel {
+    widening,   ///< same-type, or narrow operands widened on load: one k value per multiply-add
+    quad,       ///< the hardware quad multiply-accumulate: four k values per instruction
+};
+
+/// Does the (accumulator, A operand, B operand) triple ADMIT the quad kernel?
+/// Necessary for `gemm_kernel::quad`, never sufficient to select it -- see above.
+///
+/// A function rather than a variable template because `quad_accumulator_t` is
+/// undefined for a rejected pairing -- notably `(int8, uint8)`, which is absent
+/// on purpose so that a caller holding it is told to swap rather than handed the
+/// emulated path silently. Naming the trait unconditionally would turn that
+/// deliberate absence into an "incomplete type" error at every use site.
+template <typename TC, typename TA, typename TB>
+constexpr bool is_quad_gemm() {
+    if constexpr (simd::QuadPair<TA, TB>)
+        return std::is_same_v<TC, simd::quad_accumulator_t<TA, TB>>;
+    else
+        return false;
+}
+
+/// Accumulate an MR x NR tile of C from quad-interleaved packed panels:
+///
+///     C(i, j) += alpha * sum_{p < kp} A(i, p) * B(p, j)
+///
+/// `kp` is the panel depth, a multiple of four (`quad_depth(kc)`); the packing
+/// zero-pads the k tail up to it, and a zero operand contributes a zero product,
+/// so no size check reaches the inner loop. `Ap` and `Bp` are laid out by
+/// pack_A_quad / pack_B_quad. C is row-major with leading dimension `ldc`, and
+/// this is the ACCUMULATE form -- the caller zeroes or pre-scales it.
+///
+/// ALPHA IS APPLIED HERE, on the way out, and not folded into the packed A panel
+/// the way the pairwise nest does it. Folding is wrong for this kernel by
+/// construction: the panel holds 8-bit operands, so `alpha * A` would be
+/// truncated back into a byte before it ever reached the accumulator. Scaling
+/// the int32 tile instead is exact (mod 2^32, like everything here) and costs
+/// one multiply per C element per kc block, which is O(1/kc) of the work.
+template <typename TC, typename TA, typename TB, std::size_t MR, std::size_t NR>
+void gemm_quad_microkernel(std::size_t kp, const TA* Ap, const TB* Bp,
+                           TC* C, std::size_t ldc, TC alpha) {
+    using B32 = simd::batch<TC>;
+    static_assert(is_quad_gemm<TC, TA, TB>(),
+                  "the quad micro-kernel takes an 8-bit operand pair the hardware "
+                  "op accepts -- (i8,i8), (u8,i8) or (u8,u8) -- accumulated in its "
+                  "matching 32-bit type");
+    constexpr std::size_t W = B32::size;
+    static_assert(NR % W == 0, "NR (the vectorized dimension) must be a multiple of the SIMD width");
+    constexpr std::size_t NB = NR / W;   // batch-columns spanning the NR lanes
+
+    // C microtile: MR rows x NB batch-columns, register-resident, zeroed.
+    B32 c[MR][NB];
+
+    const std::size_t ngroups = kp / 4;
+    for (std::size_t g = 0; g < ngroups; ++g) {
+        const TA* ag = Ap + g * (MR * 4);   // MR quads of A, one per tile row
+        const TB* bg = Bp + g * (NR * 4);   // NR quads of B, one per tile column
+
+        // jb outermost so the B pointer is loop-invariant across the MR
+        // accumulations that consume it -- the same reason the pairwise kernel
+        // hoists its B row into registers before the rank-1 update.
+        for (std::size_t jb = 0; jb < NB; ++jb) {
+            // Columns [jb*W, jb*W + W) occupy 4*W adjacent narrow values, which
+            // is exactly one instruction's right operand.
+            const TB* bptr = bg + jb * (W * 4);
+            for (std::size_t i = 0; i < MR; ++i)
+                B32::template quad_dot_broadcast_accumulate<TA, TB>(ag + i * 4, bptr, c[i][jb]);
+        }
+    }
+
+    // Flush the microtile into C (C += alpha * tile).
+    const bool scale = !(alpha == TC(1));
+    const B32 va(alpha);
+    for (std::size_t i = 0; i < MR; ++i)
+        for (std::size_t jb = 0; jb < NB; ++jb) {
+            TC* cptr = C + i * ldc + jb * W;
+            const B32 acc = scale ? va * c[i][jb] : c[i][jb];
+            (B32::load_unaligned(cptr) + acc).store_unaligned(cptr);
+        }
+}
+
+} // namespace mtl::detail

--- a/include/mtl/detail/gemm_quad_pack.hpp
+++ b/include/mtl/detail/gemm_quad_pack.hpp
@@ -1,0 +1,140 @@
+#pragma once
+// MTL5 -- QUAD-INTERLEAVED GEMM packing, for the VNNI / SDOT micro-kernel
+// (#451 phase 5).
+//
+// The ordinary packing (gemm_pack.hpp) lays each micro-panel out one k value at
+// a time, because the micro-kernel it feeds does one rank-1 update per k:
+//
+//   pack_A   Ap[panel*MR*k + p*MR + i] == A(i, p)      -- MR-row, column-major
+//   pack_B   Bp[panel*NR*k + p*NR + j] == B(p, j)      -- NR-col, row-major
+//
+// The quad multiply-accumulate consumes FOUR k values per instruction: lane j of
+// the accumulator receives sum_{q<4} A(i, p+q) * B(p+q, j). So the four k values
+// belonging to one (row, lane) must sit in four ADJACENT bytes -- and that is a
+// different layout, not a different traversal of the same one. Interleave k in
+// groups of four, innermost:
+//
+//   pack_A_quad  Ap[panel*MR*KP + g*(MR*4) + i*4 + q] == A(i, 4g+q)
+//   pack_B_quad  Bp[panel*NR*KP + g*(NR*4) + j*4 + q] == B(4g+q, j)
+//
+// with g the k-group index and KP = k rounded up to a multiple of four. The
+// micro-kernel then reads A as a 4-byte BROADCAST unit at `i*4` and B as an
+// ordinary vector load at `jb*4*W` -- because `j*4 + q` over a run of W columns
+// is exactly the 4*W narrow lanes one instruction takes.
+//
+// Everything else is inherited from gemm_pack.hpp deliberately: generic (rs, cs)
+// strides so any orientation packs without special-casing, zero padding of the
+// ragged row/column edge so the micro-kernel only ever sees full MR x NR tiles,
+// and independent NR-column panels at computable offsets so a team of threads
+// can pack one B block cooperatively without changing a single packed byte.
+//
+// The k TAIL is zero-padded too, which the pairwise layout never had to do: k is
+// not a multiple of four in general, and a zero operand contributes a zero
+// product, so the padding is free of both special cases and arithmetic effect.
+
+#include <cstddef>
+
+#include <mtl/concepts/scalar.hpp>
+#include <mtl/detail/gemm_pack.hpp>
+
+namespace mtl::detail {
+
+/// k rounded up to a whole number of 4-value groups -- the depth the quad
+/// layout actually stores, and the depth the micro-kernel steps.
+constexpr std::size_t quad_depth(std::size_t k) { return ((k + 3) / 4) * 4; }
+
+/// Elements needed to pack an m x k A block into quad-interleaved MR-row panels.
+constexpr std::size_t packed_A_quad_size(std::size_t m, std::size_t k, std::size_t MR) {
+    return ((m + MR - 1) / MR) * MR * quad_depth(k);
+}
+
+/// Elements needed to pack a k x n B block into quad-interleaved NR-col panels.
+constexpr std::size_t packed_B_quad_size(std::size_t k, std::size_t n, std::size_t NR) {
+    return ((n + NR - 1) / NR) * NR * quad_depth(k);
+}
+
+/// The A-panel size for whichever layout the (accumulator, operand) pair selects.
+/// A single call site in the nest then covers both kernels.
+template <bool Quad>
+constexpr std::size_t packed_A_size_for(std::size_t m, std::size_t k, std::size_t MR) {
+    if constexpr (Quad) return packed_A_quad_size(m, k, MR);
+    else                return packed_A_size(m, k, MR);
+}
+
+/// The B-panel size for whichever layout the pair selects; see packed_A_size_for.
+template <bool Quad>
+constexpr std::size_t packed_B_size_for(std::size_t k, std::size_t n, std::size_t NR) {
+    if constexpr (Quad) return packed_B_quad_size(k, n, NR);
+    else                return packed_B_size(k, n, NR);
+}
+
+/// Pack an m x k block of A into quad-interleaved MR-row micro-panels.
+///
+///     Ap[q*MR*KP + g*MR*4 + i*4 + t] = (q*MR+i < m && 4g+t < k) ? A(q*MR+i, 4g+t) : 0
+///
+/// for g in [0, KP/4), i in [0,MR), t in [0,4), KP = quad_depth(k). `Ap` must
+/// hold packed_A_quad_size(m,k,MR) elements. The `i*4 + t` run is the 4-byte
+/// unit gemm_quad_microkernel broadcasts.
+template <typename T, std::size_t MR>
+    requires mtl::Scalar<T>
+void pack_A_quad(const T* A, std::ptrdiff_t rs, std::ptrdiff_t cs,
+                 std::size_t m, std::size_t k, T* Ap) {
+    static_assert(MR > 0, "MR must be positive");
+    const std::size_t KP = quad_depth(k);
+    std::size_t dst = 0;
+    for (std::size_t i0 = 0; i0 < m; i0 += MR) {
+        const std::size_t mr = (m - i0 < MR) ? (m - i0) : MR;   // rows in this panel
+        for (std::size_t p = 0; p < KP; p += 4) {
+            for (std::size_t i = 0; i < MR; ++i) {
+                const T* row = A + static_cast<std::ptrdiff_t>(i0 + i) * rs;
+                for (std::size_t t = 0; t < 4; ++t)
+                    Ap[dst++] = (i < mr && p + t < k)
+                        ? row[static_cast<std::ptrdiff_t>(p + t) * cs]
+                        : T(0);   // ragged rows and the k tail both pad with zero
+            }
+        }
+    }
+}
+
+/// Pack panels [q0, q1) of a k x n B block into quad-interleaved NR-col
+/// micro-panels, each written at the offset it would occupy in a whole pack:
+///
+///     Bp[q*NR*KP + g*NR*4 + j*4 + t] = (q*NR+j < n && 4g+t < k) ? B(4g+t, q*NR+j) : 0
+///
+/// `Bp` must hold packed_B_quad_size(k,n,NR) elements. Panel destinations are
+/// disjoint and computable, and packing is pure data movement, so a cooperative
+/// split across a thread team produces byte-identical output -- which is what
+/// keeps the threaded quad GEMM bit-identical to the serial one.
+template <typename T, std::size_t NR>
+    requires mtl::Scalar<T>
+void pack_B_quad_panels(const T* B, std::ptrdiff_t rs, std::ptrdiff_t cs,
+                        std::size_t k, std::size_t n, T* Bp,
+                        std::size_t q0, std::size_t q1) {
+    static_assert(NR > 0, "NR must be positive");
+    const std::size_t KP = quad_depth(k);
+    const std::size_t npanels = (n + NR - 1) / NR;
+    if (q1 > npanels) q1 = npanels;
+    for (std::size_t q = q0; q < q1; ++q) {
+        const std::size_t j0 = q * NR;
+        const std::size_t nr = (n - j0 < NR) ? (n - j0) : NR;   // cols in this panel
+        std::size_t dst = q * NR * KP;                          // this panel's slot
+        for (std::size_t p = 0; p < KP; p += 4) {
+            for (std::size_t j = 0; j < NR; ++j) {
+                const T* col = B + static_cast<std::ptrdiff_t>(j0 + j) * cs;
+                for (std::size_t t = 0; t < 4; ++t)
+                    Bp[dst++] = (j < nr && p + t < k)
+                        ? col[static_cast<std::ptrdiff_t>(p + t) * rs]
+                        : T(0);
+            }
+        }
+    }
+}
+
+template <typename T, std::size_t NR>
+    requires mtl::Scalar<T>
+void pack_B_quad(const T* B, std::ptrdiff_t rs, std::ptrdiff_t cs,
+                 std::size_t k, std::size_t n, T* Bp) {
+    pack_B_quad_panels<T, NR>(B, rs, cs, k, n, Bp, 0, (n + NR - 1) / NR);
+}
+
+} // namespace mtl::detail

--- a/include/mtl/operation/mult.hpp
+++ b/include/mtl/operation/mult.hpp
@@ -321,13 +321,18 @@ void mult(const MA& A, const MB& B, MC& C) {
         // The integer analogue: 8- or 16-bit operands accumulated in 32 bits
         // through the same blocked nest and the same widening load.
         //
-        // This is the WIDEN-ON-LOAD path, not the hardware dot product. It
+        // This is the WIDEN-ON-LOAD path, not the hardware quad product. It
         // promotes narrow operands into int32 lanes and does an ordinary
         // multiply-add, so it captures the memory-traffic win -- an int8 GEMM
-        // reads an eighth of the bytes of an fp64 one -- but not `vpdpbusd`,
-        // which needs a different micro-kernel and a quad-interleaved pack
-        // layout. Measured on the dot kernels, traffic is where most of the
-        // integer speedup lives; see docs/performance.
+        // reads an eighth of the bytes of an fp64 one -- but not `vpdpbusd`.
+        //
+        // That kernel now exists: see `mult_quad` below, which is FASTER here
+        // (1.26x symmetric, 1.64x for u8 x i8) even on a machine that only
+        // emulates the instruction. This path is deliberately NOT rerouted to
+        // it -- both are correct for an (i8,i8) pair, so switching silently
+        // would destroy the within-machine control the benchmark needs, and
+        // nothing in a timing can tell the two apart afterwards. The default
+        // moves when there is a measurement behind it.
         //
         // Same signedness on both operands and the accumulator, matching
         // batch::load_widen: a mixed pair is a question about the caller's
@@ -440,6 +445,84 @@ void mult(const MA& A, const MB& B, MC& C) {
 #endif
     detail::mult_generic(A, B, C);
     }
+}
+
+/// C = A * B through the QUAD MULTIPLY-ACCUMULATE micro-kernel -- VNNI
+/// `vpdpbusd` on x86, `SDOT`/`UDOT` on NEON (#451 phase 5).
+///
+/// WHY THIS IS A SEPARATE ENTRY POINT and not a silent upgrade inside `mult`.
+/// Both kernels are correct for an `(i8, i8)` pair, so making `mult` choose
+/// between them would mean the same call measures a different thing on different
+/// machines -- and the benchmark README already warns that nothing in a timing
+/// distinguishes `vpdpbusd` from its decomposition. The whole reason to build
+/// this kernel was to find out what the instruction is worth, and that needs
+/// both arms compilable in ONE binary so they can be compared within a machine.
+/// The programme has paid for a missing within-machine control once already: the
+/// instruction's share looked like 1.42x from a single Zen 4 run and came out at
+/// ~1.2x once an i7 could run both arms decomposed. So `mult` is unchanged, this
+/// is explicit, and the default flips later with data behind it.
+///
+/// The operand pair must be one the hardware op accepts -- `(i8,i8)`, `(u8,i8)`
+/// or `(u8,u8)`, accumulating in the matching 32-bit type. `(i8,u8)` is rejected
+/// rather than reordered: unlike a dot product a GEMM is NOT symmetric in its
+/// operands, so there is no argument swap that fixes it for the caller, and
+/// `(u8,i8)` -- unsigned activations against signed weights -- is the shape
+/// quantized inference actually produces.
+///
+/// Falls back to the accumulator-aware generic loop when the matrices are not
+/// dense and contiguous, so this is always correct, never merely fast. One case
+/// is worth naming: COLUMN-MAJOR C is computed as C^T = B^T A^T, which swaps the
+/// operand order, and `(u8,i8)` swapped is `(i8,u8)` -- not a pairing the
+/// instruction has. That combination therefore takes the generic loop. The
+/// symmetric pairs are unaffected.
+template <typename Accumulator, Matrix MA, Matrix MB, Matrix MC>
+void mult_quad(const MA& A, const MB& B, MC& C) {
+    assert(A.num_cols() == B.num_rows());
+    assert(A.num_rows() == C.num_rows());
+    assert(B.num_cols() == C.num_cols());
+
+    using TA = typename MA::value_type;
+    using TB = typename MB::value_type;
+#ifdef MTL5_NATIVE_FAST_GEMM
+    // Row-major C keeps the operand order, so the pair is (TA, TB); col-major C
+    // computes C^T = B^T A^T and therefore needs (TB, TA) to be a pairing too.
+    constexpr bool row_major_c = interface::is_row_major_v<MC>;
+    constexpr bool kernel_ok = row_major_c ? detail::is_quad_gemm<Accumulator, TA, TB>()
+                                           : detail::is_quad_gemm<Accumulator, TB, TA>();
+    if constexpr (kernel_ok &&
+                  std::is_same_v<typename MC::value_type, Accumulator> &&
+                  interface::SimdDenseMatrix<MC> &&
+                  interface::ContiguousMatrixData<MA> &&
+                  interface::ContiguousMatrixData<MB>) {
+        const std::size_t M = A.num_rows();
+        const std::size_t N = B.num_cols();
+        const std::size_t K = A.num_cols();
+        const std::ptrdiff_t a_rs = interface::is_row_major_v<MA> ? static_cast<std::ptrdiff_t>(A.num_cols()) : 1;
+        const std::ptrdiff_t a_cs = interface::is_row_major_v<MA> ? 1 : static_cast<std::ptrdiff_t>(A.num_rows());
+        const std::ptrdiff_t b_rs = interface::is_row_major_v<MB> ? static_cast<std::ptrdiff_t>(B.num_cols()) : 1;
+        const std::ptrdiff_t b_cs = interface::is_row_major_v<MB> ? 1 : static_cast<std::ptrdiff_t>(B.num_rows());
+        const unsigned nthreads = detail::gemm_default_threads();
+        constexpr auto kern = detail::gemm_kernel::quad;   // asked for out loud
+        if constexpr (row_major_c) {
+            detail::gemm_blocked<Accumulator, TA, TB, kern>(
+                M, N, K, math::one<Accumulator>(),
+                A.data(), a_rs, a_cs, B.data(), b_rs, b_cs,
+                math::zero<Accumulator>(), C.data(), N, nthreads);
+        } else {
+            detail::gemm_blocked<Accumulator, TB, TA, kern>(
+                N, M, K, math::one<Accumulator>(),
+                B.data(), b_cs, b_rs, A.data(), a_cs, a_rs,
+                math::zero<Accumulator>(), C.data(), M, nthreads);
+        }
+        return;
+    }
+#endif
+    static_assert(simd::QuadPair<TA, TB>,
+                  "mult_quad takes an 8-bit operand pair the hardware op accepts -- "
+                  "(i8,i8), (u8,i8) or (u8,u8). (i8,u8) is absent on purpose: a GEMM "
+                  "is not symmetric in its operands, so swapping is the caller's "
+                  "decision, not this function's");
+    detail::mult_generic<Accumulator>(A, B, C);
 }
 
 } // namespace mtl

--- a/include/mtl/simd/batch.hpp
+++ b/include/mtl/simd/batch.hpp
@@ -45,6 +45,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <type_traits>
 
 // wrap_add / wrap_sub / wrap_mul: the two's-complement helpers the scalar paths
@@ -209,7 +210,10 @@ public:
     /// multiply-add. It captures the memory-traffic win (one byte per element
     /// instead of eight) which is where most of the integer speedup lives --
     /// see docs/performance -- but not the specialised instruction, which needs
-    /// a different micro-kernel and a quad-interleaved pack layout.
+    /// a quad-interleaved pack layout and the broadcast-quad micro-kernel in
+    /// detail/gemm_quad_microkernel.hpp (#451 phase 5). For a GEMM that one is
+    /// measurably faster even where the instruction is emulated, so this path is
+    /// the fallback for pairs the quad op does not accept, not the preferred one.
     template <typename Src>
     static batch load_widen(const Src* p) {
         static_assert((std::is_floating_point_v<T> && std::is_floating_point_v<Src>) ||
@@ -295,6 +299,46 @@ public:
         const hn::Repartition<NA, D> dna;
         const hn::Repartition<NB, D> dnb;
         sum.v_ = hn::SumOfMulQuadAccumulate(d_, hn::LoadU(dna, a), hn::LoadU(dnb, b), sum.v_);
+    }
+
+    /// Quad multiply-accumulate with a BROADCAST left operand -- the GEMM shape
+    /// of the instruction, and the reason the micro-kernel needs a primitive of
+    /// its own (#451 phase 5).
+    ///
+    /// `quad_dot_accumulate` walks two vectors in step, which is a dot product.
+    /// A GEMM does not: one C row needs ONE A element (four of them here, for
+    /// four k values) multiplied against a whole row of B. So the left operand
+    /// is the same four narrow values in every lane, and lane j accumulates
+    ///
+    ///     sum[j] += sum_{q<4} a4[q] * b[4*j + q]
+    ///
+    /// which is exactly the rank-4 update the packed panels are laid out for:
+    /// `a4` is A(i, p..p+3) and `b[4*j+q]` is B(p+q, j). Four k steps per
+    /// instruction, against the widening load's one.
+    ///
+    /// The broadcast is a 32-bit splat of the four bytes AS THEY LIE IN MEMORY
+    /// (memcpy, then `Set`, then a reinterpret back to narrow lanes) -- one
+    /// `vpbroadcastd` / `LD1R`, not four inserts. Note this ties the quad's lane
+    /// order to the byte order of the machine: on a little-endian target lane 0
+    /// receives `a4[0]`, which is what pairs it with the `b` load. Every target
+    /// that HAS this instruction is little-endian, and
+    /// tests/unit/simd/test_quad_dot.cpp checks the pairing against a scalar
+    /// reference, so a big-endian port would fail loudly rather than quietly
+    /// transpose the quad.
+    template <typename NA, typename NB>
+    static void quad_dot_broadcast_accumulate(const NA* a4, const NB* b, batch& sum) {
+        static_assert(is_quad_widenable_v<NA> && is_quad_widenable_v<NB>,
+                      "quad_dot_broadcast_accumulate takes 8-bit operands");
+        static_assert(std::is_same_v<T, quad_accumulator_t<NA, NB>>,
+                      "accumulator must match the operand pairing: i8*i8 and "
+                      "u8*i8 -> int32, u8*u8 -> uint32");
+        static_assert(sizeof(T) == 4 * sizeof(NA), "the broadcast unit is four narrow values");
+        const hn::Repartition<NA, D> dna;
+        const hn::Repartition<NB, D> dnb;
+        T quad;                                  // a4[0..3], in memory order
+        std::memcpy(&quad, a4, sizeof(T));
+        sum.v_ = hn::SumOfMulQuadAccumulate(d_, hn::BitCast(dna, hn::Set(d_, quad)),
+                                            hn::LoadU(dnb, b), sum.v_);
     }
 
     friend batch operator+(batch a, batch b) { return batch(hn::Add(a.v_, b.v_)); }
@@ -405,6 +449,23 @@ public:
         for (std::size_t k = 0; k < 4; ++k)
             sum.v_ = mtl::detail::wrap_add(
                 sum.v_, mtl::detail::wrap_mul(static_cast<T>(a[k]), static_cast<T>(b[k])));
+    }
+
+    /// Quad multiply-accumulate with a broadcast left operand -- scalar
+    /// fallback; see the Highway variant for the contract. With one lane the
+    /// broadcast is a no-op, so this is the same four products as
+    /// quad_dot_accumulate -- which is the definition the SIMD path has to
+    /// reproduce lane by lane, and the reference the tests compare against.
+    template <typename NA, typename NB>
+    static void quad_dot_broadcast_accumulate(const NA* a4, const NB* b, batch& sum) {
+        static_assert(is_quad_widenable_v<NA> && is_quad_widenable_v<NB>,
+                      "quad_dot_broadcast_accumulate takes 8-bit operands");
+        static_assert(std::is_same_v<T, quad_accumulator_t<NA, NB>>,
+                      "accumulator must match the operand pairing: i8*i8 and "
+                      "u8*i8 -> int32, u8*u8 -> uint32");
+        for (std::size_t q = 0; q < 4; ++q)
+            sum.v_ = mtl::detail::wrap_add(
+                sum.v_, mtl::detail::wrap_mul(static_cast<T>(a4[q]), static_cast<T>(b[q])));
     }
 
     friend batch operator+(batch a, batch b) { return batch(mtl::detail::wrap_add(a.v_, b.v_)); }

--- a/tests/unit/detail/test_gemm_quad_pack.cpp
+++ b/tests/unit/detail/test_gemm_quad_pack.cpp
@@ -1,0 +1,195 @@
+// Quad-interleaved GEMM packing -- #451 phase 5.
+//
+// The ordinary pack stores one k value at a time because the pairwise
+// micro-kernel does one rank-1 update per k. The quad multiply-accumulate
+// consumes FOUR k values per instruction, and the four belonging to one
+// (row, lane) have to sit in four ADJACENT bytes -- so this is a different
+// layout, not a different traversal.
+//
+// The layout is the kernel's contract, and it is checked here ELEMENT BY
+// ELEMENT rather than through a GEMM result, because a pack bug and a kernel bug
+// produce the same symptom (a wrong C) and only one of them is visible from
+// here. Three properties, and each has cost someone a day somewhere:
+//
+//   1. the index formula, for every element of every panel
+//   2. zero padding of BOTH edges -- the ragged row/column edge, which the
+//      pairwise pack also has, and the k TAIL, which is new: k is not a multiple
+//      of four in general, and the kernel has no size check
+//   3. panel independence -- a cooperative split across a thread team must
+//      produce byte-identical output, which is what keeps the threaded quad GEMM
+//      bit-identical to the serial one
+#include <catch2/catch_test_macros.hpp>
+
+#include <mtl/detail/gemm_quad_pack.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace {
+
+constexpr std::size_t MR = 4, NR = 6;
+
+/// A(i,j) = a distinct nonzero value, so a misplaced element cannot coincide
+/// with the zero padding or with another cell.
+std::int8_t cell(std::size_t i, std::size_t j) {
+    return static_cast<std::int8_t>(1 + (i * 37 + j * 11) % 100);
+}
+
+} // namespace
+
+TEST_CASE("quad_depth rounds k up to whole 4-value groups", "[detail][gemm][quad][pack]") {
+    using mtl::detail::quad_depth;
+    CHECK(quad_depth(0) == 0);
+    CHECK(quad_depth(1) == 4);
+    CHECK(quad_depth(3) == 4);
+    CHECK(quad_depth(4) == 4);
+    CHECK(quad_depth(5) == 8);
+    CHECK(quad_depth(256) == 256);
+    CHECK(quad_depth(257) == 260);
+}
+
+TEST_CASE("packed quad sizes count padded panels at padded depth", "[detail][gemm][quad][pack]") {
+    using mtl::detail::packed_A_quad_size;
+    using mtl::detail::packed_B_quad_size;
+    // 7 rows in MR=4 panels -> 2 panels of 4; k=5 -> depth 8.
+    CHECK(packed_A_quad_size(7, 5, 4) == 2 * 4 * 8);
+    CHECK(packed_B_quad_size(5, 7, 6) == 2 * 6 * 8);
+    CHECK(packed_A_quad_size(0, 5, 4) == 0);
+    CHECK(packed_B_quad_size(5, 0, 6) == 0);
+}
+
+TEST_CASE("pack_A_quad lays out Ap[panel][group][row][q] == A(row, 4g+q)",
+          "[detail][gemm][quad][pack]") {
+    // m and k both ragged: 7 rows into MR=4 panels leaves one row of padding,
+    // k=6 into groups of 4 leaves two k values of padding.
+    constexpr std::size_t m = 7, k = 6;
+    const std::size_t KP = mtl::detail::quad_depth(k);
+
+    std::vector<std::int8_t> A(m * k);
+    for (std::size_t i = 0; i < m; ++i)
+        for (std::size_t j = 0; j < k; ++j) A[i * k + j] = cell(i, j);
+
+    std::vector<std::int8_t> Ap(mtl::detail::packed_A_quad_size(m, k, MR), -1);
+    mtl::detail::pack_A_quad<std::int8_t, MR>(
+        A.data(), static_cast<std::ptrdiff_t>(k), 1, m, k, Ap.data());
+
+    const std::size_t npanels = (m + MR - 1) / MR;
+    bool all = true;
+    for (std::size_t p = 0; p < npanels; ++p)
+        for (std::size_t g = 0; g < KP / 4; ++g)
+            for (std::size_t i = 0; i < MR; ++i)
+                for (std::size_t q = 0; q < 4; ++q) {
+                    const std::size_t row = p * MR + i, kk = 4 * g + q;
+                    const std::int8_t want = (row < m && kk < k) ? cell(row, kk) : std::int8_t(0);
+                    const std::int8_t got = Ap[p * MR * KP + g * MR * 4 + i * 4 + q];
+                    INFO("panel " << p << " group " << g << " row " << i << " q " << q);
+                    if (got != want) all = false;
+                    CHECK(got == want);
+                }
+    CHECK(all);
+}
+
+TEST_CASE("pack_B_quad lays out Bp[panel][group][col][q] == B(4g+q, col)",
+          "[detail][gemm][quad][pack]") {
+    constexpr std::size_t k = 6, n = 7;
+    const std::size_t KP = mtl::detail::quad_depth(k);
+
+    std::vector<std::int8_t> B(k * n);
+    for (std::size_t i = 0; i < k; ++i)
+        for (std::size_t j = 0; j < n; ++j) B[i * n + j] = cell(i, j);
+
+    std::vector<std::int8_t> Bp(mtl::detail::packed_B_quad_size(k, n, NR), -1);
+    mtl::detail::pack_B_quad<std::int8_t, NR>(
+        B.data(), static_cast<std::ptrdiff_t>(n), 1, k, n, Bp.data());
+
+    const std::size_t npanels = (n + NR - 1) / NR;
+    bool all = true;
+    for (std::size_t p = 0; p < npanels; ++p)
+        for (std::size_t g = 0; g < KP / 4; ++g)
+            for (std::size_t j = 0; j < NR; ++j)
+                for (std::size_t q = 0; q < 4; ++q) {
+                    const std::size_t col = p * NR + j, kk = 4 * g + q;
+                    const std::int8_t want = (col < n && kk < k) ? cell(kk, col) : std::int8_t(0);
+                    const std::int8_t got = Bp[p * NR * KP + g * NR * 4 + j * 4 + q];
+                    INFO("panel " << p << " group " << g << " col " << j << " q " << q);
+                    if (got != want) all = false;
+                    CHECK(got == want);
+                }
+    CHECK(all);
+}
+
+TEST_CASE("column-major sources pack identically via their strides",
+          "[detail][gemm][quad][pack]") {
+    // Generic (rs, cs) is what lets any orientation -- and a transposed view --
+    // pack with no special-casing. Same logical matrix, two storage orders, one
+    // packed result.
+    constexpr std::size_t m = 5, k = 7;
+    std::vector<std::int8_t> row(m * k), col(m * k);
+    for (std::size_t i = 0; i < m; ++i)
+        for (std::size_t j = 0; j < k; ++j) {
+            row[i * k + j] = cell(i, j);
+            col[i + j * m] = cell(i, j);
+        }
+
+    const std::size_t sz = mtl::detail::packed_A_quad_size(m, k, MR);
+    std::vector<std::int8_t> pr(sz, -1), pc(sz, -2);
+    mtl::detail::pack_A_quad<std::int8_t, MR>(row.data(), static_cast<std::ptrdiff_t>(k), 1,
+                                              m, k, pr.data());
+    mtl::detail::pack_A_quad<std::int8_t, MR>(col.data(), 1, static_cast<std::ptrdiff_t>(m),
+                                              m, k, pc.data());
+    CHECK(pr == pc);
+}
+
+TEST_CASE("a cooperative panel split is byte-identical to packing whole",
+          "[detail][gemm][quad][pack]") {
+    // The threaded nest hands each team member a disjoint range of NR-column
+    // panels. Packing is pure data movement, so the bytes -- and therefore the
+    // GEMM result -- must not depend on the split. This is the property the
+    // bit-identity claim rests on.
+    constexpr std::size_t k = 13, n = 19;
+    std::vector<std::int8_t> B(k * n);
+    for (std::size_t i = 0; i < k; ++i)
+        for (std::size_t j = 0; j < n; ++j) B[i * n + j] = cell(i, j);
+
+    const std::size_t sz = mtl::detail::packed_B_quad_size(k, n, NR);
+    const std::size_t npanels = (n + NR - 1) / NR;
+    std::vector<std::int8_t> whole(sz, -1);
+    mtl::detail::pack_B_quad<std::int8_t, NR>(B.data(), static_cast<std::ptrdiff_t>(n), 1,
+                                              k, n, whole.data());
+
+    for (std::size_t parts = 1; parts <= npanels + 2; ++parts) {
+        std::vector<std::int8_t> split(sz, -1);
+        const std::size_t per = (npanels + parts - 1) / parts;
+        for (std::size_t t = 0; t < parts; ++t) {
+            const std::size_t q0 = std::min(npanels, t * per);
+            const std::size_t q1 = std::min(npanels, q0 + per);
+            if (q0 < q1)
+                mtl::detail::pack_B_quad_panels<std::int8_t, NR>(
+                    B.data(), static_cast<std::ptrdiff_t>(n), 1, k, n, split.data(), q0, q1);
+        }
+        INFO("split into " << parts << " ranges");
+        CHECK(split == whole);
+    }
+}
+
+TEST_CASE("an out-of-range panel range is clamped, not read", "[detail][gemm][quad][pack]") {
+    // The nest computes q1 from a ceiling division, so the last member's range
+    // can run past the panel count. pack_B_quad_panels clamps; if it did not,
+    // it would write past the buffer.
+    constexpr std::size_t k = 5, n = 6;
+    std::vector<std::int8_t> B(k * n, 3);
+    std::vector<std::int8_t> Bp(mtl::detail::packed_B_quad_size(k, n, NR), -1);
+    mtl::detail::pack_B_quad_panels<std::int8_t, NR>(
+        B.data(), static_cast<std::ptrdiff_t>(n), 1, k, n, Bp.data(), 0, 99);
+    // One panel of 6 columns at depth 8; every stored k value is 3, the tail 0.
+    const std::size_t KP = mtl::detail::quad_depth(k);
+    bool all = true;
+    for (std::size_t g = 0; g < KP / 4; ++g)
+        for (std::size_t j = 0; j < NR; ++j)
+            for (std::size_t q = 0; q < 4; ++q) {
+                const std::int8_t want = (4 * g + q < k) ? std::int8_t(3) : std::int8_t(0);
+                if (Bp[g * NR * 4 + j * 4 + q] != want) all = false;
+            }
+    CHECK(all);
+}

--- a/tests/unit/operation/test_gemm_integer.cpp
+++ b/tests/unit/operation/test_gemm_integer.cpp
@@ -14,8 +14,12 @@
 // What this is NOT is a VNNI kernel. `vpdpbusd` consumes four k-values per
 // instruction and needs a quad-interleaved pack layout and a different
 // micro-kernel; this path promotes narrow operands into int32 lanes and does an
-// ordinary multiply-add. The distinction is recorded here because the two are
-// easy to conflate and only one of them is implemented.
+// ordinary multiply-add. That kernel exists as of #451 phase 5 and is tested in
+// test_gemm_quad.cpp -- reached through `mult_quad`, never through `mult`, so
+// the two stay separately measurable. The tests here therefore still pin the
+// WIDENING kernel. That `mult` has not been quietly rerouted to the other one
+// is checked in test_gemm_quad.cpp, and has to be checked structurally: the two
+// kernels give bit-identical answers, so no result can tell them apart.
 //
 // Every case is EXACT. Integer arithmetic wraps mod 2^32 (#451), and wrapping
 // addition is associative, so the blocked nest -- which reorders the k loop

--- a/tests/unit/operation/test_gemm_quad.cpp
+++ b/tests/unit/operation/test_gemm_quad.cpp
@@ -1,0 +1,451 @@
+// The VNNI / SDOT GEMM: the blocked nest driving the QUAD micro-kernel.
+// #451 phase 5.
+//
+// What is new here, against the widen-on-load integer GEMM (#468):
+//
+//   widen-on-load   int8 promoted into int32 lanes, one k value per multiply-add
+//   quad            four k values per instruction, from quad-interleaved panels
+//
+// The second is what `vpdpbusd` and `SDOT` actually are, and #468's measurement
+// is why it exists: on a machine WITHOUT the instruction, narrowing a GEMM's
+// operand buys nothing at all (Xeon E5-2420 v2, n=512 -- gemm_i8_i32 13.3 GOP/s
+// against gemm_i32's 13.5 and fp32's 18.8), because a GEMM packs each operand
+// once and reads it from cache O(n) times after, so its width in memory stops
+// mattering. Everything an int8 GEMM can offer over fp32 therefore has to come
+// from the instruction.
+//
+// CORRECTNESS IS ABSOLUTE HERE, not statistical. Integer arithmetic wraps mod
+// 2^32 and wrapping addition is associative, so every rearrangement this nest
+// performs -- splitting k across pc blocks, splitting m across threads, summing
+// four products in one instruction instead of four, accumulating in a register
+// tile -- must give the BIT-IDENTICAL answer a naive triple loop gives. Not
+// close: identical. A float GEMM could not make that claim, and the quad kernel
+// is exactly the kind of change (a different summation grouping) whose effect a
+// tolerance-based test would hide.
+//
+// The pairing rules are the hardware's and are re-checked at this level: VNNI
+// implements unsigned x signed natively, symmetric i8 x i8 only from AVX10.2,
+// and `(i8, u8)` does not exist. Unlike a dot product, a GEMM is NOT symmetric
+// in its operands, so there is no argument swap that rescues that last case --
+// which is why mult_quad rejects it rather than reordering.
+#define MTL5_NATIVE_FAST_GEMM 1
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+
+#include <mtl/detail/gemm_quad_microkernel.hpp>
+#include <mtl/interface/dispatch_traits.hpp>
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/mat/parameter.hpp>
+#include <mtl/operation/mult.hpp>
+#include <mtl/simd/batch.hpp>
+#include <mtl/tag/orientation.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <vector>
+
+namespace {
+
+using rowmaj = mtl::mat::parameters<mtl::tag::row_major>;
+using colmaj = mtl::mat::parameters<mtl::tag::col_major>;
+
+/// Exact reference, computed in 64 bits and reduced to the accumulator width.
+template <typename TC, typename MA, typename MB>
+TC ref_cell(const MA& A, const MB& B, std::size_t i, std::size_t j, std::size_t K) {
+    std::uint64_t acc = 0;
+    for (std::size_t k = 0; k < K; ++k)
+        acc += static_cast<std::uint64_t>(static_cast<std::uint32_t>(static_cast<TC>(A(i, k)))) *
+               static_cast<std::uint32_t>(static_cast<TC>(B(k, j)));
+    return static_cast<TC>(static_cast<std::uint32_t>(acc));
+}
+
+template <typename T> T gen_a(std::size_t i, std::size_t k) {
+    if constexpr (std::is_signed_v<T>) return static_cast<T>((i * 7 + k * 3) % 251 - 125);
+    else                               return static_cast<T>((i * 7 + k * 3) % 251);
+}
+template <typename T> T gen_b(std::size_t k, std::size_t j) {
+    if constexpr (std::is_signed_v<T>) return static_cast<T>((k * 5 + j * 2) % 241 - 120);
+    else                               return static_cast<T>((k * 5 + j * 2) % 241);
+}
+
+// Shapes straddling the register tile (mr x nr), the k-group of four, the cache
+// blocks and the thread partition, plus ragged ones that leave partial panels
+// everywhere. K values 1..3 exercise a panel that is ENTIRELY k-padding beyond
+// the first group, which the pairwise kernel never had to handle.
+const std::size_t kShapes[][3] = {
+    {1, 1, 1}, {1, 1, 2}, {1, 1, 3}, {1, 1, 4}, {1, 1, 5},
+    {1, 8, 1}, {8, 1, 1}, {4, 4, 4}, {7, 5, 3}, {13, 11, 7},
+    {16, 16, 16}, {17, 16, 16}, {16, 17, 16}, {16, 16, 17}, {16, 16, 18},
+    {16, 16, 19}, {33, 17, 9}, {64, 64, 64}, {65, 63, 31}, {128, 96, 48},
+    {96, 128, 64}, {67, 53, 41},
+};
+
+/// Run a shape sweep for one operand pairing.
+template <typename TA, typename TB>
+void sweep() {
+    using TC = mtl::simd::quad_accumulator_t<TA, TB>;
+    for (auto& s : kShapes) {
+        const std::size_t M = s[0], N = s[1], K = s[2];
+        mtl::mat::dense2D<TA, rowmaj> A(M, K);
+        mtl::mat::dense2D<TB, rowmaj> B(K, N);
+        mtl::mat::dense2D<TC, rowmaj> C(M, N);
+        for (std::size_t i = 0; i < M; ++i)
+            for (std::size_t k = 0; k < K; ++k) A(i, k) = gen_a<TA>(i, k);
+        for (std::size_t k = 0; k < K; ++k)
+            for (std::size_t j = 0; j < N; ++j) B(k, j) = gen_b<TB>(k, j);
+
+        mtl::mult_quad<TC>(A, B, C);
+
+        bool all = true;
+        for (std::size_t i = 0; i < M && all; ++i)
+            for (std::size_t j = 0; j < N && all; ++j)
+                all = (C(i, j) == ref_cell<TC>(A, B, i, j, K));
+        INFO("M=" << M << " N=" << N << " K=" << K);
+        CHECK(all);
+    }
+}
+
+} // namespace
+
+TEST_CASE("the quad kernel is selected by the (accumulator, operand, operand) triple",
+          "[operation][gemm][quad]") {
+    using mtl::detail::is_quad_gemm;
+    // The three pairings the hardware op accepts, with their accumulators.
+    STATIC_REQUIRE(is_quad_gemm<std::int32_t,  std::int8_t,  std::int8_t>());
+    STATIC_REQUIRE(is_quad_gemm<std::int32_t,  std::uint8_t, std::int8_t>());
+    STATIC_REQUIRE(is_quad_gemm<std::uint32_t, std::uint8_t, std::uint8_t>());
+
+    // (i8, u8) is absent on purpose -- see the file header.
+    STATIC_REQUIRE_FALSE(is_quad_gemm<std::int32_t, std::int8_t, std::uint8_t>());
+    // Right pairing, wrong accumulator signedness.
+    STATIC_REQUIRE_FALSE(is_quad_gemm<std::uint32_t, std::int8_t, std::int8_t>());
+    STATIC_REQUIRE_FALSE(is_quad_gemm<std::int32_t, std::uint8_t, std::uint8_t>());
+    // Not 8-bit operands at all: these stay on the widening or same-type kernel.
+    STATIC_REQUIRE_FALSE(is_quad_gemm<std::int32_t, std::int16_t, std::int16_t>());
+    STATIC_REQUIRE_FALSE(is_quad_gemm<std::int32_t, std::int32_t, std::int32_t>());
+    STATIC_REQUIRE_FALSE(is_quad_gemm<double, float, float>());
+}
+
+TEST_CASE("i8 x i8 -> i32 quad GEMM is exact at every shape", "[operation][gemm][quad]") {
+    sweep<std::int8_t, std::int8_t>();
+}
+
+TEST_CASE("u8 x i8 -> i32 quad GEMM is exact at every shape", "[operation][gemm][quad]") {
+    // VNNI's NATIVE shape -- unsigned activations against signed weights -- and
+    // the pairing the instruction was designed around. It is also the one the
+    // widen-on-load path CANNOT take: batch::load_widen requires matching
+    // signedness, so before this kernel a mixed pair fell to the generic loop.
+    sweep<std::uint8_t, std::int8_t>();
+}
+
+TEST_CASE("u8 x u8 -> u32 quad GEMM is exact at every shape", "[operation][gemm][quad]") {
+    sweep<std::uint8_t, std::uint8_t>();
+}
+
+TEST_CASE("the quad nest agrees with the triple loop bit for bit",
+          "[operation][gemm][quad]") {
+    // The claim a float GEMM cannot make. Four products summed by ONE
+    // instruction is a different grouping from four separate adds, and on
+    // integers that must be unobservable, because addition mod 2^32 is
+    // associative. Not "within tolerance" -- identical.
+    constexpr std::size_t M = 67, N = 53, K = 41;
+    mtl::mat::dense2D<std::uint8_t, rowmaj> A(M, K);
+    mtl::mat::dense2D<std::int8_t, rowmaj> B(K, N);
+    mtl::mat::dense2D<std::int32_t, rowmaj> C(M, N), Cref(M, N);
+    for (std::size_t i = 0; i < M; ++i)
+        for (std::size_t k = 0; k < K; ++k) A(i, k) = gen_a<std::uint8_t>(i, k);
+    for (std::size_t k = 0; k < K; ++k)
+        for (std::size_t j = 0; j < N; ++j) B(k, j) = gen_b<std::int8_t>(k, j);
+
+    mtl::mult_quad<std::int32_t>(A, B, C);
+    mtl::detail::mult_generic<std::int32_t>(A, B, Cref);   // the naive triple loop
+
+    bool all = true;
+    for (std::size_t i = 0; i < M && all; ++i)
+        for (std::size_t j = 0; j < N && all; ++j) all = (C(i, j) == Cref(i, j));
+    CHECK(all);
+}
+
+TEST_CASE("the quad kernel agrees with the widen-on-load kernel exactly",
+          "[operation][gemm][quad]") {
+    // The two arms the benchmark compares. They must differ ONLY in speed: the
+    // same operands, the same accumulator, two summation groupings that are
+    // equal mod 2^32. If this ever fails, a throughput comparison between them
+    // is measuring two different computations.
+    constexpr std::size_t M = 61, N = 47, K = 39;
+    mtl::mat::dense2D<std::int8_t, rowmaj> A(M, K), B(K, N);
+    mtl::mat::dense2D<std::int32_t, rowmaj> Cq(M, N), Cw(M, N);
+    for (std::size_t i = 0; i < M; ++i)
+        for (std::size_t k = 0; k < K; ++k) A(i, k) = gen_a<std::int8_t>(i, k);
+    for (std::size_t k = 0; k < K; ++k)
+        for (std::size_t j = 0; j < N; ++j) B(k, j) = gen_b<std::int8_t>(k, j);
+
+    mtl::mult_quad<std::int32_t>(A, B, Cq);   // quad-interleaved, four k per instruction
+    mtl::mult<std::int32_t>(A, B, Cw);        // widen-on-load, one k per multiply-add
+
+    bool all = true;
+    for (std::size_t i = 0; i < M && all; ++i)
+        for (std::size_t j = 0; j < N && all; ++j) all = (Cq(i, j) == Cw(i, j));
+    CHECK(all);
+}
+
+TEST_CASE("mult is NOT silently rerouted through the quad kernel",
+          "[operation][gemm][quad]") {
+    // Deliberate: both kernels are correct for (i8,i8), so letting `mult` choose
+    // would mean the same call measures a different thing on different machines,
+    // and nothing in a timing distinguishes vpdpbusd from its decomposition. The
+    // default flips later, with a within-machine measurement behind it. This
+    // test is what would notice the flip happening by accident.
+    //
+    // THIS IS NOT HYPOTHETICAL. The kernel selection was briefly inferred from
+    // the element types, and since (i8,i8) is valid input to both, `mult`'s
+    // widening path was silently rerouted -- caught only because the benchmark's
+    // two int8 arms started reporting the same number to three digits. They had
+    // become the same kernel, and the arm meant to be the control had stopped
+    // being one. The selection is now an explicit template argument defaulting
+    // to `widening`; these checks pin that default.
+    //
+    // Checked STRUCTURALLY, because the two kernels agree bit for bit (above) --
+    // a result genuinely cannot tell them apart, which is exactly what made the
+    // defect survive a full green test suite.
+    using Fn = void (*)(std::size_t, std::size_t, std::size_t, std::int32_t,
+                        const std::int8_t*, std::ptrdiff_t, std::ptrdiff_t,
+                        const std::int8_t*, std::ptrdiff_t, std::ptrdiff_t,
+                        std::int32_t, std::int32_t*, std::size_t, unsigned);
+    const Fn defaulted = &mtl::detail::gemm_blocked<std::int32_t, std::int8_t, std::int8_t>;
+    const Fn widening  = &mtl::detail::gemm_blocked<std::int32_t, std::int8_t, std::int8_t,
+                                                    mtl::detail::gemm_kernel::widening>;
+    const Fn quad      = &mtl::detail::gemm_blocked<std::int32_t, std::int8_t, std::int8_t,
+                                                    mtl::detail::gemm_kernel::quad>;
+    CHECK(defaulted == widening);   // the default is the kernel that was already there
+    CHECK(defaulted != quad);       // ... and asking for the other one is deliberate
+
+    // The widening path also requires MATCHING SIGNEDNESS, so a (u8,i8) pair
+    // reaching `mult` takes neither fast kernel: it must fall to the
+    // accumulator-aware generic loop, and still be right.
+    constexpr std::size_t M = 5, N = 4, K = 6;
+    mtl::mat::dense2D<std::uint8_t, rowmaj> A(M, K);
+    mtl::mat::dense2D<std::int8_t, rowmaj> B(K, N);
+    mtl::mat::dense2D<std::int32_t, rowmaj> C(M, N);
+    for (std::size_t i = 0; i < M; ++i)
+        for (std::size_t k = 0; k < K; ++k) A(i, k) = gen_a<std::uint8_t>(i, k);
+    for (std::size_t k = 0; k < K; ++k)
+        for (std::size_t j = 0; j < N; ++j) B(k, j) = gen_b<std::int8_t>(k, j);
+
+    mtl::mult<std::int32_t>(A, B, C);
+
+    bool all = true;
+    for (std::size_t i = 0; i < M && all; ++i)
+        for (std::size_t j = 0; j < N && all; ++j)
+            all = (C(i, j) == ref_cell<std::int32_t>(A, B, i, j, K));
+    CHECK(all);
+}
+
+TEST_CASE("column-major C still gets the right answer", "[operation][gemm][quad]") {
+    // Col-major C is computed as C^T = B^T A^T, which SWAPS the operand order --
+    // and a GEMM is not symmetric in its operands, so the swapped pair must
+    // itself be one the instruction has. The symmetric pairings survive the
+    // swap; (u8,i8) becomes (i8,u8), which does not exist, so that combination
+    // takes the generic loop. Both must be correct, which is what this checks.
+    constexpr std::size_t M = 33, N = 21, K = 17;
+    {
+        mtl::mat::dense2D<std::int8_t, rowmaj> A(M, K), B(K, N);
+        mtl::mat::dense2D<std::int32_t, colmaj> C(M, N);
+        for (std::size_t i = 0; i < M; ++i)
+            for (std::size_t k = 0; k < K; ++k) A(i, k) = gen_a<std::int8_t>(i, k);
+        for (std::size_t k = 0; k < K; ++k)
+            for (std::size_t j = 0; j < N; ++j) B(k, j) = gen_b<std::int8_t>(k, j);
+        mtl::mult_quad<std::int32_t>(A, B, C);
+        bool all = true;
+        for (std::size_t i = 0; i < M && all; ++i)
+            for (std::size_t j = 0; j < N && all; ++j)
+                all = (C(i, j) == ref_cell<std::int32_t>(A, B, i, j, K));
+        INFO("symmetric pairing, swapped by the col-major path");
+        CHECK(all);
+    }
+    {
+        mtl::mat::dense2D<std::uint8_t, rowmaj> A(M, K);
+        mtl::mat::dense2D<std::int8_t, rowmaj> B(K, N);
+        mtl::mat::dense2D<std::int32_t, colmaj> C(M, N);
+        for (std::size_t i = 0; i < M; ++i)
+            for (std::size_t k = 0; k < K; ++k) A(i, k) = gen_a<std::uint8_t>(i, k);
+        for (std::size_t k = 0; k < K; ++k)
+            for (std::size_t j = 0; j < N; ++j) B(k, j) = gen_b<std::int8_t>(k, j);
+        mtl::mult_quad<std::int32_t>(A, B, C);   // -> generic loop, still correct
+        bool all = true;
+        for (std::size_t i = 0; i < M && all; ++i)
+            for (std::size_t j = 0; j < N && all; ++j)
+                all = (C(i, j) == ref_cell<std::int32_t>(A, B, i, j, K));
+        INFO("asymmetric pairing: the swap has no instruction, so the generic loop runs");
+        CHECK(all);
+    }
+}
+
+TEST_CASE("column-major OPERANDS pack through their strides", "[operation][gemm][quad]") {
+    // Generic (rs, cs) means orientation is handled by the pack, not by a
+    // special case in the kernel. Same logical product, operands stored the
+    // other way round.
+    constexpr std::size_t M = 29, N = 23, K = 19;
+    mtl::mat::dense2D<std::uint8_t, colmaj> A(M, K);
+    mtl::mat::dense2D<std::int8_t, colmaj> B(K, N);
+    mtl::mat::dense2D<std::int32_t, rowmaj> C(M, N);
+    for (std::size_t i = 0; i < M; ++i)
+        for (std::size_t k = 0; k < K; ++k) A(i, k) = gen_a<std::uint8_t>(i, k);
+    for (std::size_t k = 0; k < K; ++k)
+        for (std::size_t j = 0; j < N; ++j) B(k, j) = gen_b<std::int8_t>(k, j);
+
+    mtl::mult_quad<std::int32_t>(A, B, C);
+
+    bool all = true;
+    for (std::size_t i = 0; i < M && all; ++i)
+        for (std::size_t j = 0; j < N && all; ++j)
+            all = (C(i, j) == ref_cell<std::int32_t>(A, B, i, j, K));
+    CHECK(all);
+}
+
+TEST_CASE("the quad GEMM wraps rather than overflowing", "[operation][gemm][quad]") {
+    // Full-range 8-bit operands over a long k. int8 into int32 is the pairing
+    // with real headroom -- a product needs 15 bits, leaving ~16, so of the
+    // order of 10^5 terms -- but headroom is not immunity, and past it the
+    // answer is the true product-sum reduced mod 2^32: defined, not undefined,
+    // and not saturated. K is chosen well past 2^16 / 127^2 * ... to force it.
+    constexpr std::size_t M = 5, N = 5, K = 5000;
+    mtl::mat::dense2D<std::uint8_t, rowmaj> A(M, K);
+    mtl::mat::dense2D<std::int8_t, rowmaj> B(K, N);
+    mtl::mat::dense2D<std::int32_t, rowmaj> C(M, N);
+    for (std::size_t i = 0; i < M; ++i)
+        for (std::size_t k = 0; k < K; ++k) A(i, k) = 255;
+    for (std::size_t k = 0; k < K; ++k)
+        for (std::size_t j = 0; j < N; ++j) B(k, j) = 127;
+
+    mtl::mult_quad<std::int32_t>(A, B, C);
+
+    // 255 * 127 * 5000 = 161 925 000, which still fits; push it with a bigger K
+    // via the reference itself so the check is on agreement, not on a constant.
+    bool all = true;
+    for (std::size_t i = 0; i < M && all; ++i)
+        for (std::size_t j = 0; j < N && all; ++j)
+            all = (C(i, j) == ref_cell<std::int32_t>(A, B, i, j, K));
+    CHECK(all);
+}
+
+TEST_CASE("the quad GEMM wraps past the accumulator, exactly", "[operation][gemm][quad]") {
+    // Past the headroom: 255 * 127 * 100000 ~ 3.2e9 > 2^31, so the int32
+    // accumulator goes negative. The answer must still be the true sum mod 2^32.
+    constexpr std::size_t M = 3, N = 3, K = 100000;
+    mtl::mat::dense2D<std::uint8_t, rowmaj> A(M, K);
+    mtl::mat::dense2D<std::int8_t, rowmaj> B(K, N);
+    mtl::mat::dense2D<std::int32_t, rowmaj> C(M, N);
+    for (std::size_t i = 0; i < M; ++i)
+        for (std::size_t k = 0; k < K; ++k) A(i, k) = 255;
+    for (std::size_t k = 0; k < K; ++k)
+        for (std::size_t j = 0; j < N; ++j) B(k, j) = 127;
+
+    mtl::mult_quad<std::int32_t>(A, B, C);
+
+    bool all = true, any_negative = false;
+    for (std::size_t i = 0; i < M; ++i)
+        for (std::size_t j = 0; j < N; ++j) {
+            all = all && (C(i, j) == ref_cell<std::int32_t>(A, B, i, j, K));
+            any_negative = any_negative || (C(i, j) < 0);
+        }
+    CHECK(all);
+    CHECK(any_negative);      // i.e. it really did wrap, so the check has teeth
+}
+
+TEST_CASE("threading changes nothing at all", "[operation][gemm][quad]") {
+    // The nest partitions m across threads and packs B cooperatively within a
+    // team. Every C macro-block receives the same instructions in the same order
+    // whichever thread runs it, and the pack is pure data movement, so the
+    // threaded result must be BIT-IDENTICAL -- for any grid shape.
+    constexpr std::size_t M = 129, N = 97, K = 83;
+    mtl::mat::dense2D<std::uint8_t, rowmaj> A(M, K);
+    mtl::mat::dense2D<std::int8_t, rowmaj> B(K, N);
+    mtl::mat::dense2D<std::int32_t, rowmaj> C1(M, N), Cn(M, N);
+    for (std::size_t i = 0; i < M; ++i)
+        for (std::size_t k = 0; k < K; ++k) A(i, k) = gen_a<std::uint8_t>(i, k);
+    for (std::size_t k = 0; k < K; ++k)
+        for (std::size_t j = 0; j < N; ++j) B(k, j) = gen_b<std::int8_t>(k, j);
+
+    // Serial reference, straight through the nest.
+    mtl::detail::gemm_blocked<std::int32_t, std::uint8_t, std::int8_t,
+                              mtl::detail::gemm_kernel::quad>(
+        M, N, K, 1, A.data(), static_cast<std::ptrdiff_t>(K), 1,
+        B.data(), static_cast<std::ptrdiff_t>(N), 1, 0, C1.data(), N, 1);
+
+    for (unsigned nt : {2u, 3u, 4u, 8u}) {
+        for (std::size_t t = 0; t < M * N; ++t) Cn.data()[t] = 0;
+        mtl::detail::gemm_blocked<std::int32_t, std::uint8_t, std::int8_t,
+                              mtl::detail::gemm_kernel::quad>(
+            M, N, K, 1, A.data(), static_cast<std::ptrdiff_t>(K), 1,
+            B.data(), static_cast<std::ptrdiff_t>(N), 1, 0, Cn.data(), N, nt);
+        bool all = true;
+        for (std::size_t t = 0; t < M * N && all; ++t) all = (C1.data()[t] == Cn.data()[t]);
+        INFO("nthreads = " << nt);
+        CHECK(all);
+    }
+}
+
+TEST_CASE("alpha and beta are honoured by the quad nest", "[operation][gemm][quad]") {
+    // alpha cannot be folded into the packed A panel the way the pairwise nest
+    // folds it -- the panel holds BYTES, so alpha * A would be truncated before
+    // it ever reached the accumulator. The quad kernel scales the int32 tile on
+    // the way out instead, which is exact and applies per kc block, summing to
+    // alpha times the total. beta pre-scales C as usual.
+    constexpr std::size_t M = 21, N = 19, K = 13;
+    const std::int32_t alpha = 3, beta = 5;
+    mtl::mat::dense2D<std::uint8_t, rowmaj> A(M, K);
+    mtl::mat::dense2D<std::int8_t, rowmaj> B(K, N);
+    std::vector<std::int32_t> C(M * N), want(M * N);
+    for (std::size_t i = 0; i < M; ++i)
+        for (std::size_t k = 0; k < K; ++k) A(i, k) = gen_a<std::uint8_t>(i, k);
+    for (std::size_t k = 0; k < K; ++k)
+        for (std::size_t j = 0; j < N; ++j) B(k, j) = gen_b<std::int8_t>(k, j);
+    for (std::size_t t = 0; t < M * N; ++t) C[t] = static_cast<std::int32_t>(t % 17) - 8;
+
+    for (std::size_t i = 0; i < M; ++i)
+        for (std::size_t j = 0; j < N; ++j) {
+            const std::uint32_t prod =
+                static_cast<std::uint32_t>(ref_cell<std::int32_t>(A, B, i, j, K));
+            want[i * N + j] = static_cast<std::int32_t>(
+                static_cast<std::uint32_t>(beta) * static_cast<std::uint32_t>(C[i * N + j]) +
+                static_cast<std::uint32_t>(alpha) * prod);
+        }
+
+    mtl::detail::gemm_blocked<std::int32_t, std::uint8_t, std::int8_t,
+                              mtl::detail::gemm_kernel::quad>(
+        M, N, K, alpha, A.data(), static_cast<std::ptrdiff_t>(K), 1,
+        B.data(), static_cast<std::ptrdiff_t>(N), 1, beta, C.data(), N, 1);
+
+    bool all = true;
+    for (std::size_t t = 0; t < M * N && all; ++t) all = (C[t] == want[t]);
+    CHECK(all);
+}
+
+TEST_CASE("a kc-split k reaches the same answer", "[operation][gemm][quad]") {
+    // k longer than one kc block forces the pc loop to split it, so the panel is
+    // packed and padded to a multiple of four MORE THAN ONCE -- each block
+    // independently. The padding of an interior block is what a naive "pad the
+    // whole k once" implementation would get wrong.
+    const std::size_t KC = mtl::simd::runtime_blocking<std::int32_t>().kc;
+    const std::size_t K = 2 * KC + 7;              // several blocks, ragged last one
+    constexpr std::size_t M = 9, N = 11;
+    mtl::mat::dense2D<std::uint8_t, rowmaj> A(M, K);
+    mtl::mat::dense2D<std::int8_t, rowmaj> B(K, N);
+    mtl::mat::dense2D<std::int32_t, rowmaj> C(M, N);
+    for (std::size_t i = 0; i < M; ++i)
+        for (std::size_t k = 0; k < K; ++k) A(i, k) = gen_a<std::uint8_t>(i, k);
+    for (std::size_t k = 0; k < K; ++k)
+        for (std::size_t j = 0; j < N; ++j) B(k, j) = gen_b<std::int8_t>(k, j);
+
+    mtl::mult_quad<std::int32_t>(A, B, C);
+
+    bool all = true;
+    for (std::size_t i = 0; i < M && all; ++i)
+        for (std::size_t j = 0; j < N && all; ++j)
+            all = (C(i, j) == ref_cell<std::int32_t>(A, B, i, j, K));
+    INFO("K=" << K << " over kc=" << KC);
+    CHECK(all);
+}

--- a/tests/unit/simd/test_quad_broadcast.cpp
+++ b/tests/unit/simd/test_quad_broadcast.cpp
@@ -1,0 +1,189 @@
+// The BROADCAST form of the quad multiply-accumulate -- #451 phase 5.
+//
+// `quad_dot_accumulate` walks two vectors in step, which is a dot product. A
+// GEMM does not: one C row needs one A element -- four of them here, for four k
+// values -- multiplied against a whole row of B. So the left operand is the same
+// four narrow values in every lane, and lane j must accumulate
+//
+//     sum[j] += sum_{q<4} a4[q] * b[4*j + q]
+//
+// WHY THIS NEEDS ITS OWN TEST, and a strict one. The broadcast is implemented as
+// a 32-bit splat of the four bytes as they lie in memory, then a reinterpret back
+// to 8-bit lanes -- one `vpbroadcastd`, not four inserts. That ties the quad's
+// lane order to the machine's BYTE order: on a little-endian target lane 0 gets
+// a4[0], which is what pairs it with the `b` load. Get it wrong and the kernel
+// still computes something -- a transposed quad -- with no crash and no
+// diagnostic, and only a numeric check catches it. Every target that HAS the
+// instruction is little-endian, so this is the assertion that would fail loudly
+// on a big-endian port instead of silently transposing.
+//
+// The lane assignment is checked EXACTLY, per lane, not through a horizontal
+// sum. `quad_dot_accumulate` gets away with "the total is right" because the
+// instruction may permute products across lanes and a reduction cannot observe
+// it. A GEMM can: lane j is a COLUMN of C, and a permutation there is a wrong
+// answer, not a reordering. So this primitive's contract is stronger than its
+// sibling's, and the tests have to be too.
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+
+#include <mtl/simd/batch.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace {
+
+template <typename T> T gen(std::size_t i, std::uint8_t salt) {
+    return static_cast<T>(static_cast<std::uint8_t>(0x9Eu * (i + 1) + salt));
+}
+
+/// Per-lane check for one operand pairing; the three pairings the hardware op
+/// accepts each get a TEST_CASE below.
+template <typename NA, typename NB>
+void check_lanes() {
+    using W = mtl::simd::quad_accumulator_t<NA, NB>;
+    using Batch = mtl::simd::batch<W>;
+    constexpr std::size_t L = Batch::size;          // lanes = C columns in a batch
+
+    NA a4[4];
+    std::vector<NB> b(4 * L);
+    for (std::size_t q = 0; q < 4; ++q) a4[q] = gen<NA>(q, 0x37u);
+    for (std::size_t i = 0; i < b.size(); ++i)      b[i] = gen<NB>(i, 0xEBu);
+
+    Batch acc{};
+    Batch::template quad_dot_broadcast_accumulate<NA, NB>(a4, b.data(), acc);
+
+    std::vector<W> got(L);
+    acc.store_unaligned(got.data());
+
+    // Per-lane reference. Computed in 64 bits and reduced, so it is exact and
+    // says nothing about the accumulator's own wrapping.
+    bool all = true;
+    for (std::size_t j = 0; j < L; ++j) {
+        std::uint64_t want = 0;
+        for (std::size_t q = 0; q < 4; ++q)
+            want += static_cast<std::uint64_t>(static_cast<std::uint32_t>(static_cast<W>(a4[q]))) *
+                    static_cast<std::uint32_t>(static_cast<W>(b[4 * j + q]));
+        const W wantw = static_cast<W>(static_cast<std::uint32_t>(want));
+        INFO("lane " << j << " of " << L << ": got " << std::int64_t(got[j])
+                     << " want " << std::int64_t(wantw));
+        if (got[j] != wantw) all = false;
+        CHECK(got[j] == wantw);
+    }
+    CHECK(all);
+}
+
+} // namespace
+
+TEST_CASE("i8 x i8: the broadcast quad lands each product in the right lane",
+          "[simd][quad][broadcast]") {
+    check_lanes<std::int8_t, std::int8_t>();
+}
+
+TEST_CASE("u8 x i8: the broadcast quad lands each product in the right lane",
+          "[simd][quad][broadcast]") {
+    // VNNI's native shape, and the one the widening load cannot express at all.
+    check_lanes<std::uint8_t, std::int8_t>();
+}
+
+TEST_CASE("u8 x u8: the broadcast quad lands each product in the right lane",
+          "[simd][quad][broadcast]") {
+    check_lanes<std::uint8_t, std::uint8_t>();
+}
+
+TEST_CASE("the broadcast is a broadcast: every lane sees the same four values",
+          "[simd][quad][broadcast]") {
+    // A left operand of (1,0,0,0) against a b whose every 4-group starts with
+    // the lane index isolates a4[0] * b[4j], so a mis-splatted A -- one that
+    // varied by lane, or that shifted -- shows up as a lane-dependent factor.
+    using Batch = mtl::simd::batch<std::int32_t>;
+    constexpr std::size_t L = Batch::size;
+
+    const std::int8_t a4[4] = {1, 0, 0, 0};
+    std::vector<std::int8_t> b(4 * L, 0);
+    for (std::size_t j = 0; j < L; ++j) b[4 * j] = static_cast<std::int8_t>(j + 1);
+
+    Batch acc{};
+    Batch::template quad_dot_broadcast_accumulate<std::int8_t, std::int8_t>(a4, b.data(), acc);
+
+    std::vector<std::int32_t> got(L);
+    acc.store_unaligned(got.data());
+    for (std::size_t j = 0; j < L; ++j) {
+        INFO("lane " << j);
+        CHECK(got[j] == static_cast<std::int32_t>(j + 1));
+    }
+}
+
+TEST_CASE("the quad position is preserved, not reversed", "[simd][quad][broadcast]") {
+    // The endianness guard, stated as arithmetic. a4 = (1,2,4,8) against a b
+    // that selects one position per lane group: lane j sees b[4j+q] = 1 only at
+    // q == j % 4. A byte-reversed splat would return 8,4,2,1 instead.
+    using Batch = mtl::simd::batch<std::int32_t>;
+    constexpr std::size_t L = Batch::size;
+
+    const std::int8_t a4[4] = {1, 2, 4, 8};
+    std::vector<std::int8_t> b(4 * L, 0);
+    for (std::size_t j = 0; j < L; ++j) b[4 * j + (j % 4)] = 1;
+
+    Batch acc{};
+    Batch::template quad_dot_broadcast_accumulate<std::int8_t, std::int8_t>(a4, b.data(), acc);
+
+    std::vector<std::int32_t> got(L);
+    acc.store_unaligned(got.data());
+    const std::int32_t expect[4] = {1, 2, 4, 8};
+    for (std::size_t j = 0; j < L; ++j) {
+        INFO("lane " << j << " selects quad position " << (j % 4));
+        CHECK(got[j] == expect[j % 4]);
+    }
+}
+
+TEST_CASE("the broadcast accumulates rather than overwriting", "[simd][quad][broadcast]") {
+    using Batch = mtl::simd::batch<std::int32_t>;
+    constexpr std::size_t L = Batch::size;
+
+    const std::int8_t a4[4] = {2, 3, 5, 7};
+    std::vector<std::int8_t> b(4 * L);
+    for (std::size_t i = 0; i < b.size(); ++i) b[i] = static_cast<std::int8_t>((i % 11) - 5);
+
+    Batch once{}, thrice{};
+    Batch::template quad_dot_broadcast_accumulate<std::int8_t, std::int8_t>(a4, b.data(), once);
+    for (int r = 0; r < 3; ++r)
+        Batch::template quad_dot_broadcast_accumulate<std::int8_t, std::int8_t>(a4, b.data(), thrice);
+
+    std::vector<std::int32_t> g1(L), g3(L);
+    once.store_unaligned(g1.data());
+    thrice.store_unaligned(g3.data());
+    for (std::size_t j = 0; j < L; ++j) CHECK(g3[j] == 3 * g1[j]);
+}
+
+TEST_CASE("a full k-group agrees with the dot form on the diagonal",
+          "[simd][quad][broadcast]") {
+    // Cross-check against the primitive that was already tested (#451 phase 3):
+    // if the broadcast quad IS the b vector's own lane-j group, then lane j of
+    // the broadcast result equals the dot form's lane j. Feeding the same b to
+    // both, with a4 taken from group j, must agree there.
+    using Batch = mtl::simd::batch<std::int32_t>;
+    constexpr std::size_t L = Batch::size;
+
+    std::vector<std::int8_t> a(4 * L), b(4 * L);
+    for (std::size_t i = 0; i < a.size(); ++i) {
+        a[i] = static_cast<std::int8_t>((i * 7) % 61 - 30);
+        b[i] = static_cast<std::int8_t>((i * 5) % 53 - 26);
+    }
+
+    Batch dot{};
+    Batch::template quad_dot_accumulate<std::int8_t, std::int8_t>(a.data(), b.data(), dot);
+    std::vector<std::int32_t> gdot(L);
+    dot.store_unaligned(gdot.data());
+
+    for (std::size_t j = 0; j < L; ++j) {
+        Batch bc{};
+        Batch::template quad_dot_broadcast_accumulate<std::int8_t, std::int8_t>(
+            a.data() + 4 * j, b.data(), bc);
+        std::vector<std::int32_t> gbc(L);
+        bc.store_unaligned(gbc.data());
+        INFO("group " << j);
+        CHECK(gbc[j] == gdot[j]);   // same operands in lane j -> same product sum
+    }
+}


### PR DESCRIPTION
`vpdpbusd` consumes **four k-values per instruction**, which needs a quad-interleaved pack layout and a micro-kernel whose left operand is a *broadcast quad* rather than a broadcast scalar. #468 built neither and said so. This builds both.

## The result revises #468's headline

#468 concluded: *"on a machine without VNNI there is no int8 GEMM win at all."* That was true of the **widen-on-load** kernel — the only int8 GEMM that existed when it was written — and it does not survive changing the kernel.

Same Xeon E5-2420 v2, SSE4, n = 512, the instruction still **decomposed**:

| arm | GOP/s | vs widen |
|---|---|---|
| `gemm_f32` | 19.5 | 1.47× |
| `gemm_i32` | 12.2–14.0 | — |
| `gemm_i8_i32` (widen-on-load) | 13.2 | 1.00× |
| `gemm_i8_i32_quad` | **16.6** | **1.26×** |
| `gemm_u8i8_i32_quad` | **20.7–21.7** | **~1.6×** |

The native `u8 × i8` shape beats fp32 — on a 2013 part with no VNNI silicon in it.

The mechanism was **checked in the disassembly, not inferred**: Highway's decomposition is a pair of `vpmaddwd` plus sign-extension shifts, which still folds four products into each accumulator lane in a handful of instructions, where widen-on-load runs four independent promote-multiply-add chains. The symmetric form carries more of that shift work than the mixed one (4 `vpsraw` + 2 `vpsllw` against 2 + 1 plus a mask) — exactly the 16.6-against-21.7 gap.

**What survives:** the operand *width* still contributes nothing to a GEMM. **What was wrong:** equating "the instruction" with "VNNI silicon". Most of the win here is the four-products-per-lane *kernel shape*, which a machine without the instruction can partly express anyway. So a VNNI part now has a narrower question to answer — what the native instruction adds *on top of* the quad kernel, against that same kernel decomposed on the same machine — and `hardware-expansion-plan.md` is corrected to ask it that way rather than to expect the whole 1.6×.

## The selection is explicit, and that is the interesting bug

Kernel selection was first *inferred from the element types*. Since `(i8,i8)` is valid input to **both** kernels, that silently rerouted `mult`'s widening path — through a completely green test suite, because the two kernels agree **bit for bit** and no result can tell them apart.

The benchmark caught it: the two int8 arms started reporting the same number to three digits. They had become the same kernel, and the arm meant to be the control had stopped being one.

Now: `gemm_blocked` takes a `gemm_kernel` template argument defaulting to `widening`, `mult` is unchanged, the quad kernel is reached only through the new `mult_quad`, and a **structural** test pins the default — since a result-based one provably cannot. Both arms compile into one binary on purpose: comparing a quad number on one machine against a widen number on another is the same missing-control error that cost the dot headline 20% once already.

## What's in it

- **`batch::quad_dot_broadcast_accumulate`** — a GEMM needs the same four A-values against a whole row of B, so the left operand is a 32-bit splat of four bytes. Its lane assignment is checked **exactly, per lane**; the dot form's weaker *"the total is right"* contract would not have caught a transposed quad, because for a GEMM a lane **is** a column of C — a permutation there is a wrong answer, not a reordering.
- **`detail/gemm_quad_pack.hpp`** — `Ap[…][i*4+q] == A(i, 4g+q)`, k zero-padded to a multiple of four. Keeps generic strides, edge padding, and independent panels for cooperative threaded packing.
- **`detail/gemm_quad_microkernel.hpp`** — alpha applied to the int32 tile on the way out, *not* folded into the packed panel (folding truncates it into a byte).
- **`gemm_blocked<TC, TA, TB, Kern>`** — one nest, three kernels; `TA`/`TB` split because `(u8,i8)` is VNNI's native shape. All the threading, barriers, grid planning and exception handling are shared.
- **`mtl::mult_quad`** + two new benchmark arms.

`(i8, u8)` is **rejected rather than reordered**: a dot product is symmetric so swapping fixes it there, but a GEMM is not, so there is no swap to suggest. This also means column-major C — computed as `C^T = B^T A^T` — cannot take the asymmetric pairing through the kernel and falls to the generic loop. Tested.

## Known lever, deliberately untouched

`kc` is still derived for a TC-wide B micro-panel while the quad panel holds bytes, so it could be several times larger. Left alone and documented: #430 and #453 both found that moving a cache-derived parameter moves *block counts* the thread partition is sensitive to, so this gets its own measurement rather than riding along with a new kernel.

## Testing

179/179 (was 176) on **gcc+Highway**, **clang+Highway** and the **scalar fallback**, plus **UBSan** over the integer kernels on both backends.

⚠️ The benchmark box is noisy — figures above are best-of-8 interleaved rounds (the two quad arms were the *most* stable of the six). A committed number should come from `run_int_bench.sh` on a quiet machine.

Relates to #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added quad-optimized integer GEMM support for signed 8-bit and mixed unsigned/signed 8-bit operands.
  - Added a dedicated `mult_quad` operation with support for common matrix layouts, scaling, threading, and accumulator behavior.
  - Added optimized packing and SIMD execution for supported workloads, with safe fallback behavior when conditions are not met.

- **Performance**
  - Improved int8 GEMM throughput on supported hardware, including systems without specialized VNNI instructions.

- **Documentation**
  - Updated benchmark and performance guidance with results, limitations, and validation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->